### PR TITLE
change convo name from main convo activity

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoAdapter.kt
@@ -94,7 +94,6 @@ class ConversationInfoAdapter @Inject constructor(
             }
 
             is ConversationInfoSettings -> {
-                holder.groupName.isVisible = item.recipients.size > 1
                 holder.groupName.summary = item.name
 
                 holder.notifications.isEnabled = !item.blocked

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -61,6 +61,7 @@ import dev.octoshrimpy.quik.repository.SyncRepository
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dagger.android.AndroidInjection
+import dev.octoshrimpy.quik.common.widget.TextInputDialog
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.PublishSubject
@@ -111,6 +112,7 @@ class MainActivity : QkThemedActivity(), MainView {
     override val rateIntent by lazy { rateOkay.clicks() }
     override val conversationsSelectedIntent by lazy { conversationsAdapter.selectionChanges }
     override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
+    override val renameConversationIntent: Subject<String> = PublishSubject.create()
     override val swipeConversationIntent by lazy { itemTouchCallback.swipes }
     override val changelogMoreIntent by lazy { changelogDialog.moreClicks }
     override val undoArchiveIntent: Subject<Unit> = PublishSubject.create()
@@ -234,6 +236,7 @@ class MainActivity : QkThemedActivity(), MainView {
         toolbar.menu.findItem(R.id.read)?.isVisible = markRead && selectedConversations != 0
         toolbar.menu.findItem(R.id.unread)?.isVisible = !markRead && selectedConversations != 0
         toolbar.menu.findItem(R.id.block)?.isVisible = selectedConversations != 0
+        toolbar.menu.findItem(R.id.rename)?.isVisible = selectedConversations == 1
 
         listOf(plusBadge1, plusBadge2).forEach { badge ->
             badge.isVisible = drawerBadgesExperiment.variant && !state.upgraded
@@ -396,6 +399,14 @@ class MainActivity : QkThemedActivity(), MainView {
                 .setPositiveButton(R.string.button_delete) { _, _ -> confirmDeleteIntent.onNext(conversations) }
                 .setNegativeButton(R.string.button_cancel, null)
                 .show()
+    }
+
+    override fun showRenameDialog(conversationName: String) {
+        TextInputDialog(
+            this,
+            getString(R.string.info_name),
+            renameConversationIntent::onNext
+        ).setText(conversationName).show()
     }
 
     override fun showChangelog(changelog: ChangelogManager.CumulativeChangelog) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
@@ -38,6 +38,7 @@ interface MainView : QkView<MainState> {
     val rateIntent: Observable<*>
     val conversationsSelectedIntent: Observable<List<Long>>
     val confirmDeleteIntent: Observable<List<Long>>
+    val renameConversationIntent: Observable<String>
     val swipeConversationIntent: Observable<Pair<Long, Int>>
     val changelogMoreIntent: Observable<*>
     val undoArchiveIntent: Observable<Unit>
@@ -50,6 +51,7 @@ interface MainView : QkView<MainState> {
     fun themeChanged()
     fun showBlockingDialog(conversations: List<Long>, block: Boolean)
     fun showDeleteDialog(conversations: List<Long>)
+    fun showRenameDialog(conversationName: String)
     fun showChangelog(changelog: ChangelogManager.CumulativeChangelog)
     fun showArchivedSnackbar()
 

--- a/presentation/src/main/res/layout/conversation_info_settings.xml
+++ b/presentation/src/main/res/layout/conversation_info_settings.xml
@@ -33,7 +33,6 @@
         android:id="@+id/groupName"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         app:icon="@drawable/ic_people_black_24dp"
         app:title="@string/info_name" />
 

--- a/presentation/src/main/res/layout/text_input_dialog.xml
+++ b/presentation/src/main/res/layout/text_input_dialog.xml
@@ -29,5 +29,4 @@
     android:padding="24dp"
     android:singleLine="true"
     android:textStyle="bold"
-    app:textSize="dialog"
-    tools:hint="Enter something" />
+    app:textSize="dialog" />

--- a/presentation/src/main/res/menu/main.xml
+++ b/presentation/src/main/res/menu/main.xml
@@ -83,4 +83,11 @@
         android:visible="false"
         app:showAsAction="ifRoom" />
 
+    <item
+        android:id="@+id/rename"
+        android:icon="@drawable/ic_people_black_24dp"
+        android:title="@string/main_menu_rename_conversation"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
 </menu>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="main_menu_read">Mark read</string>
     <string name="main_menu_unread">Mark unread</string>
     <string name="main_menu_block">Block</string>
+    <string name="main_menu_rename_conversation">Rename conversation</string>
     <string name="main_syncing">Syncing messages…</string>
     <string name="main_sender_you">You: %s</string>
     <string name="main_draft">Draft</string>


### PR DESCRIPTION
add new 'rename conversation' menu option on main activity when 1 convo selected that allows changing conversation name/title 
* note - no restriction of renaming only group conversations

removed restriction on renaming only group conversations on conversationinfo screen because, ummmm... why restrict renaming to only group convos ??

satisfies issue https://github.com/octoshrimpy/quik/issues/14