### PR TITLE
Disable auto hyperlink (warn link on press) 201

### DIFF
--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -80,6 +80,10 @@ class Preferences @Inject constructor(
         const val BLOCKING_MANAGER_CC = 1
         const val BLOCKING_MANAGER_SIA = 2
         const val BLOCKING_MANAGER_CB = 3
+
+        const val MESSAGE_LINK_HANDLING_BLOCK = 0
+        const val MESSAGE_LINK_HANDLING_ALLOW = 1
+        const val MESSAGE_LINK_HANDLING_ASK = 2
     }
 
     // Internal
@@ -124,6 +128,7 @@ class Preferences @Inject constructor(
     val autoDelete = rxPrefs.getInteger("autoDelete", 0)
     val longAsMms = rxPrefs.getBoolean("longAsMms", false)
     val mmsSize = rxPrefs.getInteger("mmsSize", 300)
+    val messageLinkHandling = rxPrefs.getInteger("messageLinkHandling", MESSAGE_LINK_HANDLING_ASK)
     val logging = rxPrefs.getBoolean("logging", false)
     val unreadAtTop = rxPrefs.getBoolean("unreadAtTop", false)
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -206,6 +206,12 @@ class NotificationManagerImpl @Inject constructor(
             }
         }
 
+        // remove system generated contextual actions (they're generated from message links) unless
+        // the user has explicitly set to allow message links
+        notification.setAllowSystemGeneratedContextualActions(
+            (prefs.messageLinkHandling.get() == Preferences.MESSAGE_LINK_HANDLING_ALLOW)
+        )
+
         // Set the large icon
         val avatar = conversation.recipients.takeIf { it.size == 1 }
                 ?.first()?.contact?.photoUri

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ViewExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ViewExtensions.kt
@@ -92,55 +92,67 @@ fun View.setVisible(visible: Boolean, invisible: Int = View.GONE) {
  * the view no longer work. Also problematic when we try to long press on an image in the message
  * view
  */
-fun View.forwardTouches(parent: View) {
-    var isLongClick = false
-    var textInitiallySelectable = false
-    if (this@forwardTouches is TextView)
-        textInitiallySelectable = this@forwardTouches.isTextSelectable
+
+class CancelableSimpleOnGestureListener(view: View, parentView: View) : SimpleOnGestureListener() {
+    private var lastUpEvent: MotionEvent? = null
+    private val parent = parentView
+    private val thisView = view
+    private var textInitiallySelectable = false
+
+    init {
+        if (thisView is TextView)
+            textInitiallySelectable = thisView.isTextSelectable
+    }
+
+    fun cancelCurrentClick() {
+        lastUpEvent?.recycle()
+        lastUpEvent = null
+    }
+
+    override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+        if (lastUpEvent !== null) {
+            parent.onTouchEvent(e)
+            parent.onTouchEvent(lastUpEvent)
+            lastUpEvent?.recycle()
+            lastUpEvent = null
+        }
+        return true
+    }
+
+    override fun onSingleTapUp(e: MotionEvent): Boolean {
+        lastUpEvent = MotionEvent.obtain(e)
+        thisView.onTouchEvent(e)
+        return true
+    }
+
+    override fun onDown(e: MotionEvent): Boolean {
+        thisView.onTouchEvent(e)
+        return true
+    }
+
+    override fun onLongPress(e: MotionEvent) {
+        parent.onTouchEvent(e)
+        // this is kinda odd but we have to 'bounce' the text selectable value so it doesn't
+        // start selecting text on a long press, but will start selecting it on the next double-tap
+        if (thisView is TextView) {
+            thisView.setTextIsSelectable(false)
+            thisView.setTextIsSelectable(textInitiallySelectable)
+        }
+    }
+}
+
+fun View.forwardTouches(parent: View): CancelableSimpleOnGestureListener {
+    val gestureListener = CancelableSimpleOnGestureListener(this, parent)
 
     setOnTouchListener(object : OnTouchListener {
-        private val gestureDetector =
-            GestureDetector(parent.context, object : SimpleOnGestureListener() {
-                private var lastUpEvent: MotionEvent? = null
-
-                override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-                    parent.onTouchEvent(e)
-                    if (lastUpEvent !== null) {
-                        parent.onTouchEvent(lastUpEvent)
-                        lastUpEvent?.recycle()
-                        lastUpEvent = null
-                    }
-                    return true
-                }
-
-                override fun onSingleTapUp(e: MotionEvent): Boolean {
-                    onTouchEvent(e)
-                    lastUpEvent = MotionEvent.obtain(e)
-                    return true
-                }
-
-                override fun onDown(e: MotionEvent): Boolean {
-                    isLongClick = false
-                    onTouchEvent(e)
-                    return true
-                }
-
-                override fun onLongPress(e: MotionEvent) {
-                    parent.onTouchEvent(e)
-                    isLongClick = true
-                    // this is kinda odd but we have to 'bounce' the text selectable value so it doesn't
-                    // start selecting text on a long press, but will start selecting it on the next double-tap
-                    if (this@forwardTouches is TextView) {
-                        (this@forwardTouches as TextView).setTextIsSelectable(false)
-                        (this@forwardTouches as TextView).setTextIsSelectable(textInitiallySelectable)
-                    }
-                }
-            })
+        val gestureDetector = GestureDetector(parent.context, gestureListener)
 
         override fun onTouch(v: View, e: MotionEvent): Boolean {
             return gestureDetector.onTouchEvent(e)
         }
     })
+
+    return gestureListener
 }
 
 fun ViewPager.addOnPageChangeListener(listener: (Int) -> Unit) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -43,6 +43,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
