### PR TITLE
fix mms image compression bug not compressing

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -429,8 +429,8 @@ class MessageRepositoryImpl @Inject constructor(
 
                         attempts++
                         scaledBytes = when (attachment.getType(context) == "image/gif") {
-                            true -> ImageUtils.getScaledGif(context, attachment.getUri(), maxWidth, maxHeight)
-                            false -> ImageUtils.getScaledImage(context, attachment.getUri(), maxWidth, maxHeight)
+                            true -> ImageUtils.getScaledGif(context, attachment.getUri(), newWidth, newHeight)
+                            false -> ImageUtils.getScaledImage(context, attachment.getUri(), newWidth, newHeight)
                         }
 
                         Timber.d("Compression attempt $attempts: ${scaledBytes.size / 1024}/${maxBytes.toInt() / 1024}Kb ($width*$height -> $newWidth*$newHeight)")


### PR DESCRIPTION
compression was not being applied to images and gifs.

should satisfy issue https://github.com/octoshrimpy/quik/issues/116

* suggest this bugfix goes into latest beta build so it can be well tested