### PR TITLE
Basic speech to text for compose (and qkreply)

### DIFF
--- a/presentation/src/main/res/layout/compose_activity.xml
+++ b/presentation/src/main/res/layout/compose_activity.xml
@@ -242,6 +242,7 @@
         android:gravity="center_vertical"
         android:hint="@string/compose_hint"
         android:inputType="textLongMessage|textCapSentences|textMultiLine"
+        android:longClickable="true"
         android:maxLines="6"
         android:minHeight="44dp"
         android:paddingStart="16dp"

--- a/presentation/src/main/res/layout/qkreply_activity.xml
+++ b/presentation/src/main/res/layout/qkreply_activity.xml
@@ -87,6 +87,7 @@
         android:gravity="center_vertical"
         android:hint="@string/compose_hint"
         android:inputType="textLongMessage|textCapSentences|textMultiLine"
+        android:longClickable="true"
         android:maxLines="6"
         android:minHeight="44dp"
         android:paddingStart="16dp"


### PR DESCRIPTION
added STT to compose and qkreply activities using system STT engine.

long press on compose/qkreply edittext input view to launch STT.

related feature request: https://github.com/octoshrimpy/quik/issues/204