### PR TITLE
make unread conversations float at the top of conversation lists

### DIFF
--- a/domain/src/main/java/com/moez/QKSMS/interactor/UpdateBadge.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/UpdateBadge.kt
@@ -31,7 +31,7 @@ class UpdateBadge @Inject constructor(
     override fun buildObservable(params: Unit): Flowable<*> {
         return Flowable.just(params)
                 .doOnNext { shortcutManager.updateBadge() }
-                .doOnNext { widgetManager.updateUnreadCount() }
+                .doOnNext { widgetManager.sendDatasetChanged() }
     }
 
 }

--- a/domain/src/main/java/com/moez/QKSMS/manager/WidgetManager.kt
+++ b/domain/src/main/java/com/moez/QKSMS/manager/WidgetManager.kt
@@ -24,7 +24,7 @@ interface WidgetManager {
         const val ACTION_NOTIFY_DATASET_CHANGED = "dev.octoshrimpy.quik.intent.action.ACTION_NOTIFY_DATASET_CHANGED"
     }
 
-    fun updateUnreadCount()
+    fun sendDatasetChanged()
 
     fun updateTheme()
 

--- a/domain/src/main/java/com/moez/QKSMS/repository/ConversationRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/ConversationRepository.kt
@@ -27,9 +27,9 @@ import io.realm.RealmResults
 
 interface ConversationRepository {
 
-    fun getConversations(archived: Boolean = false): RealmResults<Conversation>
+    fun getConversations(unreadAtTop: Boolean, archived: Boolean = false): RealmResults<Conversation>
 
-    fun getConversationsSnapshot(): List<Conversation>
+    fun getConversationsSnapshot(unreadAtTop: Boolean): List<Conversation>
 
     /**
      * Returns the top conversations that were active in the last week

--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -123,6 +123,7 @@ class Preferences @Inject constructor(
     val longAsMms = rxPrefs.getBoolean("longAsMms", false)
     val mmsSize = rxPrefs.getInteger("mmsSize", 300)
     val logging = rxPrefs.getBoolean("logging", false)
+    val unreadAtTop = rxPrefs.getBoolean("unreadAtTop", false)
 
     init {
         // Migrate from old night mode preference to new one, now that we support android Q night mode

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -136,7 +136,7 @@ class ComposeViewModel @Inject constructor(
                     }
 
                     // Otherwise, we'll monitor the conversations until our expected conversation is created
-                    conversationRepo.getConversations().asObservable()
+                    conversationRepo.getConversations(prefs.unreadAtTop.get()).asObservable()
                             .filter { it.isLoaded }
                             .observeOn(Schedulers.io())
                             .map { conversationRepo.getOrCreateConversation(addresses)?.id ?: 0 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
@@ -169,6 +169,8 @@ class SettingsController : QkController<SettingsView, SettingsState, SettingsPre
 
         delivery.checkbox.isChecked = state.deliveryEnabled
 
+        unreadAtTop.checkbox.isChecked = state.unreadAtTopEnabled
+
         signature.summary = state.signature.takeIf { it.isNotBlank() }
                 ?: context.getString(R.string.settings_signature_summary)
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -98,7 +98,10 @@ class SettingsPresenter @Inject constructor(
                 .subscribe { id -> newState { copy(sendDelaySummary = delayedSendingLabels[id], sendDelayId = id) } }
 
         disposables += prefs.delivery.asObservable()
-                .subscribe { enabled -> newState { copy(deliveryEnabled = enabled) } }
+            .subscribe { enabled -> newState { copy(deliveryEnabled = enabled) } }
+
+        disposables += prefs.unreadAtTop.asObservable()
+            .subscribe { enabled -> newState { copy(unreadAtTopEnabled = enabled) } }
 
         disposables += prefs.signature.asObservable()
                 .subscribe { signature -> newState { copy(signature = signature) } }
@@ -177,6 +180,8 @@ class SettingsPresenter @Inject constructor(
                         R.id.delayed -> view.showDelayDurationDialog()
 
                         R.id.delivery -> prefs.delivery.set(!prefs.delivery.get())
+
+                        R.id.unreadAtTop -> prefs.unreadAtTop.set(!prefs.unreadAtTop.get())
 
                         R.id.signature -> view.showSignatureDialog(prefs.signature.get())
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
@@ -34,6 +34,7 @@ data class SettingsState(
     val sendDelaySummary: String = "",
     val sendDelayId: Int = 0,
     val deliveryEnabled: Boolean = false,
+    val unreadAtTopEnabled: Boolean = false,
     val signature: String = "",
     val textSizeSummary: String = "",
     val textSizeId: Int = Preferences.TEXT_SIZE_NORMAL,

--- a/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
@@ -19,7 +19,6 @@
 package dev.octoshrimpy.quik.feature.widget
 
 import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.text.SpannableStringBuilder
@@ -34,8 +33,6 @@ import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.DateFormatter
 import dev.octoshrimpy.quik.common.util.extensions.dpToPx
 import dev.octoshrimpy.quik.common.util.extensions.getColorCompat
-import dev.octoshrimpy.quik.feature.compose.ComposeActivity
-import dev.octoshrimpy.quik.feature.main.MainActivity
 import dev.octoshrimpy.quik.injection.appComponent
 import dev.octoshrimpy.quik.model.Contact
 import dev.octoshrimpy.quik.model.Conversation
@@ -85,7 +82,7 @@ class WidgetAdapter(intent: Intent) : RemoteViewsService.RemoteViewsFactory {
     }
 
     override fun onDataSetChanged() {
-        conversations = conversationRepo.getConversationsSnapshot()
+        conversations = conversationRepo.getConversationsSnapshot(prefs.unreadAtTop.get())
 
         val remoteViews = RemoteViews(context.packageName, R.layout.widget)
         appWidgetManager.partiallyUpdateAppWidget(appWidgetId, remoteViews)

--- a/presentation/src/main/res/drawable/ic_unreadattop_all_black_24dp.xml
+++ b/presentation/src/main/res/drawable/ic_unreadattop_all_black_24dp.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (C) 2019 Moez Bhatti <moez.bhatti@gmail.com>
+  ~
+  ~ This file is part of QKSMS.
+  ~
+  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M5,8h14v-3L5,5v2z,M5,13h14v-3L5,10v2z,M5,16h14v-1L5,15v2z,M5,19h14v-1L5,18v2z" />
+</vector>

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -153,6 +153,15 @@
             app:widget="@layout/settings_switch_widget" />
 
         <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/unreadAtTop"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_unreadattop_all_black_24dp"
+            app:summary="@string/settings_unread_at_top_summary"
+            app:title="@string/settings_unread_at_top_title"
+            app:widget="@layout/settings_switch_widget" />
+
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
             android:id="@+id/signature"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -259,6 +259,8 @@
     </string-array>
     <string name="settings_delivery_title">Delivery confirmations</string>
     <string name="settings_delivery_summary">Confirm that messages were sent successfully</string>
+    <string name="settings_unread_at_top_title">Unread at the top</string>
+    <string name="settings_unread_at_top_summary">Show unread conversations at the top</string>
     <string name="settings_signature_title">Signature</string>
     <string name="settings_signature_summary">Add a signature to the end of your messages</string>
     <string name="settings_unicode_title">Strip accents</string>


### PR DESCRIPTION
make unread conversations float at the top of conversation lists (including widget) via a new setting "Unread at the top"
satisfies https://github.com/octoshrimpy/quik/issues/41 and https://github.com/octoshrimpy/quik/issues/208
and largely satisfies https://github.com/octoshrimpy/quik/issues/99 (but continues to also show read messages below unread messages in the widget)

order of conversation list items with the setting turned on is;
- unread
- pinned
- draft
- last message date

per conversations repo code;

        val sortOrder: MutableList<String> = arrayListOf("pinned", "draft", "lastMessage.date")
        val sortDirections: MutableList<Sort> = arrayListOf(Sort.DESCENDING, Sort.DESCENDING, Sort.DESCENDING)
        if (unreadAtTop) {
            sortOrder.add(0, "lastMessage.read")
            sortDirections.add(0, Sort.ASCENDING)
        }