### PR TITLE
silent notifications if no recipients are a contact

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/ContactRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/ContactRepositoryImpl.kt
@@ -82,6 +82,15 @@ class ContactRepositoryImpl @Inject constructor(
         }
     }
 
+    override fun getUnmanagedAllContacts(): List<Contact> {
+        val realm = Realm.getDefaultInstance()
+
+        return realm
+            .where(Contact::class.java)
+            .findAll()
+            .map { realm.copyFromRealm(it) }
+    }
+
     override fun getUnmanagedContacts(starred: Boolean): Observable<List<Contact>> {
         val realm = Realm.getDefaultInstance()
 

--- a/domain/src/main/java/com/moez/QKSMS/repository/ContactRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/ContactRepository.kt
@@ -33,6 +33,8 @@ interface ContactRepository {
 
     fun getUnmanagedContact(lookupKey: String): Contact?
 
+    fun getUnmanagedAllContacts(): List<Contact>
+
     fun getUnmanagedContacts(starred: Boolean = false): Observable<List<Contact>>
 
     fun getUnmanagedContactGroups(): Observable<List<ContactGroup>>

--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -107,6 +107,7 @@ class Preferences @Inject constructor(
     val textSize = rxPrefs.getInteger("textSize", TEXT_SIZE_NORMAL)
     val blockingManager = rxPrefs.getInteger("blockingManager", BLOCKING_MANAGER_QKSMS)
     val drop = rxPrefs.getBoolean("drop", false)
+    val silentNotContact = rxPrefs.getBoolean("silentNotContact", false)
     val notifAction1 = rxPrefs.getInteger("notifAction1", NOTIFICATION_ACTION_READ)
     val notifAction2 = rxPrefs.getInteger("notifAction2", NOTIFICATION_ACTION_REPLY)
     val notifAction3 = rxPrefs.getInteger("notifAction3", NOTIFICATION_ACTION_NONE)

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -52,6 +52,7 @@ import dev.octoshrimpy.quik.receiver.MarkReadReceiver
 import dev.octoshrimpy.quik.receiver.MarkSeenReceiver
 import dev.octoshrimpy.quik.receiver.RemoteMessagingReceiver
 import dev.octoshrimpy.quik.receiver.SpeakThreadsReceiver
+import dev.octoshrimpy.quik.repository.ContactRepository
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.repository.MessageRepository
 import dev.octoshrimpy.quik.util.GlideApp
@@ -70,7 +71,8 @@ class NotificationManagerImpl @Inject constructor(
     private val prefs: Preferences,
     private val messageRepo: MessageRepository,
     private val permissions: PermissionManager,
-    private val phoneNumberUtils: PhoneNumberUtils
+    private val phoneNumberUtils: PhoneNumberUtils,
+    private val contactRepo: ContactRepository,
 ) : dev.octoshrimpy.quik.manager.NotificationManager {
 
     companion object {
@@ -145,12 +147,28 @@ class NotificationManagerImpl @Inject constructor(
                 .setAutoCancel(true)
                 .setContentIntent(contentPI)
                 .setDeleteIntent(seenPI)
-                .setSound(ringtone)
                 .setLights(Color.WHITE, 500, 2000)
                 .setWhen(conversation.lastMessage?.date ?: System.currentTimeMillis())
                 .setVibrate(if (prefs.vibration(threadId).get()) VIBRATE_PATTERN else longArrayOf(0))
 
-        // Tell the notification if it's a group message
+        // if preference set to silence notifications if no recipients in contacts
+        if (prefs.silentNotContact.get() && run {
+            val msgRecipientNumbers = conversation.recipients.map { it.address }
+
+            // true if any message recipients are in device's contacts
+            !contactRepo
+                .getUnmanagedAllContacts()
+                .flatMap { it.numbers }
+                .map { it.address }
+                .any { contactNumber ->
+                    msgRecipientNumbers.any { phoneNumberUtils.compare(contactNumber, it) }
+                }
+        })
+            notification.setSilent(true)
+        else
+            notification.setSound(ringtone)
+
+    // Tell the notification if it's a group message
         val messagingStyle = NotificationCompat.MessagingStyle("Me")
         if (conversation.recipients.size >= 2) {
             messagingStyle.isGroupConversation = true

--- a/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsActivity.kt
@@ -99,6 +99,8 @@ class NotificationPrefsActivity : QkThemedActivity(), NotificationPrefsView {
         previews.summary = state.previewSummary
         previewModeDialog.adapter.selectedItem = state.previewId
         wake.checkbox.isChecked = state.wakeEnabled
+        silentNotContact.checkbox.isChecked = state.silentNotContact
+        silentNotContact.isVisible = state.threadId == 0L
         vibration.checkbox.isChecked = state.vibrationEnabled
         ringtone.summary = state.ringtoneName
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsState.kt
@@ -28,6 +28,7 @@ data class NotificationPrefsState(
     val previewSummary: String = "",
     val previewId: Int = Preferences.NOTIFICATION_PREVIEWS_ALL,
     val wakeEnabled: Boolean = false,
+    val silentNotContact: Boolean = false,
     val action1Summary: String = "",
     val action2Summary: String = "",
     val action3Summary: String = "",

--- a/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsViewModel.kt
@@ -79,6 +79,9 @@ class NotificationPrefsViewModel @Inject constructor(
         disposables += wake.asObservable()
                 .subscribe { enabled -> newState { copy(wakeEnabled = enabled) } }
 
+        disposables += prefs.silentNotContact.asObservable()
+                .subscribe { enabled -> newState { copy(silentNotContact = enabled) } }
+
         disposables += vibration.asObservable()
                 .subscribe { enabled -> newState { copy(vibrationEnabled = enabled) } }
 
@@ -112,6 +115,8 @@ class NotificationPrefsViewModel @Inject constructor(
                         R.id.previews -> view.showPreviewModeDialog()
 
                         R.id.wake -> wake.set(!wake.get())
+
+                        R.id.silentNotContact -> prefs.silentNotContact.set(!prefs.silentNotContact.get())
 
                         R.id.vibration -> vibration.set(!vibration.get())
 

--- a/presentation/src/main/res/layout/notification_prefs_activity.xml
+++ b/presentation/src/main/res/layout/notification_prefs_activity.xml
@@ -70,13 +70,21 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:title="@string/settings_notification_previews_title"
-                tools:summary="Show name and message" />
+                tools:summary="@string/settings_notification_previews_summary" />
 
             <dev.octoshrimpy.quik.common.widget.PreferenceView
                 android:id="@+id/wake"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:title="@string/settings_notification_wake_title"
+                app:widget="@layout/settings_switch_widget" />
+
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/silentNotContact"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:title="@string/settings_notification_silent_title"
+                app:summary="@string/settings_notification_silent_summary"
                 app:widget="@layout/settings_switch_widget" />
 
             <dev.octoshrimpy.quik.common.widget.PreferenceView

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -239,7 +239,10 @@
     <string name="settings_notification_action_2">Button 2</string>
     <string name="settings_notification_action_3">Button 3</string>
     <string name="settings_notification_previews_title">Notification previews</string>
+    <string name="settings_notification_previews_summary">Show name and message</string>
     <string name="settings_notification_wake_title">Wake screen</string>
+    <string name="settings_notification_silent_title">Silent if not a contact</string>
+    <string name="settings_notification_silent_summary">Silences notifications for messages without recipients in your contacts</string>
     <string name="settings_vibration_title">Vibration</string>
     <string name="settings_ringtone_title">Sound</string>
     <string name="settings_ringtone_none">None</string>


### PR DESCRIPTION
changes to make new message notifications silent if any of the recipients of the new message are not in user's contacts. new setting on settings->notifications page

* everything else operates the same except the new message notification - yes, there is still a notification - will make no sound and not distract your attention

![image](https://github.com/user-attachments/assets/516d74b5-4ba6-4687-be42-c2a78b8ea3db)
