### PR TITLE
disable reply ability to non-replyable messages/conversations

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -40,6 +40,8 @@ import android.view.View
 import android.view.View.OnTouchListener
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.app.ActivityCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
@@ -289,6 +291,26 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
 
         send.isEnabled = state.canSend
         send.imageAlpha = if (state.canSend) 255 else 128
+
+        // if not in editing mode, and there are no non-me participants that can be sent to,
+        // hide controls that allow constructing a reply and inform user no valid recipients
+        if (!state.editingMode && (state.validRecipientNumbers == 0)) {
+            composeBar.visibility = View.GONE
+            noValidRecipients.visibility = View.VISIBLE
+
+            // change constraint of messageList to constrain bottom to top of noValidRecipients
+            val constraintLayout = findViewById<ConstraintLayout>(R.id.contentView)
+            val constraintSet = ConstraintSet()
+            constraintSet.clone(constraintLayout)
+            constraintSet.connect(
+                R.id.messageList,
+                ConstraintSet.BOTTOM,
+                R.id.noValidRecipients,
+                ConstraintSet.TOP,
+                0
+            )
+            constraintSet.applyTo(constraintLayout)
+        }
     }
 
     override fun clearSelection() = messageAdapter.clearSelection()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
@@ -44,5 +44,6 @@ data class ComposeState(
     val attaching: Boolean = false,
     val remaining: String = "",
     val subscription: SubscriptionInfoCompat? = null,
-    val canSend: Boolean = false
+    val canSend: Boolean = false,
+    val validRecipientNumbers: Int = 1,
 )

--- a/presentation/src/main/res/layout/compose_activity.xml
+++ b/presentation/src/main/res/layout/compose_activity.xml
@@ -353,12 +353,14 @@
     </androidx.appcompat.widget.Toolbar>
 
     <View
+        android:id="@+id/titleBarShadow"
         android:layout_width="match_parent"
         android:layout_height="8dp"
         android:background="@drawable/ab_shadow"
         app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
     <View
+        android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="?android:attr/divider"
@@ -532,5 +534,19 @@
         app:layout_constraintStart_toStartOf="parent"
         tools:backgroundTint="@color/tools_theme"
         tools:tint="@color/textPrimaryDark" />
+
+    <TextView
+        android:id="@+id/noValidRecipients"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:gravity="center"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:text="@string/compose_no_valid_recipients"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="compose_scheduled_plus">You must unlock QUIK+ to use scheduled messaging</string>
     <string name="compose_scheduled_toast">Added to scheduled messages</string>
     <string name="compose_hint">Write a message…</string>
+    <string name="compose_no_valid_recipients">Can\'t send to other participants</string>
     <string name="compose_menu_copy">Copy text</string>
     <string name="compose_menu_forward">Forward</string>
     <string name="compose_menu_delete">Delete</string>


### PR DESCRIPTION
changes to disable reply controls and display a relevant message to the user on compose screen if all other conversation  participant numbers are non-replyable (ie alphanumeric sender id)

satisfies feature request https://github.com/octoshrimpy/quik/issues/94

![image](https://github.com/user-attachments/assets/d242d225-32e9-434a-abbb-97f3c5160da7)

