### PR TITLE
select all on conversations and compose screens. new compose 'show status' option

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -73,6 +73,7 @@ import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import kotlinx.android.synthetic.main.compose_activity.*
+import kotlinx.android.synthetic.main.main_activity.toolbar
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
@@ -256,6 +257,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         // Don't set the adapters unless needed
         if (state.editingMode && chips.adapter == null) chips.adapter = chipsAdapter
 
+        toolbar.menu.findItem(R.id.select_all)?.isVisible = !state.editingMode && (messageAdapter.itemCount > 1) && state.selectedMessages != 0
         toolbar.menu.findItem(R.id.add)?.isVisible = state.editingMode
         toolbar.menu.findItem(R.id.call)?.isVisible = !state.editingMode && state.selectedMessages == 0
                 && state.query.isEmpty()
@@ -265,6 +267,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         toolbar.menu.findItem(R.id.details)?.isVisible = !state.editingMode && state.selectedMessages == 1
         toolbar.menu.findItem(R.id.delete)?.isVisible = !state.editingMode && state.selectedMessages > 0
         toolbar.menu.findItem(R.id.forward)?.isVisible = !state.editingMode && state.selectedMessages == 1
+        toolbar.menu.findItem(R.id.show_status)?.isVisible = !state.editingMode && state.selectedMessages > 0
         toolbar.menu.findItem(R.id.previous)?.isVisible = state.selectedMessages == 0 && state.query.isNotEmpty()
         toolbar.menu.findItem(R.id.next)?.isVisible = state.selectedMessages == 0 && state.query.isNotEmpty()
         toolbar.menu.findItem(R.id.clear)?.isVisible = state.selectedMessages == 0 && state.query.isNotEmpty()
@@ -321,6 +324,14 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     }
 
     override fun clearSelection() = messageAdapter.clearSelection()
+
+    override fun toggleSelectAll() {
+        messageAdapter.toggleSelectAll()
+    }
+
+    override fun expandMessages(messageIds: List<Long>, expand: Boolean) {
+        messageAdapter.expandMessages(messageIds, expand)
+    }
 
     override fun showDetails(details: String) {
         AlertDialog.Builder(this)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -58,6 +58,8 @@ interface ComposeView : QkView<ComposeState> {
     val confirmDeleteIntent: Observable<List<Long>>
 
     fun clearSelection()
+    fun toggleSelectAll()
+    fun expandMessages(messageIds: List<Long>, expand: Boolean)
     fun showDetails(details: String)
     fun requestDefaultSms()
     fun requestStoragePermission()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -21,7 +21,6 @@ package dev.octoshrimpy.quik.feature.compose
 import android.animation.ObjectAnimator
 import android.content.Context
 import android.graphics.Typeface
-import android.os.Build
 import android.text.Layout
 import android.text.Spannable
 import android.text.SpannableString
@@ -315,12 +314,45 @@ class MessagesAdapter @Inject constructor(
         })
     }
 