@@ -121,6 +122,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val viewQksmsPlusIntent: Subject<Unit> = PublishSubject.create()
     override val backPressedIntent: Subject<Unit> = PublishSubject.create()
     override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
+    override val messageLinkAskIntent: Subject<Uri> by lazy { messageAdapter.messageLinkClicks }
 
     private val viewModel by lazy { ViewModelProviders.of(this, viewModelFactory)[ComposeViewModel::class.java] }
 
@@ -348,6 +350,23 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                 .setMessage(details)
                 .setCancelable(true)
                 .show()
+    }
+
+    override fun showMessageLinkAskDialog(uri: Uri) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.messageLinkHandling_dialog_title)
+            .setMessage(getString(R.string.messageLinkHandling_dialog_body, uri.toString()))
+            .setPositiveButton(
+                R.string.messageLinkHandling_dialog_positive
+            ) { _, _ ->
+                ContextCompat.startActivity(
+                    this,
+                    Intent(Intent.ACTION_VIEW).setData(uri),
+                    null
+                )
+            }
+            .setNegativeButton(R.string.messageLinkHandling_dialog_negative) { _, _ -> { } }
+            .show()
     }
 
     override fun requestDefaultSms() {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -68,11 +68,13 @@ interface ComposeView : QkView<ComposeState> {
     val viewQksmsPlusIntent: Subject<Unit>
     val backPressedIntent: Observable<Unit>
     val confirmDeleteIntent: Observable<List<Long>>
+    val messageLinkAskIntent: Observable<Uri>
 
     fun clearSelection()
     fun toggleSelectAll()
     fun expandMessages(messageIds: List<Long>, expand: Boolean)
     fun showDetails(details: String)
+    fun showMessageLinkAskDialog(uri: Uri)
     fun requestDefaultSms()
     fun requestStoragePermission()
     fun requestSmsPermission()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -513,6 +513,11 @@ class ComposeViewModel @Inject constructor(
                     )
                 }
 
+        // Show the message details
+        view.messageLinkAskIntent
+            .autoDisposable(view.scope())
+            .subscribe { view.showMessageLinkAskDialog(it) }
+
         // Set the current conversation
         Observables
                 .combineLatest(

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -339,6 +339,7 @@ class MessagesAdapter @Inject constructor(
                     spanString.removeSpan(span)
                 }
             }
+            else -> holder.body.movementMethod = LinkMovementMethod.getInstance()
         }
 
         holder.body.text = spanString

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
@@ -41,7 +41,6 @@ import dev.octoshrimpy.quik.common.util.extensions.animateLayoutChanges
 import dev.octoshrimpy.quik.common.util.extensions.setBackgroundTint
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
 import dev.octoshrimpy.quik.common.widget.PreferenceView
-import dev.octoshrimpy.quik.common.widget.QkSwitch
 import dev.octoshrimpy.quik.common.widget.TextInputDialog
 import dev.octoshrimpy.quik.feature.settings.about.AboutController
 import dev.octoshrimpy.quik.feature.settings.autodelete.AutoDeleteDialog
