### PR TITLE
bug fix for motion events being used after recycled

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ViewExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ViewExtensions.kt
@@ -98,15 +98,15 @@ fun View.forwardTouches(parent: View) {
                     parent.onTouchEvent(e)
                     if (lastUpEvent !== null) {
                         parent.onTouchEvent(lastUpEvent)
+                        lastUpEvent?.recycle()
                         lastUpEvent = null
                     }
-
                     return true
                 }
 
                 override fun onSingleTapUp(e: MotionEvent): Boolean {
                     onTouchEvent(e)
-                    lastUpEvent = e
+                    lastUpEvent = MotionEvent.obtain(e)
                     return true
                 }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -183,6 +183,8 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         message.setOnTouchListener(object : OnTouchListener {
             private val gestureDetector =
                 GestureDetector(this@ComposeActivity, object : SimpleOnGestureListener() {
+                    private var lastUpEvent: MotionEvent? = null
+
                     override fun onDoubleTap(e: MotionEvent): Boolean {
                         val speechRecognizerIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
                             .putExtra(
@@ -195,11 +197,16 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                     }
 
                     override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-                        message.showKeyboard()
+                        if (lastUpEvent !== null) {
+                            message.onTouchEvent(lastUpEvent)
+                            lastUpEvent?.recycle()
+                            lastUpEvent = null
+                        }
                         return true
                     }
 
                     override fun onSingleTapUp(e: MotionEvent): Boolean {
+                        lastUpEvent = MotionEvent.obtain(e)
                         return true     // don't show soft keyboard on this event
                     }
                 })


### PR DESCRIPTION
small changes to GestureDectector usage to fix a race condition on MotionEvents being used after they've been recycled resulting in unpredictable touch event processing