### PR TITLE
Scheduled messages click doesnt schedule 18

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
@@ -95,9 +95,10 @@ class Navigator @Inject constructor(
         }
     }
 
-    fun showCompose(body: String? = null, images: List<Uri>? = null) {
+    fun showCompose(body: String? = null, images: List<Uri>? = null, mode: String? = null) {
         val intent = Intent(context, ComposeActivity::class.java)
         intent.putExtra(Intent.EXTRA_TEXT, body)
+        intent.putExtra("mode", mode)
 
         images?.takeIf { it.isNotEmpty() }?.let {
             intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(images))

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -71,10 +71,12 @@ import dev.octoshrimpy.quik.feature.contacts.ContactsActivity
 import dev.octoshrimpy.quik.model.Attachment
 import dev.octoshrimpy.quik.model.Recipient
 import io.reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import kotlinx.android.synthetic.main.compose_activity.*
 import kotlinx.android.synthetic.main.main_activity.toolbar
+import kotlinx.coroutines.reactive.publish
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
@@ -94,6 +96,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val chipDeletedIntent: Subject<Recipient> by lazy { chipsAdapter.chipDeleted }
     override val menuReadyIntent: Observable<Unit> = menu.map { Unit }
     override val optionsItemIntent: Subject<Int> = PublishSubject.create()
+    override val scheduleAction: Subject<Boolean> = PublishSubject.create()
     override val sendAsGroupIntent by lazy { sendAsGroupBackground.clicks() }
     override val messageClickIntent: Subject<Long> by lazy { messageAdapter.clicks }
     override val messagePartClickIntent: Subject<Long> by lazy { messageAdapter.partClicks }
@@ -323,6 +326,10 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             )
             constraintSet.applyTo(constraintLayout)
         }
+
+        // if scheduling mode is set, show schedule dialog
+        if (state.scheduling)
+            scheduleAction.onNext(true)
     }
 
     override fun clearSelection() = messageAdapter.clearSelection()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -83,6 +83,12 @@ class ComposeActivityModule {
     }
 
     @Provides
+    @Named("mode")
+    fun provideSharedAction(activity: ComposeActivity): String {
+        return activity.intent.getStringExtra("mode") ?: "";
+    }
+
+    @Provides
     @IntoMap
     @ViewModelKey(ComposeViewModel::class)
     fun provideComposeViewModel(viewModel: ComposeViewModel): ViewModel = viewModel

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
@@ -42,6 +42,7 @@ data class ComposeState(
     val scheduled: Long = 0,
     val attachments: List<Attachment> = ArrayList(),
     val attaching: Boolean = false,
+    val scheduling: Boolean = false,
     val remaining: String = "",
     val subscription: SubscriptionInfoCompat? = null,
     val canSend: Boolean = false,

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -56,6 +56,7 @@ interface ComposeView : QkView<ComposeState> {
     val attachAnyFileIntent: Observable<*>
     val attachImageFileIntent: Observable<*>
     val scheduleIntent: Observable<*>
+    val scheduleAction: Observable<*>
     val attachContactIntent: Observable<*>
     val attachAnyFileSelectedIntent: Observable<Uri>
     val contactSelectedIntent: Observable<Uri>

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -79,6 +79,7 @@ class ComposeViewModel @Inject constructor(
     @Named("addresses") private val addresses: List<String>,
     @Named("text") private val sharedText: String,
     @Named("attachments") private val sharedAttachments: Attachments,
+    @Named("mode") private val mode: String,
     private val contactRepo: ContactRepository,
     private val context: Context,
     private val activeConversationManager: ActiveConversationManager,
@@ -242,6 +243,10 @@ class ComposeViewModel @Inject constructor(
             val sub = if (subs.size > 1) subs.firstOrNull { it.subscriptionId == subId } ?: subs[0] else null
             newState { copy(subscription = sub) }
         }.subscribe()
+
+        // actions
+        if (mode == "scheduling")
+            newState { copy(scheduling = true) }
     }
 
     override fun bindView(view: ComposeView) {
@@ -573,6 +578,12 @@ class ComposeViewModel @Inject constructor(
                 }
                 .autoDisposable(view.scope())
                 .subscribe { view.requestDatePicker() }
+
+        view.scheduleAction
+            .take(1)
+            .doOnNext{ newState { copy(scheduling = false) } }
+            .autoDisposable(view.scope())
+            .subscribe { view.requestDatePicker() }
 
         // a file, photo or otherwise, was picked by the user
         Observable.merge(

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledViewModel.kt
@@ -70,7 +70,7 @@ class ScheduledViewModel @Inject constructor(
 
         view.composeIntent
             .autoDisposable(view.scope())
-            .subscribe { navigator.showCompose() }
+            .subscribe { navigator.showCompose(mode = "scheduling") }
 
         view.upgradeIntent
             .autoDisposable(view.scope())


### PR DESCRIPTION
changes to enter the compose screen in 'scheduling' mode when launched from the scheduling activity. causes message scheduling to shown be shown after contact is chosen

closes https://github.com/octoshrimpy/quik/issues/18


use schedule message button on scheduled activity;

![image](https://github.com/user-attachments/assets/979fb910-e7e6-4dcb-b30c-c8650bc1ef63)

... select contact (or back button and select none)

![image](https://github.com/user-attachments/assets/32cd7add-8f31-49d3-a64c-05a620e41d63)

... scheduling dialog is shown;

![image](https://github.com/user-attachments/assets/1593c9a7-cfec-492a-840e-ddb73c800afb)

... continue to compose message as normal