### PR TITLE
Properly remove AM/PM indicator

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/DateFormatter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/DateFormatter.kt
@@ -42,7 +42,7 @@ class DateFormatter @Inject constructor(val context: Context) {
             formattedPattern = formattedPattern
                     .replace("h", "HH")
                     .replace("K", "HH")
-                    .replace(" a".toRegex(), "")
+                    .replace("\\s+a".toRegex(), "")
         }
 
         return SimpleDateFormat(formattedPattern, Locale.getDefault())


### PR DESCRIPTION
I observed that the space before the AM/PM indicator was really an NBSP which caused the original pattern to not match. This pattern, which uses `\s` instead, should match any type of spacing.