+    override fun getItemId(position: Int): Long {
+        return getItem(position)?.id ?: -1
+    }
+
     override fun getItemViewType(position: Int): Int {
         val message = getItem(position) ?: return -1
         return when (message.isMe()) {
             true -> VIEW_TYPE_MESSAGE_OUT
             false -> VIEW_TYPE_MESSAGE_IN
         }
+    }
+
+    fun toggleSelectAll() {
+        var needToSelectAll = false
+
+        // if a non-selected item is found, then we need to select all, otherwise deselect all
+        for (position in 0 until itemCount)
+            if (!isSelected(getItemId(position))) {
+                needToSelectAll = true
+                break
+            }
+
+        // select or deselect item based on if toggling all selected of deselected
+        for (position in 0 until itemCount) {
+            val messageId = getItemId(position)
+            // if deselecting all then toggle selection (we know all items are selected)
+            if (!needToSelectAll)
+                toggleSelection(messageId)
+            // else, selecting all, toggle if not already selected
+            else if (!isSelected(messageId))
+                toggleSelection(messageId)
+        }
+
+        notifyDataSetChanged()
+    }
+
+    fun expandMessages(messageIds: List<Long>, expand: Boolean) {
+        messageIds.forEach { messageId -> expanded[messageId] = expand }
+        notifyDataSetChanged()
     }
 
     /**

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
@@ -130,4 +130,28 @@ class ConversationsAdapter @Inject constructor(
     override fun getItemViewType(position: Int): Int {
         return if (getItem(position)?.unread == false) 0 else 1
     }
+
+    fun toggleSelectAll() {
+        var needToSelectAll = false
+
+        // if a non-selected item is found, then we need to select all, otherwise deselect all
+        for (position in 0 until itemCount)
+            if (!isSelected(getItemId(position))) {
+                needToSelectAll = true
+                break
+            }
+
+        // select or deselect item based on if toggling all selected of deselected
+        for (position in 0 until itemCount) {
+            val threadId = getItemId(position)
+            // if deselecting all then toggle selection (we know all items are selected)
+            if (!needToSelectAll)
+                toggleSelection(threadId)
+            // else, selecting all, toggle if not already selected
+            else if (!isSelected(threadId))
+                toggleSelection(threadId)
+        }
+
+        notifyDataSetChanged()
+    }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -225,6 +225,7 @@ class MainActivity : QkThemedActivity(), MainView {
         toolbarSearch.setVisible(state.page is Inbox && state.page.selected == 0 || state.page is Searching)
         toolbarTitle.setVisible(toolbarSearch.visibility != View.VISIBLE)
 
+        toolbar.menu.findItem(R.id.select_all)?.isVisible = (conversationsAdapter.itemCount > 1) && selectedConversations != 0
         toolbar.menu.findItem(R.id.archive)?.isVisible = state.page is Inbox && selectedConversations != 0
         toolbar.menu.findItem(R.id.unarchive)?.isVisible = state.page is Archived && selectedConversations != 0
         toolbar.menu.findItem(R.id.delete)?.isVisible = selectedConversations != 0
@@ -380,6 +381,10 @@ class MainActivity : QkThemedActivity(), MainView {
         conversationsAdapter.clearSelection()
     }
 
+    override fun toggleSelectAll() {
+        conversationsAdapter.toggleSelectAll()
+    }
+
     override fun themeChanged() {
         recyclerView.scrapViews()
     }
@@ -402,8 +407,12 @@ class MainActivity : QkThemedActivity(), MainView {
         changelogDialog.show(changelog)
     }
 
-    override fun showArchivedSnackbar() {
-        Snackbar.make(drawerLayout, R.string.toast_archived, Snackbar.LENGTH_LONG).apply {
+    override fun showArchivedSnackbar(countConversationsArchived: Int) {
+        Snackbar.make(
+            drawerLayout,
+            resources.getQuantityString(R.plurals.toast_archived, countConversationsArchived, countConversationsArchived),
+            if (countConversationsArchived < 10) Snackbar.LENGTH_LONG else Snackbar.LENGTH_INDEFINITE
+        ).apply {
             setAction(R.string.button_undo) { undoArchiveIntent.onNext(Unit) }
             setActionTextColor(colors.theme().theme)
             show()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
@@ -47,11 +47,12 @@ interface MainView : QkView<MainState> {
     fun requestPermissions()
     fun clearSearch()
     fun clearSelection()
+    fun toggleSelectAll()
     fun themeChanged()
     fun showBlockingDialog(conversations: List<Long>, block: Boolean)
     fun showDeleteDialog(conversations: List<Long>)
     fun showChangelog(changelog: ChangelogManager.CumulativeChangelog)
-    fun showArchivedSnackbar()
+    fun showArchivedSnackbar(countConversationsArchived: Int)
 
 }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -18,9 +18,6 @@
  */
 package dev.octoshrimpy.quik.feature.main
 