@@ -73,6 +72,7 @@ class SettingsController : QkController<SettingsView, SettingsState, SettingsPre
     @Inject lateinit var textSizeDialog: QkDialog
     @Inject lateinit var sendDelayDialog: QkDialog
     @Inject lateinit var mmsSizeDialog: QkDialog
+    @Inject lateinit var messageLinkHandlingDialog: QkDialog
 
     @Inject override lateinit var presenter: SettingsPresenter
 
@@ -113,6 +113,7 @@ class SettingsController : QkController<SettingsView, SettingsState, SettingsPre
         textSizeDialog.adapter.setData(R.array.text_sizes)
         sendDelayDialog.adapter.setData(R.array.delayed_sending_labels)
         mmsSizeDialog.adapter.setData(R.array.mms_sizes, R.array.mms_sizes_ids)
+        messageLinkHandlingDialog.adapter.setData(R.array.messageLinkHandlings, R.array.messageLinkHandling_ids)
 
         about.summary = context.getString(R.string.settings_version, BuildConfig.VERSION_NAME)
     }
@@ -149,6 +150,8 @@ class SettingsController : QkController<SettingsView, SettingsState, SettingsPre
     override fun autoDeleteChanged(): Observable<Int> = autoDeleteSubject
 
     override fun mmsSizeSelected(): Observable<Int> = mmsSizeDialog.adapter.menuItemClicks
