### PR TITLE
Main widget launch appropriate app activities

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/receiver/StartActivityFromWidgetReceiver.kt
+++ b/data/src/main/java/com/moez/QKSMS/receiver/StartActivityFromWidgetReceiver.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+ *
+ * This file is part of QKSMS.
+ *
+ * QKSMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QKSMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
+import dagger.android.AndroidInjection
+
+class StartActivityFromWidgetReceiver : BroadcastReceiver() {
+    // why does this shim class exist rather than the widget launching activities more directly?
+    // the main widget listview items all need to launch the compose activity at an existing
+    // threadId *except* the 'view more conversations' footer item, which needs to launch
+    // the main activity. a listview in a widget *must* use a single pending intent template
+    // for all items which doesn't allow for more than one component/class. this shim class
+    // allows a single component/class for the widget listview pending intent template that, based
+    // on the activityToStart value, launches the appropriate activity
+
+    companion object {
+        const val COMPOSE_ACTIVITY = ".feature.compose.ComposeActivity"
+        const val MAIN_ACTIVITY = ".feature.main.MainActivity"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        AndroidInjection.inject(this, context)
+
+        var activityToStartName = intent.getStringExtra("activityToStart")
+
+        // protect against invalid launch activity
+        activityToStartName = when (activityToStartName) {
+            COMPOSE_ACTIVITY -> activityToStartName
+            MAIN_ACTIVITY -> activityToStartName
+            else -> return
+        }
+
+        context.startActivity(
+            Intent(context, Class.forName(context.packageName + activityToStartName))
+                .setFlags(FLAG_ACTIVITY_NEW_TASK)
+                .putExtra("threadId", intent.getLongExtra("threadId", 0L))
+        )
+    }
+
+}

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -219,6 +219,7 @@
                 android:resource="@xml/widget_info" />
         </receiver>
         <receiver android:name=".receiver.SendSmsReceiver" />
+        <receiver android:name=".receiver.StartActivityFromWidgetReceiver" />
 
         <service android:name="com.android.mms.transaction.TransactionService" />
         <service android:name=".feature.backup.RestoreBackupService" />

--- a/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
@@ -19,7 +19,6 @@
 package dev.octoshrimpy.quik.feature.widget
 
 import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.text.SpannableStringBuilder
@@ -34,12 +33,11 @@ import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.DateFormatter
 import dev.octoshrimpy.quik.common.util.extensions.dpToPx
 import dev.octoshrimpy.quik.common.util.extensions.getColorCompat
-import dev.octoshrimpy.quik.feature.compose.ComposeActivity
-import dev.octoshrimpy.quik.feature.main.MainActivity
 import dev.octoshrimpy.quik.injection.appComponent
 import dev.octoshrimpy.quik.model.Contact
 import dev.octoshrimpy.quik.model.Conversation
 import dev.octoshrimpy.quik.model.PhoneNumber
+import dev.octoshrimpy.quik.receiver.StartActivityFromWidgetReceiver
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.util.GlideApp
 import dev.octoshrimpy.quik.util.Preferences
@@ -163,11 +161,13 @@ class WidgetAdapter(intent: Intent) : RemoteViewsService.RemoteViewsFactory {
         remoteViews.setTextColor(R.id.snippet, if (conversation.unread) textPrimary else textTertiary)
         remoteViews.setTextViewText(R.id.snippet, boldText(snippet, conversation.unread))
 
-        // Launch conversation on click
-        val clickIntent = Intent()
-                .putExtra("screen", "compose")
+        // set fill-in intent to be used for current item
+        remoteViews.setOnClickFillInIntent(
+            R.id.conversation,
+            Intent()
+                .putExtra("activityToStart", StartActivityFromWidgetReceiver.COMPOSE_ACTIVITY)
                 .putExtra("threadId", conversation.id)
-        remoteViews.setOnClickFillInIntent(R.id.conversation, clickIntent)
+        )
 
         return remoteViews
     }