-import android.content.Intent
-import android.net.Uri
-import android.provider.Settings
 import androidx.recyclerview.widget.ItemTouchHelper
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.Navigator
@@ -84,6 +81,7 @@ class MainViewModel @Inject constructor(
     private val syncContacts: SyncContacts,
     private val syncMessages: SyncMessages
 ) : QkViewModel<MainView, MainState>(MainState(page = Inbox(data = conversationRepo.getConversations(prefs.unreadAtTop.get())))) {
+    private val lastArchivedThreadIds = ArrayList<Long>()
 
     init {
         disposables += deleteConversations
@@ -334,9 +332,17 @@ class MainViewModel @Inject constructor(
                 .subscribe()
 
         view.optionsItemIntent
+            .filter { itemId -> itemId == R.id.select_all }
+            .autoDisposable(view.scope())
+            .subscribe { view.toggleSelectAll() }
+
+        view.optionsItemIntent
                 .filter { itemId -> itemId == R.id.archive }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
                     markArchived.execute(conversations)
+                    lastArchivedThreadIds.clear()
+                    conversations.forEach { conversation -> lastArchivedThreadIds.add(conversation) }
+                    view.showArchivedSnackbar(conversations.count())
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -346,6 +352,7 @@ class MainViewModel @Inject constructor(
                 .filter { itemId -> itemId == R.id.unarchive }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
                     markUnarchived.execute(conversations)
+                    view.showArchivedSnackbar(conversations.count())
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -481,7 +488,12 @@ class MainViewModel @Inject constructor(
                 .subscribe { (threadId, direction) ->
                     val action = if (direction == ItemTouchHelper.RIGHT) prefs.swipeRight.get() else prefs.swipeLeft.get()
                     when (action) {
-                        Preferences.SWIPE_ACTION_ARCHIVE -> markArchived.execute(listOf(threadId)) { view.showArchivedSnackbar() }
+                        Preferences.SWIPE_ACTION_ARCHIVE -> markArchived.execute(listOf(threadId))
+                        {
+                            lastArchivedThreadIds.clear()
+                            lastArchivedThreadIds.add(threadId)
+                            view.showArchivedSnackbar(1)
+                        }
                         Preferences.SWIPE_ACTION_DELETE -> view.showDeleteDialog(listOf(threadId))
                         Preferences.SWIPE_ACTION_BLOCK -> view.showBlockingDialog(listOf(threadId), true)
                         Preferences.SWIPE_ACTION_CALL -> conversationRepo.getConversation(threadId)?.recipients?.firstOrNull()?.address?.let(navigator::makePhoneCall)
@@ -492,9 +504,11 @@ class MainViewModel @Inject constructor(
                 }
 
         view.undoArchiveIntent
-                .withLatestFrom(view.swipeConversationIntent) { _, pair -> pair.first }
                 .autoDisposable(view.scope())
-                .subscribe { threadId -> markUnarchived.execute(listOf(threadId)) }
+                .subscribe {
+                    markUnarchived.execute(lastArchivedThreadIds)
+                    lastArchivedThreadIds.clear()
+                }
 
         view.snackbarButtonIntent
                 .withLatestFrom(state) { _, state ->

--- a/presentation/src/main/res/menu/compose.xml
+++ b/presentation/src/main/res/menu/compose.xml
@@ -35,6 +35,13 @@
         app:showAsAction="always" />
 
     <item
+        android:id="@+id/select_all"
+        android:icon="?attr/actionModeSelectAllDrawable"
+        android:title="@string/main_menu_select_all"
+        android:visible="false"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/info"
         android:icon="@drawable/ic_more_vert_black_24dp"
         android:title="@string/menu_info"
@@ -46,14 +53,14 @@
         android:icon="@drawable/ic_info_black_24dp"
         android:title="@string/compose_menu_copy"
         android:visible="false"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/delete"
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/compose_menu_delete"
         android:visible="false"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/copy"
@@ -66,6 +73,13 @@
         android:id="@+id/forward"
         android:icon="@drawable/ic_forward_black_24dp"
         android:title="@string/compose_menu_forward"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/show_status"
+        android:icon="@android:drawable/ic_menu_more"
+        android:title="@string/compose_menu_show_status"
         android:visible="false"
         app:showAsAction="ifRoom" />
 

--- a/presentation/src/main/res/menu/main.xml
+++ b/presentation/src/main/res/menu/main.xml
@@ -21,25 +21,32 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/select_all"
+        android:icon="?attr/actionModeSelectAllDrawable"
+        android:title="@string/main_menu_select_all"
+        android:visible="false"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/archive"
         android:icon="@drawable/ic_archive_white_24dp"
         android:title="@string/main_menu_archive"
         android:visible="false"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/unarchive"
         android:icon="@drawable/ic_inbox_black_24dp"
         android:title="@string/main_menu_unarchive"
         android:visible="false"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/delete"
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/main_menu_delete"
         android:visible="false"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
 
     <item
         android:id="@+id/add"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="main_drawer_open_cd">Open navigation drawer</string>
     <string name="main_title_selected">%d selected</string>
     <string name="main_menu_clear">Clear</string>
+    <string name="main_menu_select_all">Select all</string>
     <string name="main_menu_archive">Archive</string>
     <string name="main_menu_unarchive">Unarchive</string>
     <string name="main_menu_delete">Delete</string>
@@ -122,6 +123,7 @@
     <string name="compose_no_valid_recipients">Can\'t send to other participants</string>
     <string name="compose_menu_copy">Copy text</string>
     <string name="compose_menu_forward">Forward</string>
+    <string name="compose_menu_show_status">Show status</string>
     <string name="compose_menu_delete">Delete</string>
     <string name="compose_menu_previous">Previous</string>
     <string name="compose_menu_next">Next</string>
@@ -427,7 +429,11 @@
     <string name="button_undo">Undo</string>
 
     <string name="toast_copied">Copied</string>
-    <string name="toast_archived">Archived conversation</string>
+    <plurals name="toast_archived">
+        <item quantity="one">Archived conversation</item>
+        <item quantity="other">Archived %d conversations</item>
+    </plurals>
+
     <string name="toast_qksms_plus">You must unlock QUIK+ to use this</string>
 
     <plurals name="notification_new_messages">


### PR DESCRIPTION
added select all actionbar item on main (inc archived) and compose activities. item becomes available when first item selected. menu item toggles select all/select none.

added indefinite timeout to archive snackbar on conversations activity when >= 10 conversations are archived at once. in case of accidental mass archive gives user more time to undo.

added 'show status' menu item on compose activity that does the same as short touching on an item (expands it to show time, etc) but can be applied to multiple selected items at once.

made some actionbar items on conversation/archive and compose screens always displayable to maintain user experience whether one or more items are selected on those screens.

select all allows faster actions for 'mark all (un)read', archive all, delete all, pin all, block all, copy messages text (in compose), delete mesages (in compose)

new select all actionbar item available on conversations and compose screens when at least 1 item selected;
![image](https://github.com/user-attachments/assets/952524ea-2ac5-4431-8837-b934ae29bc38)

new show status item on compose menu when at least 1 item selected;
![image](https://github.com/user-attachments/assets/6852231d-6d13-48ce-b882-80a773ef0a52)


largely satisfies https://github.com/octoshrimpy/quik/issues/141 by enabling; select all -> mark read; for quick mark all read

satisfies item 3 in https://github.com/octoshrimpy/quik/issues/53 - 3. Select all conversations...

largely satisfies https://github.com/octoshrimpy/quik/issues/134 - display time for all messages by enabling select all -> show status