+
+    override fun messageLinkHandlingSelected(): Observable<Int> = messageLinkHandlingDialog.adapter.menuItemClicks
 
     override fun render(state: SettingsState) {
         themePreview.setBackgroundTint(state.theme)
@@ -194,6 +197,9 @@ class SettingsController : QkController<SettingsView, SettingsState, SettingsPre
 
         mmsSize.summary = state.maxMmsSizeSummary
         mmsSizeDialog.adapter.selectedItem = state.maxMmsSizeId
+
+        messsageLinkHandling.summary = state.messageLinkHandlingSummary
+        messageLinkHandlingDialog.adapter.selectedItem = state.messageLinkHandlingId
 
         when (state.syncProgress) {
             is SyncRepository.SyncProgress.Idle -> syncingProgress.isVisible = false
@@ -253,6 +259,8 @@ class SettingsController : QkController<SettingsView, SettingsState, SettingsPre
     }
 
     override fun showMmsSizePicker() = mmsSizeDialog.show(activity!!)
+
+    override fun showMessageLinkHandlingDialogPicker() = messageLinkHandlingDialog.show(activity!!)
 
     override fun showSwipeActions() {
         router.pushController(RouterTransaction.with(SwipeActionsController())

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -138,6 +138,19 @@ class SettingsPresenter @Inject constructor(
                     newState { copy(maxMmsSizeSummary = mmsSizeLabels[index], maxMmsSizeId = maxMmsSize) }
                 }
 
+        val messageLinkHandlingLabels = context.resources.getStringArray(R.array.messageLinkHandlings)
+        val messageLinkHandlingIds = context.resources.getIntArray(R.array.messageLinkHandling_ids)
+        disposables += prefs.messageLinkHandling.asObservable()
+            .subscribe { messageLinkHandlingId ->
+                val index = messageLinkHandlingIds.indexOf(messageLinkHandlingId)
+                newState {
+                    copy(
+                        messageLinkHandlingSummary = messageLinkHandlingLabels[index],
+                        messageLinkHandlingId = messageLinkHandlingId
+                    )
+                }
+            }
+
         disposables += syncRepo.syncProgress
                 .sample(16, TimeUnit.MILLISECONDS)
                 .distinctUntilChanged()
@@ -203,6 +216,8 @@ class SettingsPresenter @Inject constructor(
                         R.id.longAsMms -> prefs.longAsMms.set(!prefs.longAsMms.get())
 
                         R.id.mmsSize -> view.showMmsSizePicker()
+
+                        R.id.messsageLinkHandling -> view.showMessageLinkHandlingDialogPicker()
 
                         R.id.sync -> syncMessages.execute(Unit)
 
@@ -294,6 +309,10 @@ class SettingsPresenter @Inject constructor(
         view.mmsSizeSelected()
                 .autoDisposable(view.scope())
                 .subscribe(prefs.mmsSize::set)
+
+        view.messageLinkHandlingSelected()
+            .autoDisposable(view.scope())
+            .subscribe(prefs.messageLinkHandling::set)
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
@@ -46,5 +46,7 @@ data class SettingsState(
     val longAsMms: Boolean = false,
     val maxMmsSizeSummary: String = "100KB",
     val maxMmsSizeId: Int = 100,
+    val messageLinkHandlingSummary: String = "Ask before opening",
+    val messageLinkHandlingId: Int = 2,
     val syncProgress: SyncRepository.SyncProgress = SyncRepository.SyncProgress.Idle
 )

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsView.kt
@@ -34,6 +34,7 @@ interface SettingsView : QkViewContract<SettingsState> {
     fun signatureChanged(): Observable<String>
     fun autoDeleteChanged(): Observable<Int>
     fun mmsSizeSelected(): Observable<Int>
+    fun messageLinkHandlingSelected(): Observable<Int>
 
     fun showQksmsPlusSnackbar()
     fun showNightModeDialog()
@@ -45,6 +46,7 @@ interface SettingsView : QkViewContract<SettingsState> {
     fun showAutoDeleteDialog(days: Int)
     suspend fun showAutoDeleteWarningDialog(messages: Int): Boolean
     fun showMmsSizePicker()
+    fun showMessageLinkHandlingDialogPicker()
     fun showSwipeActions()
     fun showThemePicker()
     fun showAbout()

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -212,6 +212,15 @@
             app:title="@string/settings_mms_size_title"
             tools:summary="100KB" />
 
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/messsageLinkHandling"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="visible"
+            app:icon="@android:drawable/stat_sys_warning"
+            app:title="@string/settings_mms_weblink_title"
+            tools:summary="100KB" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -296,6 +296,7 @@
     <string name="settings_long_as_mms_title">Send long messages as MMS</string>
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
     <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
+    <string name="settings_mms_weblink_title">Link handling in messages</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>
@@ -505,6 +506,18 @@
         <item>0</item>
     </integer-array>
 
+    <string-array name="messageLinkHandlings">
+        <item>Block</item>
+        <item>Allow</item>
+        <item>Ask before opening</item>
+    </string-array>
+
+    <integer-array name="messageLinkHandling_ids">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </integer-array>
+
     <string-array name="qk_responses">
         <item>Okay</item>
         <item>Give me a moment</item>
@@ -521,4 +534,8 @@
     </string-array>
     <string name="speak_no_messages">No Messages</string>
     <string name="speak_unseen_messages">Speak unseen messages</string>
+    <string name="messageLinkHandling_dialog_title">External Link Warning</string>
+    <string name="messageLinkHandling_dialog_body">Some links may be unsafe or redirect you unexpectedly. Review the link below before proceeding:\n\n%1$s\n\nDo you want to continue?</string>
+    <string name="messageLinkHandling_dialog_positive">Yes, open the link</string>
+    <string name="messageLinkHandling_dialog_negative">No</string>
 </resources>


### PR DESCRIPTION
changes to add a new setting that allows user to choose to
- allow all message links
- block all message links (including in notifications)
- ask via a dialog box whether the user wishes to proceed

setting defaults to "ask"


![image](https://github.com/user-attachments/assets/ba90c52a-5d86-425a-986e-1c07111322f6)

![image](https://github.com/user-attachments/assets/067d104c-1e82-419b-8612-0b485b413b72)

When "allow," links render as underlined and are touchable. they go straight to their default activity;

![image](https://github.com/user-attachments/assets/cd344c5b-b4ba-46d0-a5b8-8c39e7442ce0)

and notifications include system generated actions;

![image](https://github.com/user-attachments/assets/7c424471-70ab-4bb1-95f3-b0184c832da3)


When "block," hyperlinks don't render underlined and are not touchable;

![image](https://github.com/user-attachments/assets/642bf3ce-8a2e-4fed-808f-7d598bc8456f)

also notifications don't show system generated actions;

![image](https://github.com/user-attachments/assets/2a70e4b5-1df5-4bcf-85c6-d299ac9a878d)


When "ask," links render underlined and are touchable. each link will take user to a dialog box;

![image](https://github.com/user-attachments/assets/5a12c3d2-6416-4747-a5f1-94e8dea044e9)

any link type will cause the dialog box, including telephone number links;

![image](https://github.com/user-attachments/assets/c32b5b2a-c93e-4ee4-9572-4325ac8aa012)


closes https://github.com/octoshrimpy/quik/pull/252