### PR TITLE
fix bug that disabled download/view of mms attachments

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -181,9 +181,9 @@ class MessageRepositoryImpl @Inject constructor(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             values.put(MediaStore.MediaColumns.IS_PENDING, 1)
             values.put(MediaStore.MediaColumns.RELATIVE_PATH, when {
-                part.isImage() -> "${Environment.DIRECTORY_PICTURES}/QKSMS"
-                part.isVideo() -> "${Environment.DIRECTORY_MOVIES}/QKSMS"
-                else -> "${Environment.DIRECTORY_DOWNLOADS}/QKSMS"
+                part.isImage() -> "${Environment.DIRECTORY_PICTURES}/QUIK"
+                part.isVideo() -> "${Environment.DIRECTORY_MOVIES}/QUIK"
+                else -> "${Environment.DIRECTORY_DOWNLOADS}/QUIK"
             })
         }
 

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".common.QKApplication"


### PR DESCRIPTION
enabled WRITE_EXTERNAL_STORAGE permission in app manifest which is required to save mms attachments to media storage.
changed media storage locations from ...../QKSMS to ...../QUIK.

satisfies ticket https://github.com/octoshrimpy/quik/issues/235

this pr gets the existing functionality working again for attachment downloading, _but_ that existing functionality is sub-optimal. new issue https://github.com/octoshrimpy/quik/issues/242 opened to address those sub-optimal aspects in future