@@ -176,7 +176,11 @@ class WidgetAdapter(intent: Intent) : RemoteViewsService.RemoteViewsFactory {
         val view = RemoteViews(context.packageName, R.layout.widget_loading)
         view.setTextColor(R.id.loadingText, textSecondary)
         view.setTextViewText(R.id.loadingText, context.getString(R.string.widget_more))
-        view.setOnClickFillInIntent(R.id.loading, Intent())
+        view.setOnClickFillInIntent(
+            R.id.loadingText,
+            Intent()
+                .putExtra("activityToStart", StartActivityFromWidgetReceiver.MAIN_ACTIVITY)
+        )
         return view
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/injection/android/BroadcastReceiverBuilderModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/injection/android/BroadcastReceiverBuilderModule.kt
@@ -41,6 +41,7 @@ import dev.octoshrimpy.quik.receiver.SmsSentReceiver
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import dev.octoshrimpy.quik.receiver.SpeakThreadsReceiver
+import dev.octoshrimpy.quik.receiver.StartActivityFromWidgetReceiver
 
 @Module
 abstract class BroadcastReceiverBuilderModule {
@@ -72,6 +73,10 @@ abstract class BroadcastReceiverBuilderModule {
     @ActivityScope
     @ContributesAndroidInjector()
     abstract fun bindSpeakThreadsReceiver(): SpeakThreadsReceiver
+
+    @ActivityScope
+    @ContributesAndroidInjector()
+    abstract fun bindStartActivityFromWidgetReceiver(): StartActivityFromWidgetReceiver
 
     @ActivityScope
     @ContributesAndroidInjector()

--- a/presentation/src/main/res/layout/widget_list_item.xml
+++ b/presentation/src/main/res/layout/widget_list_item.xml
@@ -24,6 +24,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:background="@drawable/ripple"
+    android:clickable="false"
     android:gravity="center_vertical|start"
     android:orientation="horizontal"
     android:paddingLeft="16dp"
@@ -36,12 +37,14 @@
         android:layout_width="48dp"
         android:layout_height="48dp"
         android:layout_marginEnd="16dp"
+        android:clickable="false"
         tools:background="@color/tools_theme">
 
         <TextView
             android:id="@+id/initial"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:clickable="false"
             android:gravity="center"
             android:textAllCaps="true"
             android:textSize="20sp"
@@ -53,6 +56,7 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_gravity="center"
+            android:clickable="false"
             android:src="@drawable/ic_person_black_24dp"
             tools:tint="@color/textPrimaryDark" />
 
@@ -60,19 +64,22 @@
             android:id="@+id/photo"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:clickable="false"
             tools:src="@tools:sample/avatars" />
 
         <ImageView
             android:id="@+id/avatarMask"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:clickable="false"
             android:src="@drawable/circle_mask" />
 
     </FrameLayout>
 
     <RelativeLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:clickable="false">
 
         <TextView
             android:id="@+id/name"
@@ -80,6 +87,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_toStartOf="@+id/date"
+            android:clickable="false"
             android:singleLine="true"
             android:textSize="16sp"
             tools:text="@tools:sample/full_names" />
@@ -91,6 +99,7 @@
             android:layout_alignParentTop="true"
             android:layout_alignParentEnd="true"
             android:layout_marginStart="16dp"
+            android:clickable="false"
             android:textSize="12sp"
             tools:text="@tools:sample/date/day_of_week" />
 
@@ -100,6 +109,7 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/name"
             android:layout_alignParentStart="true"
+            android:clickable="false"
             android:lines="1"
             android:singleLine="true"
             android:textSize="14sp"


### PR DESCRIPTION
changes to allow individual widget conversations to launch corresponding compose activity in thread of conversation.

widget footer item 'view more conversations' launches main activity/conversations view

main widget responds as expected with these changes.

satisfies issue https://github.com/octoshrimpy/quik/issues/162