### PR TITLE
changes to allow attaching *any* type of file

### DIFF
--- a/android-smsmms/src/main/java/com/android/mms/transaction/RetryScheduler.java
+++ b/android-smsmms/src/main/java/com/android/mms/transaction/RetryScheduler.java
@@ -143,6 +143,11 @@ public class RetryScheduler implements Observer {
                             case PduHeaders.RESPONSE_STATUS_ERROR_PERMANENT_MESSAGE_NOT_FOUND:
                                 errorString = R.string.service_message_not_found;
                                 break;
+                            case PduHeaders.RESPONSE_STATUS_ERROR_CONTENT_NOT_ACCEPTED:
+                            case PduHeaders.RESPONSE_STATUS_ERROR_PERMANENT_CONTENT_NOT_ACCEPTED:
+                                errorString = R.string.service_message_content_not_accepted;
+                                break;
+
                         }
                         if (errorString != 0) {
                             DownloadManager.init(mContext.getApplicationContext());

--- a/android-smsmms/src/main/res/values/strings.xml
+++ b/android-smsmms/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@ limitations under the License.
     <string name="invalid_destination">Invalid destination address.</string>
     <string name="service_not_activated">Service not activated on network.</string>
     <string name="service_message_not_found">Message expired or not available.</string>
+    <string name="service_message_content_not_accepted">Message content is not accepted.</string>
     <string name="service_network_problem">Couldn\'t send due to network problem.</string>
     <string name="message_queued">Currently can\'t send your message. It will be sent when the service becomes available.</string>
     <string name="download_later">Can\'t download right now. Try again later.</string>

--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -19,4 +19,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 </manifest>

--- a/data/src/main/java/com/moez/QKSMS/extensions/UriExtensions.kt
+++ b/data/src/main/java/com/moez/QKSMS/extensions/UriExtensions.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+ *
+ * This file is part of QKSMS.
+ *
+ * QKSMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QKSMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.extensions
+
+import android.content.Context
+import android.net.Uri
+
+fun Uri.resourceExists(context: Context): Boolean {
+    // check if resource at uri still exists
+    try {
+        return context.contentResolver.query(
+            this, null, null, null, null
+        )?.use {
+            it.moveToFirst()
+        } ?: false
+    }
+    catch (e: Exception) { /* nothing */ }
+
+    return false
+}

--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -25,7 +25,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.graphics.BitmapFactory
-import android.media.MediaScannerConnection
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -65,14 +64,7 @@ import io.realm.Case
 import io.realm.Realm
 import io.realm.RealmResults
 import io.realm.Sort
-import okio.buffer
-import okio.source
 import timber.log.Timber
-import java.io.File
-import java.io.FileNotFoundException
-import java.io.FileOutputStream
-import java.io.IOException
-import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -376,27 +368,37 @@ class MessageRepositoryImpl @Inject constructor(
                 parts += MMSPart("text", ContentType.TEXT_PLAIN, bytes)
             }
 
-            // Attach contacts
+            // Attach those that can't be compressed (ie. everything but not images)
             parts += attachments
-                    .mapNotNull { attachment -> attachment as? Attachment.Contact }
-                    .map { attachment -> attachment.vCard.toByteArray() }
-                    .map { vCard ->
-                        remainingBytes -= vCard.size
-                        MMSPart("contact", ContentType.TEXT_VCARD, vCard)
-                    }
+                // filter out images
+                .filter { !it.isImage(context) }
+                // filter out items that have no data available (ie user may have deleted
+                // the file from storage)
+                .filter { it.getResourceBytes(context).isNotEmpty() }
+                .map {
+                    remainingBytes -= it.getResourceBytes(context).size
+                    MMSPart(
+                        it.getName(context),
+                        it.getType(context),
+                        it.getResourceBytes(context)
+                    )
+                }
 
             val imageBytesByAttachment = attachments
-                    .mapNotNull { attachment -> attachment as? Attachment.Image }
-                    .associateWith { attachment ->
-                        val uri = attachment.getUri() ?: return@associateWith byteArrayOf()
-                        when (attachment.isGif(context)) {
-                            true -> ImageUtils.getScaledGif(context, uri, maxWidth, maxHeight)
-                            false -> ImageUtils.getScaledImage(context, uri, maxWidth, maxHeight)
-                        }
+                // filter out non-images
+                .filter { it.isImage(context) }
+                // filter out items that have no data available (ie user may have deleted
+                // the file from storage)
+                .filter { it.getResourceBytes(context).isNotEmpty() }
+                .associateWith {
+                    when (it.getType(context) == "image/gif") {
+                        true -> ImageUtils.getScaledGif(context, it.getUri(), maxWidth, maxHeight)
+                        false -> ImageUtils.getScaledImage(context, it.getUri(), maxWidth, maxHeight)
                     }
-                    .toMutableMap()
+                }
+                .toMutableMap()
 
-            val imageByteCount = imageBytesByAttachment.values.sumBy { byteArray -> byteArray.size }
+            val imageByteCount = imageBytesByAttachment.values.sumOf { it.size }
             if (imageByteCount > remainingBytes) {
                 imageBytesByAttachment.forEach { (attachment, originalBytes) ->
                     val uri = attachment.getUri() ?: return@forEach
@@ -426,9 +428,9 @@ class MessageRepositoryImpl @Inject constructor(
                         val newHeight = (newWidth / aspectRatio).toInt()
 
                         attempts++
-                        scaledBytes = when (attachment.isGif(context)) {
-                            true -> ImageUtils.getScaledGif(context, uri, newWidth, newHeight, 80)
-                            false -> ImageUtils.getScaledImage(context, uri, newWidth, newHeight, 80)
+                        scaledBytes = when (attachment.getType(context) == "image/gif") {
+                            true -> ImageUtils.getScaledGif(context, attachment.getUri(), maxWidth, maxHeight)
+                            false -> ImageUtils.getScaledImage(context, attachment.getUri(), maxWidth, maxHeight)
                         }
 
                         Timber.d("Compression attempt $attempts: ${scaledBytes.size / 1024}/${maxBytes.toInt() / 1024}Kb ($width*$height -> $newWidth*$newHeight)")
@@ -440,7 +442,7 @@ class MessageRepositoryImpl @Inject constructor(
             }
 
             imageBytesByAttachment.forEach { (attachment, bytes) ->
-                parts += when (attachment.isGif(context)) {
+                parts += when (attachment.getType(context) == "image/gif") {
                     true -> MMSPart("image", ContentType.IMAGE_GIF, bytes)
                     false -> MMSPart("image", ContentType.IMAGE_JPEG, bytes)
                 }

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendScheduledMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendScheduledMessage.kt
@@ -47,7 +47,7 @@ class SendScheduledMessage @Inject constructor(
                 }
                 .map { message ->
                     val threadId = TelephonyCompat.getOrCreateThreadId(context, message.recipients)
-                    val attachments = message.attachments.mapNotNull(Uri::parse).map { Attachment.Image(it) }
+                    val attachments = message.attachments.mapNotNull(Uri::parse).map { Attachment(it) }
                     SendMessage.Params(message.subId, threadId, message.recipients, message.body, attachments)
                 }
                 .flatMap(sendMessage::buildObservable)

--- a/domain/src/main/java/com/moez/QKSMS/model/Attachment.kt
+++ b/domain/src/main/java/com/moez/QKSMS/model/Attachment.kt
@@ -21,33 +21,106 @@ package dev.octoshrimpy.quik.model
 import android.content.Context
 import android.net.Uri
 import android.os.Build
+import android.provider.OpenableColumns
 import androidx.core.view.inputmethod.InputContentInfoCompat
 
-sealed class Attachment {
 
-    data class Image(
-        private val uri: Uri? = null,
-        private val inputContent: InputContentInfoCompat? = null
-    ) : Attachment() {
+class Attachment(
+    private val uri: Uri? = null,
+    private val inputContent: InputContentInfoCompat? = null
+) {
+    private var resourceBytes: ByteArray? = null
 
-        fun getUri(): Uri? {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-                inputContent?.contentUri ?: uri
-            } else {
-                uri
-            }
-        }
-
-        fun isGif(context: Context): Boolean {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && inputContent != null) {
-                inputContent.description.hasMimeType("image/gif")
-            } else {
-                uri?.let(context.contentResolver::getType) == "image/gif"
-            }
-        }
+    fun getUri(): Uri {
+        return (
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1)
+                inputContent?.contentUri ?: uri ?: Uri.EMPTY
+            else uri ?: Uri.EMPTY
+        )
     }
 
-    data class Contact(val vCard: String) : Attachment()
+    fun getType(context: Context): String {
+        return context.contentResolver.getType(getUri()) ?: "application/octect-stream"
+    }
+
+    fun getName(context: Context): String {
+        try {
+            context.contentResolver.query(
+                getUri(),
+                arrayOf(OpenableColumns.DISPLAY_NAME),
+                null,
+                null,
+                null
+            )
+            ?.use { cursor ->
+                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (nameIndex == -1)
+                    return "unknown"
+                cursor.moveToFirst()
+                return cursor.getString(nameIndex) ?: "unknown"
+            }
+        }
+        catch (e: Exception) { /* nothing*/ }
+
+        return "unknown"
+    }
+
+    fun isVCard(context: Context): Boolean {
+        return (getType(context) == "text/x-vcard")
+    }
+
+    fun hasDisplayableImage(context: Context): Boolean {
+        val mimeType = getType(context)
+        return (mimeType.startsWith("image/") || mimeType.startsWith("video/"))
+    }
+
+    fun isAudio(context: Context): Boolean {
+        val mimeType = getType(context)
+        return (mimeType.startsWith("audio/"))
+    }
+
+    fun isImage(context: Context): Boolean {
+        val mimeType = getType(context)
+        return (mimeType.startsWith("image/"))
+    }
+
+    fun getSize(context: Context): Long {
+        try {
+            context.contentResolver.query(
+                getUri(),
+                arrayOf(OpenableColumns.SIZE),
+                null,
+                null,
+                null
+            )
+            ?.use {
+                val sizeIndex = it.getColumnIndex(OpenableColumns.SIZE)
+                if (sizeIndex == -1)
+                    return -1
+                it.moveToFirst()
+                return it.getLong(sizeIndex)
+            }
+        }
+        catch (e: Exception) { /* nothing */ }
+
+        return -1
+    }
+
+    fun getResourceBytes(context: Context): ByteArray {
+        if (resourceBytes != null)
+            return resourceBytes!!
+
+            resourceBytes = ByteArray(0)
+
+        try {
+            context.contentResolver.openInputStream(getUri())?.use {
+                resourceBytes = it.readBytes()
+            }
+        } catch (e: Exception) {
+        }
+
+        return resourceBytes!!
+    }
 
 }
 

--- a/domain/src/main/java/com/moez/QKSMS/model/MmsPart.kt
+++ b/domain/src/main/java/com/moez/QKSMS/model/MmsPart.kt
@@ -40,11 +40,13 @@ open class MmsPart : RealmObject() {
     fun getUri() = "content://mms/part/$id".toUri()
 
     fun getSummary(): String? = when {
+        type == "application/smil" -> null
         type == "text/plain" -> text
-        type == "text/x-vCard" -> "Contact card"
+        type == "text/x-vcard" -> "Contact card"
         type.startsWith("image") -> "Photo"
         type.startsWith("video") -> "Video"
-        else -> null
+        type.startsWith("audio") -> "Audio"
+        else -> type.substring(type.indexOf('/') + 1)
     }
 
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -88,22 +88,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="image/*" />
+                <data android:mimeType="*/*" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="image/*" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/x-vcard" />
+                <data android:mimeType="*/*" />
             </intent-filter>
 
             <meta-data

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -78,22 +78,8 @@ class ComposeActivityModule {
         val uris = mutableListOf<Uri>()
         activity.intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::add)
         activity.intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::addAll)
-        return Attachments(uris.mapNotNull { uri ->
-            val mimeType = activity.contentResolver.getType(uri)
-            when {
-                ContentType.isImageType(mimeType) -> {
-                    Attachment.Image(uri)
-                }
 
-                ContentType.TEXT_VCARD.equals(mimeType, true) -> {
-                    val inputStream = activity.contentResolver.openInputStream(uri)
-                    val text = inputStream?.reader(Charset.forName("utf-8"))?.readText()
-                    text?.let(Attachment::Contact)
-                }
-
-                else -> null
-            }
-        })
+        return Attachments(uris.mapNotNull { Attachment(it) })
     }
 
     @Provides

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -29,6 +29,15 @@ import io.reactivex.subjects.Subject
 
 interface ComposeView : QkView<ComposeState> {
 
+    companion object {
+        const val SelectContactRequestCode = 0
+        const val TakePhotoRequestCode = 1
+        const val AttachAFileRequestCode = 4
+        const val AttachContactRequestCode = 3
+
+        const val CameraDestinationKey = "camera_destination"
+    }
+
     val activityVisibleIntent: Observable<Boolean>
     val chipsSelectedIntent: Subject<HashMap<String, String?>>
     val chipDeletedIntent: Subject<Recipient>
@@ -43,10 +52,11 @@ interface ComposeView : QkView<ComposeState> {
     val textChangedIntent: Observable<CharSequence>
     val attachIntent: Observable<Unit>
     val cameraIntent: Observable<*>
-    val galleryIntent: Observable<*>
+    val attachAnyFileIntent: Observable<*>
+    val attachImageFileIntent: Observable<*>
     val scheduleIntent: Observable<*>
     val attachContactIntent: Observable<*>
-    val attachmentSelectedIntent: Observable<Uri>
+    val attachAnyFileSelectedIntent: Observable<Uri>
     val contactSelectedIntent: Observable<Uri>
     val inputContentIntent: Observable<InputContentInfoCompat>
     val scheduleSelectedIntent: Observable<Long>
@@ -68,7 +78,7 @@ interface ComposeView : QkView<ComposeState> {
     fun themeChanged()
     fun showKeyboard()
     fun requestCamera()
-    fun requestGallery()
+    fun requestGallery(mimeType: String, requestCode: Int)
     fun requestDatePicker()
     fun requestContact()
     fun setDraft(draft: String)

--- a/presentation/src/main/res/drawable/ic_round_volume_up_24.xml
+++ b/presentation/src/main/res/drawable/ic_round_volume_up_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M3,10v4c0,0.55 0.45,1 1,1h3l3.29,3.29c0.63,0.63 1.71,0.18 1.71,-0.71L12,6.41c0,-0.89 -1.08,-1.34 -1.71,-0.71L7,9L4,9c-0.55,0 -1,0.45 -1,1zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,4.45v0.2c0,0.38 0.25,0.71 0.6,0.85C17.18,6.53 19,9.06 19,12s-1.82,5.47 -4.4,6.5c-0.36,0.14 -0.6,0.47 -0.6,0.85v0.2c0,0.63 0.63,1.07 1.21,0.85C18.6,19.11 21,15.84 21,12s-2.4,-7.11 -5.79,-8.4c-0.58,-0.23 -1.21,0.22 -1.21,0.85z"/>
+    
+</vector>

--- a/presentation/src/main/res/layout/attachment_file_list_item.xml
+++ b/presentation/src/main/res/layout/attachment_file_list_item.xml
@@ -37,7 +37,17 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scaleType="centerCrop"
-            tools:src="@tools:sample/avatars" />
+            tools:src="@tools:sample/backgrounds/scenic[0]" />
+
+        <TextView
+            android:id="@+id/fileName"
+            style="@style/TextPrimary"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="#ddffffff"
+            android:gravity="center"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
     </FrameLayout>
 

--- a/presentation/src/main/res/layout/compose_activity.xml
+++ b/presentation/src/main/res/layout/compose_activity.xml
@@ -204,7 +204,7 @@
         android:layout_height="56dp"
         android:padding="10dp"
         android:src="@drawable/ic_cancel_black_24dp"
-        android:tint="?android:attr/textColorSecondary"
+        app:tint="?android:attr/textColorSecondary"
         app:layout_constraintBottom_toTopOf="@id/scheduledSeparator"
         app:layout_constraintEnd_toEndOf="@id/messageBackground" />
 
@@ -230,7 +230,7 @@
         app:layout_constraintBottom_toTopOf="@id/message"
         app:layout_constraintEnd_toEndOf="@id/messageBackground"
         app:layout_constraintStart_toStartOf="@id/messageBackground"
-        tools:listitem="@layout/attachment_image_list_item" />
+        tools:listitem="@layout/attachment_file_list_item" />
 
     <dev.octoshrimpy.quik.common.widget.QkEditText
         android:id="@+id/message"
@@ -262,7 +262,7 @@
         android:contentDescription="@string/compose_sim_cd"
         android:padding="8dp"
         android:src="@drawable/ic_sim_card_black_24dp"
-        android:tint="?android:attr/textColorSecondary"
+        app:tint="?android:attr/textColorSecondary"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@id/messageBackground"
         app:layout_constraintEnd_toEndOf="@id/messageBackground" />
@@ -304,7 +304,7 @@
         android:contentDescription="@string/compose_send_cd"
         android:padding="10dp"
         android:src="@drawable/ic_send_black_24dp"
-        android:tint="?android:textColorSecondary"
+        app:tint="?android:textColorSecondary"
         app:layout_constraintBottom_toBottomOf="@id/messageBackground"
         app:layout_constraintEnd_toEndOf="parent" />
 
@@ -371,7 +371,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone"
-        app:constraint_referenced_ids="contact,contactLabel,schedule,scheduleLabel,gallery,galleryLabel,camera,cameraLabel,attachingBackground" />
+        app:constraint_referenced_ids="contact,contactLabel,schedule,scheduleLabel,gallery,galleryLabel,attachAFileIcon,attachAFileLabel,camera,cameraLabel,attachingBackground" />
 
     <View
         android:id="@+id/attachingBackground"
@@ -395,7 +395,7 @@
         android:elevation="4dp"
         android:padding="10dp"
         android:src="@drawable/ic_person_black_24dp"
-        android:tint="?android:attr/textColorSecondary"
+        app:tint="?android:attr/textColorSecondary"
         android:visibility="visible"
         app:layout_constraintBottom_toTopOf="@id/schedule"
         app:layout_constraintEnd_toEndOf="@id/attach"
@@ -429,9 +429,9 @@
         android:elevation="4dp"
         android:padding="10dp"
         android:src="@drawable/ic_event_black_24dp"
-        android:tint="?android:attr/textColorSecondary"
+        app:tint="?android:attr/textColorSecondary"
         android:visibility="visible"
-        app:layout_constraintBottom_toTopOf="@id/gallery"
+        app:layout_constraintBottom_toTopOf="@id/attachAFileIcon"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach" />
 
@@ -452,6 +452,43 @@
         app:layout_constraintStart_toEndOf="@id/schedule"
         app:layout_constraintTop_toTopOf="@id/schedule" />
 
+
+    <ImageView
+        android:id="@+id/attachAFileIcon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_marginBottom="12dp"
+        android:background="@drawable/circle"
+        android:backgroundTint="?attr/bubbleColor"
+        android:contentDescription="@string/compose_attach_file_cd"
+        android:elevation="4dp"
+        android:padding="10dp"
+        android:rotation="-45"
+        android:src="@drawable/ic_attachment_black_24dp"
+        android:visibility="visible"
+        app:layout_constraintBottom_toTopOf="@id/gallery"
+        app:layout_constraintEnd_toEndOf="@id/attach"
+        app:layout_constraintStart_toStartOf="@id/attach"
+        app:tint="?android:attr/textColorSecondary" />
+
+    <dev.octoshrimpy.quik.common.widget.QkTextView
+        android:id="@+id/attachAFileLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="32dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/rounded_rectangle_4dp"
+        android:backgroundTint="?attr/bubbleColor"
+        android:elevation="4dp"
+        android:gravity="center_vertical"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
+        android:text="@string/compose_attach_file_cd"
+        android:textColor="?android:attr/textColorPrimary"
+        app:layout_constraintBottom_toBottomOf="@id/attachAFileIcon"
+        app:layout_constraintStart_toEndOf="@id/attachAFileIcon"
+        app:layout_constraintTop_toTopOf="@id/attachAFileIcon" />
+
+
     <ImageView
         android:id="@+id/gallery"
         android:layout_width="40dp"
@@ -463,7 +500,7 @@
         android:elevation="4dp"
         android:padding="10dp"
         android:src="@drawable/ic_insert_photo_black_24dp"
-        android:tint="?android:attr/textColorSecondary"
+        app:tint="?android:attr/textColorSecondary"
         android:visibility="visible"
         app:layout_constraintBottom_toTopOf="@id/camera"
         app:layout_constraintEnd_toEndOf="@id/attach"
@@ -497,7 +534,7 @@
         android:elevation="4dp"
         android:padding="10dp"
         android:src="@drawable/ic_camera_alt_black_24dp"
-        android:tint="?android:attr/textColorSecondary"
+        app:tint="?android:attr/textColorSecondary"
         android:visibility="visible"
         app:layout_constraintBottom_toTopOf="@id/attach"
         app:layout_constraintEnd_toEndOf="@id/attach"

--- a/presentation/src/main/res/layout/scheduled_message_image_list_item.xml
+++ b/presentation/src/main/res/layout/scheduled_message_image_list_item.xml
@@ -19,18 +19,27 @@
   -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="48dp"
-    android:layout_height="48dp"
+    android:layout_width="56dp"
+    android:layout_height="56dp"
     android:layout_marginEnd="8dp">
 
     <ImageView
         android:id="@+id/thumbnail"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:adjustViewBounds="true"
         android:background="@drawable/rounded_rectangle_4dp"
         android:backgroundTint="?android:attr/divider"
         android:scaleType="centerCrop"
         tools:src="@tools:sample/backgrounds/scenic" />
+
+    <TextView
+        android:id="@+id/fileName"
+        style="@style/TextPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#ddffffff"
+        android:gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </FrameLayout>

--- a/presentation/src/main/res/values-el/strings.xml
+++ b/presentation/src/main/res/values-el/strings.xml
@@ -250,7 +250,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Συγχρονισμός μηνυμάτων</string>
     <string name="settings_sync_summary">Επανασυγχρονισμός μηνυμάτων με τη βάση δεδομένων SMS του Android</string>
     <string name="settings_about_title">Σχετικά με το QUIK</string>

--- a/presentation/src/main/res/values-gd/strings.xml
+++ b/presentation/src/main/res/values-gd/strings.xml
@@ -254,7 +254,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>

--- a/presentation/src/main/res/values-lt/strings.xml
+++ b/presentation/src/main/res/values-lt/strings.xml
@@ -254,7 +254,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sinchronizuoti pranešimus</string>
     <string name="settings_sync_summary">Iš naujo sinchronizuoti Android pranešimų duomenų bazę</string>
     <string name="settings_about_title">Apie QUIK</string>

--- a/presentation/src/main/res/values-ne/strings.xml
+++ b/presentation/src/main/res/values-ne/strings.xml
@@ -250,7 +250,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>

--- a/presentation/src/main/res/values-ta/strings.xml
+++ b/presentation/src/main/res/values-ta/strings.xml
@@ -250,7 +250,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">நீண்ட செய்திகளை எம்.எம்.எஸ் ஆக அனுப்பு</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">தகவல்களை ஒத்திசை</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">QUIK பற்றி</string>

--- a/presentation/src/main/res/values-tl/strings.xml
+++ b/presentation/src/main/res/values-tl/strings.xml
@@ -250,7 +250,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>

--- a/presentation/src/main/res/values-ur/strings.xml
+++ b/presentation/src/main/res/values-ur/strings.xml
@@ -250,7 +250,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="compose_details_delivered">Delivered: %s</string>
     <string name="compose_details_error_code">Error code: %d</string>
     <string name="compose_attach_cd">Add an attachment</string>
+    <string name="compose_attach_file_cd">Attach any file</string>
     <string name="compose_gallery_cd">Attach a photo</string>
     <string name="compose_camera_cd">Take a photo</string>
     <string name="compose_schedule_cd">Schedule message</string>
@@ -211,6 +212,7 @@
     <string name="scheduled_empty_message_3_timestamp">Sending on December 23rd&#x200A;</string>
     <string name="scheduled_compose_cd">Schedule a message</string>
     <string name="scheduled_options_title">Scheduled message</string>
+    <string name="attachment_missing">Missing</string>
     <string-array name="scheduled_options">
         <item>Send now</item>
         <item>Copy text</item>
@@ -284,7 +286,7 @@
     </plurals>
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
-    <string name="settings_mms_size_title">Auto-compress MMS attachments</string>
+    <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>


### PR DESCRIPTION
changes to allow attaching any type of file.
primary use-case is for video and audio attachments but nothing to stop any type of file being attached.
changes also allow any file type (*/*) to be shared to quik.
* non-image files cannot be compressed so be very aware of your providers mmsc mms size limit

satisfies request  https://github.com/octoshrimpy/quik/issues/122

satisfies video part of request https://github.com/octoshrimpy/quik/issues/115

![image](https://github.com/user-attachments/assets/15cf69d6-5434-402f-a1b5-1b3d6b16bb24)
