### PR TITLE
Update build-on-pull.yml

### DIFF
--- a/.github/workflows/build-on-pull.yml
+++ b/.github/workflows/build-on-pull.yml
@@ -11,11 +11,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
+        distribution: 'temurin'
         java-version: '17'
 
     - name: Build with Gradle
@@ -25,7 +26,7 @@ jobs:
       run: ./gradlew test
 
     - name: Deploy Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-artifacts
         path: build/libs/


### PR DESCRIPTION
This pr updates all the versions in the build-on-pull.yml. Note, this does not actually make this action succeed. It only allows the build to start. The build then makes it about 3/4 of the way through and fails with a signing keys error. I am currently working on this, but I have not made much headway. My apologies @Ilithy for jumping in on this. Thanks!