### PR TITLE
bug fix of 'take a photo' not working

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -528,12 +528,8 @@ class ComposeViewModel @Inject constructor(
         view.cameraIntent
                 .autoDisposable(view.scope())
                 .subscribe {
-                    if (permissionManager.hasStorage()) {
-                        newState { copy(attaching = false) }
-                        view.requestCamera()
-                    } else {
-                        view.requestStoragePermission()
-                    }
+                    newState { copy(attaching = false) }
+                    view.requestCamera()
                 }
 
         // pick a photo (specifically) from image provider apps


### PR DESCRIPTION
fix for 'take a photo' not working.

removed runtime check for WRITE_EXTERNAL_STORAGE at 'take a photo' time which is not required for taking a photo