### PR TITLE
context menu to save, share, forward, open externally

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/MenuItemAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/MenuItemAdapter.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
 
 data class MenuItem(val title: String, val actionId: Int)
 
-class MenuItemAdapter @Inject constructor(private val context: Context, private val colors: Colors) : QkAdapter<MenuItem>() {
+class MenuItemAdapter @Inject constructor(private val context: Context, private val colors: Colors) : QkAdapter<MenuItem, QkViewHolder>() {
 
     val menuItemClicks: Subject<Int> = PublishSubject.create()
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/FlowableAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/FlowableAdapter.kt
@@ -27,7 +27,7 @@ import io.reactivex.disposables.Disposable
  * Base RecyclerView.Adapter that provides some convenience when creating a new Adapter, such as
  * data list handing and item animations
  */
-abstract class FlowableAdapter<T> : QkAdapter<T>() {
+abstract class FlowableAdapter<T> : QkAdapter<T, QkViewHolder>() {
 
     var flowable: Flowable<List<T>>? = null
         set(value) {

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkAdapter.kt
@@ -30,7 +30,7 @@ import io.reactivex.subjects.Subject
  * Base RecyclerView.Adapter that provides some convenience when creating a new Adapter, such as
  * data list handing and item animations
  */
-abstract class QkAdapter<T> : RecyclerView.Adapter<QkViewHolder>() {
+abstract class QkAdapter<T, VHT : RecyclerView.ViewHolder> : RecyclerView.Adapter<VHT>() {
 
     var data: List<T> = ArrayList()
         set(value) {

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkViewHolder.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkViewHolder.kt
@@ -22,6 +22,6 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
 
-class QkViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
+open class QkViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
     override val containerView: View = view
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/QkContextMenuRecyclerView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/QkContextMenuRecyclerView.kt
@@ -1,0 +1,83 @@
+package dev.octoshrimpy.quik.common.widget
+
+import android.content.Context
+import android.net.Uri
+import android.util.AttributeSet
+import android.view.ContextMenu
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import dev.octoshrimpy.quik.common.base.QkAdapter
+import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.model.MmsPart
+
+open class QkContextMenuRecyclerView<ADAPTER_VALUE_TYPE, VIEW_HOLDER_VALUE_TYPE> : RecyclerView {
+    class ViewHolder<VIEW_HOLDER_VALUE_TYPE>(view: View) : QkViewHolder(view) {
+        init { itemView.isLongClickable = true }
+        var contextMenuValue: VIEW_HOLDER_VALUE_TYPE? = null
+    }
+
+    abstract class Adapter<
+                ADAPTER_VALUE_TYPE,
+                T,
+                VHT : RecyclerView.ViewHolder
+            > : QkAdapter<T, VHT>() {
+        var contextMenuValue: ADAPTER_VALUE_TYPE? = null
+    }
+
+    private var contextMenuInfo: ContextMenuInfo<
+                ADAPTER_VALUE_TYPE,
+                VIEW_HOLDER_VALUE_TYPE
+            >? = null
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int)
+            : super(context, attrs, defStyleAttr)
+
+    override fun getContextMenuInfo() = contextMenuInfo
+
+    override fun getChildViewHolder(child: View): ViewHolder<VIEW_HOLDER_VALUE_TYPE>? {
+        return super.getChildViewHolder(child) as ViewHolder<VIEW_HOLDER_VALUE_TYPE>
+    }
+
+    override fun showContextMenuForChild(originalView: View): Boolean {
+        saveContextMenuInfo(originalView)
+        return super.showContextMenuForChild(originalView)
+    }
+
+    override fun showContextMenuForChild(originalView: View, x: Float, y: Float): Boolean {
+        saveContextMenuInfo(originalView)
+        return super.showContextMenuForChild(originalView, x, y)
+    }
+
+    private fun saveContextMenuInfo(originalView: View) {
+        contextMenuInfo = ContextMenuInfo(
+            (adapter as Adapter<ADAPTER_VALUE_TYPE, *, *>)?.contextMenuValue,
+            getChildViewHolder(originalView)?.contextMenuValue,
+            this,
+            originalView,
+            getChildAdapterPosition(originalView),
+            getChildItemId(originalView)
+        )
+    }
+
+    class ContextMenuInfo<ADAPTER_VALUE_TYPE, VIEW_HOLDER_VALUE_TYPE>(
+        val adapterValue: ADAPTER_VALUE_TYPE?,
+        val viewHolderValue: VIEW_HOLDER_VALUE_TYPE?,
+        val recyclerView: QkContextMenuRecyclerView<ADAPTER_VALUE_TYPE, VIEW_HOLDER_VALUE_TYPE>,
+        val itemView: View,
+        val adapterPosition: Int,
+        val childItemStableId: Long
+    ) : ContextMenu.ContextMenuInfo
+}
+
+class QkContextMenuRecyclerViewLongMmsPart : QkContextMenuRecyclerView<Long, MmsPart> {
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int)
+            : super(context, attrs, defStyleAttr)
+}

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/QkDialog.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/QkDialog.kt
@@ -59,7 +59,7 @@ class QkDialog(private val context: Activity) : AlertDialog(context) {
             view.subtitle.isVisible = !value.isNullOrBlank()
         }
 
-    var adapter: QkAdapter<*>? = null
+    var adapter: QkAdapter<*, *>? = null
         set(value) {
             field = value
             view.list.isVisible = value != null

--- a/presentation/src/main/java/com/moez/QKSMS/feature/changelog/ChangelogAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/changelog/ChangelogAdapter.kt
@@ -28,7 +28,7 @@ import dev.octoshrimpy.quik.common.base.QkViewHolder
 import dev.octoshrimpy.quik.manager.ChangelogManager
 import kotlinx.android.synthetic.main.changelog_list_item.*
 
-class ChangelogAdapter(private val context: Context) : QkAdapter<ChangelogAdapter.ChangelogItem>() {
+class ChangelogAdapter(private val context: Context) : QkAdapter<ChangelogAdapter.ChangelogItem, QkViewHolder>() {
 
     data class ChangelogItem(val type: Int, val label: String)
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/AttachmentAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/AttachmentAdapter.kt
@@ -43,7 +43,7 @@ import javax.inject.Inject
 
 class AttachmentAdapter @Inject constructor(
     private val context: Context
-) : QkAdapter<Attachment>() {
+) : QkAdapter<Attachment, QkViewHolder>() {
 
     companion object {
         private const val VIEW_TYPE_FILE = 0

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -19,6 +19,8 @@
 package dev.octoshrimpy.quik.feature.compose
 
 import android.net.Uri
+import android.view.MenuItem
+import android.view.View
 import androidx.annotation.StringRes
 import androidx.core.view.inputmethod.InputContentInfoCompat
 import dev.octoshrimpy.quik.common.base.QkView
@@ -43,12 +45,14 @@ interface ComposeView : QkView<ComposeState> {
     val chipDeletedIntent: Subject<Recipient>
     val menuReadyIntent: Observable<Unit>
     val optionsItemIntent: Observable<Int>
+    val contextItemIntent: Observable<MenuItem>
     val sendAsGroupIntent: Observable<*>
-    val messageClickIntent: Subject<Long>
     val messagePartClickIntent: Subject<Long>
+    val messagePartContextMenuRegistrar: Subject<View>
     val messagesSelectedIntent: Observable<List<Long>>
     val cancelSendingIntent: Subject<Long>
     val sendNowIntent: Subject<Long>
+    val resendIntent: Subject<Long>
     val attachmentDeletedIntent: Subject<Attachment>
     val textChangedIntent: Observable<CharSequence>
     val attachIntent: Observable<Unit>

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -45,7 +45,6 @@ import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.DateFormatter
 import dev.octoshrimpy.quik.common.util.TextViewStyler
 import dev.octoshrimpy.quik.common.util.extensions.dpToPx
-import dev.octoshrimpy.quik.common.util.extensions.forwardTouches
 import dev.octoshrimpy.quik.common.util.extensions.setBackgroundTint
 import dev.octoshrimpy.quik.common.util.extensions.setPadding
 import dev.octoshrimpy.quik.common.util.extensions.setTint
@@ -66,7 +65,7 @@ import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import io.realm.RealmResults
 import kotlinx.android.synthetic.main.message_list_item_in.*
-import kotlinx.android.synthetic.main.message_list_item_in.attachments
+import kotlinx.android.synthetic.main.message_list_item_in.parts
 import kotlinx.android.synthetic.main.message_list_item_in.body
 import kotlinx.android.synthetic.main.message_list_item_in.sim
 import kotlinx.android.synthetic.main.message_list_item_in.simIndex
@@ -109,11 +108,13 @@ class MessagesAdapter @Inject constructor(
 
     }
 
-    val clicks: Subject<Long> = PublishSubject.create()
+    // click events passed back to compose view model
     val partClicks: Subject<Long> = PublishSubject.create()
     val messageLinkClicks: Subject<Uri> = PublishSubject.create()
-    val cancelSending: Subject<Long> = PublishSubject.create()
-    val sendNow: Subject<Long> = PublishSubject.create()
+    val cancelSendingClicks: Subject<Long> = PublishSubject.create()
+    val sendNowClicks: Subject<Long> = PublishSubject.create()
+    val resendClicks: Subject<Long> = PublishSubject.create()
+    val partContextMenuRegistrar: Subject<View> = PublishSubject.create()
 
     var data: Pair<Conversation, RealmResults<Message>>? = null
         set(value) {
@@ -150,11 +151,6 @@ class MessagesAdapter @Inject constructor(
 
     private val audioState = AudioState()
 
-    /**
-     * If the viewType is negative, then the viewHolder has an attachment. We'll consider
-     * this a unique viewType even though it uses the same view, so that regular messages
-     * don't need clipToOutline set to true, and they don't need to worry about images
-     */
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
 
         // Use the parent's context to inflate the layout, otherwise link clicks will crash the app
@@ -166,15 +162,15 @@ class MessagesAdapter @Inject constructor(
             view.findViewById<ImageView>(R.id.cancelIcon).setTint(theme.theme)
             view.findViewById<ProgressBar>(R.id.cancel).setTint(theme.theme)
             view.findViewById<ImageView>(R.id.sendNowIcon).setTint(theme.theme)
+            view.findViewById<ImageView>(R.id.resendIcon).setTint(theme.theme)
         } else {
             view = layoutInflater.inflate(R.layout.message_list_item_in, parent, false)
         }
 
         view.body.hyphenationFrequency = Layout.HYPHENATION_FREQUENCY_NONE
 
-        val partsAdapter = partsAdapterProvider.get()
-        partsAdapter.clicks.subscribe(partClicks)
-        view.attachments.adapter = partsAdapter
+        // register recycler view with compose activity for context menus
+        partContextMenuRegistrar.onNext(view.parts)
 
         return QkViewHolder(view).apply {
             view.setOnClickListener {
@@ -182,7 +178,6 @@ class MessagesAdapter @Inject constructor(
                 when (toggleSelection(message.id, false)) {
                     true -> view.isActivated = isSelected(message.id)
                     false -> {
-                        clicks.onNext(message.id)
                         expanded[message.id] = view.status.visibility != View.VISIBLE
                         notifyItemChanged(adapterPosition)
                     }
@@ -207,44 +202,59 @@ class MessagesAdapter @Inject constructor(
             false -> colors.theme(contactCache[message.address])
         }
 
+        holder.parts.adapter = partsAdapterProvider.get().apply {
+            contextMenuValue = message.id
+            clicks.subscribe(partClicks)    // part clicks gets passed back to compose view model
+        }
+
         // Update the selected state
         holder.containerView.isActivated = isSelected(message.id) || highlight == message.id
 
         // Bind the cancelFrame (cancel button) view
-        if (holder.cancelFrame != null) {
-            holder.cancelFrame.let { cancelFrame ->
-                val isCancellable = message.isSending() && message.date > System.currentTimeMillis()
-                cancelFrame.visibility = if (isCancellable) View.VISIBLE else View.GONE
-                cancelFrame.clicks().subscribe { cancelSending.onNext(message.id) }
-                cancelFrame.cancel.progress = 2
+        holder.cancelFrame.let { cancelFrame ->
+            val isCancellable = message.isSending() && message.date > System.currentTimeMillis()
+            cancelFrame.visibility = if (isCancellable) View.VISIBLE else View.GONE
+            cancelFrame.clicks().subscribe { cancelSendingClicks.onNext(message.id) }
+            cancelFrame.cancel.progress = 2
 
-                if (isCancellable) {
-                    val delay = when (prefs.sendDelay.get()) {
-                        Preferences.SEND_DELAY_SHORT -> 3000
-                        Preferences.SEND_DELAY_MEDIUM -> 5000
-                        Preferences.SEND_DELAY_LONG -> 10000
-                        else -> 0
-                    }
-                    val progress =
-                        (1 - (message.date - System.currentTimeMillis()) / delay.toFloat()) * 100
+            if (isCancellable) {
+                val delay = when (prefs.sendDelay.get()) {
+                    Preferences.SEND_DELAY_SHORT -> 3000
+                    Preferences.SEND_DELAY_MEDIUM -> 5000
+                    Preferences.SEND_DELAY_LONG -> 10000
+                    else -> 0
+                }
+                val progress =
+                    (1 - (message.date - System.currentTimeMillis()) / delay.toFloat()) * 100
 
-                    ObjectAnimator.ofInt(cancelFrame.cancel, "progress", progress.toInt(), 100)
-                        .setDuration(message.date - System.currentTimeMillis())
-                        .start()
+                ObjectAnimator.ofInt(cancelFrame.cancel, "progress", progress.toInt(), 100)
+                    .setDuration(message.date - System.currentTimeMillis())
+                    .start()
+            }
+        }
+
+        // bind the send now icon view
+        holder.sendNowIcon.let { sendNowIcon ->
+            if (message.isSending() && message.date > System.currentTimeMillis()) {
+                sendNowIcon.visibility = View.VISIBLE
+                sendNowIcon.clicks().subscribe { sendNowClicks.onNext(message.id) }
+            }
+            else
+                sendNowIcon.visibility = View.GONE
+        }
+
+        // bind the resend icon view
+        holder.resendIcon.let { resendIcon ->
+            if (message.isFailedMessage()) {
+                resendIcon.visibility = View.VISIBLE
+                resendIcon.clicks().subscribe {
+                    resendClicks.onNext(message.id)
+                    resendIcon.visibility = View.GONE
                 }
             }
+            else
+                resendIcon.visibility = View.GONE
         }
-
-        // Bind the send now icon view
-        if (holder.sendNowIcon != null) {
-            holder.sendNowIcon.let { sendNowIcon ->
-                val isCancellable = message.isSending() && message.date > System.currentTimeMillis()
-                sendNowIcon.visibility = if (isCancellable) View.VISIBLE else View.GONE
-                sendNowIcon.clicks().subscribe { sendNow.onNext(message.id) }
-            }
-        }
-
-        val cancelableSimpleOnGestureListener = holder.body.forwardTouches(holder.containerView)
 
         // Bind the message status
         bindStatus(holder, message, next)
@@ -325,9 +335,6 @@ class MessagesAdapter @Inject constructor(
                         object : ClickableSpan() {
                             override fun onClick(widget: View) {
                                 messageLinkClicks.onNext(Uri.parse(span.url))
-
-                                // interrupt the upcoming click event on the body view
-                                cancelableSimpleOnGestureListener.cancelCurrentClick()
                             }
                         },
                         spanString.getSpanStart(span),
@@ -351,8 +358,8 @@ class MessagesAdapter @Inject constructor(
                 canGroupWithNext = canGroup(message, next),
                 isMe = message.isMe()))
 
-        // Bind the attachments
-        val partsAdapter = holder.attachments.adapter as PartsAdapter
+        // Bind the parts
+        val partsAdapter = (holder.parts.adapter as PartsAdapter)
         partsAdapter.theme = theme
         partsAdapter.setData(message, previous, next, holder, audioState)
     }
@@ -365,12 +372,9 @@ class MessagesAdapter @Inject constructor(
             message.isDelivered() -> context.getString(R.string.message_status_delivered,
                     dateFormatter.getTimestamp(message.dateSent))
             message.isFailedMessage() -> context.getString(R.string.message_status_failed)
-
-            // Incoming group message
-            !message.isMe() && conversation?.recipients?.size ?: 0 > 1 -> {
+            !message.isMe() && (conversation?.recipients?.size ?: 0) > 1 -> {  // incoming group message
                 "${contactCache[message.address]?.getDisplayName()} • ${dateFormatter.getTimestamp(message.date)}"
             }
-
             else -> dateFormatter.getTimestamp(message.date)
         }
 
@@ -379,7 +383,7 @@ class MessagesAdapter @Inject constructor(
             message.isSending() -> true
             message.isFailedMessage() -> true
             expanded[message.id] == false -> false
-            conversation?.recipients?.size ?: 0 > 1 && !message.isMe() && next?.compareSender(message) != true -> true
+            (conversation?.recipients?.size ?: 0) > 1 && !message.isMe() && next?.compareSender(message) != true -> true
             message.isDelivered() && next?.isDelivered() != true && age <= BubbleUtils.TIMESTAMP_THRESHOLD -> true
             else -> false
         })

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/ChipsAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/ChipsAdapter.kt
@@ -35,7 +35,7 @@ import io.reactivex.subjects.PublishSubject
 import kotlinx.android.synthetic.main.contact_chip.*
 import javax.inject.Inject
 
-class ChipsAdapter @Inject constructor() : QkAdapter<Recipient>() {
+class ChipsAdapter @Inject constructor() : QkAdapter<Recipient, QkViewHolder>() {
 
     var view: RecyclerView? = null
     val chipDeleted: PublishSubject<Recipient> = PublishSubject.create<Recipient>()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/ComposeItemAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/ComposeItemAdapter.kt
@@ -45,7 +45,7 @@ import javax.inject.Inject
 class ComposeItemAdapter @Inject constructor(
     private val colors: Colors,
     private val conversationRepo: ConversationRepository
-) : QkAdapter<ComposeItem>() {
+) : QkAdapter<ComposeItem, QkViewHolder>() {
 
     val clicks: Subject<ComposeItem> = PublishSubject.create()
     val longClicks: Subject<ComposeItem> = PublishSubject.create()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/PhoneNumberAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/PhoneNumberAdapter.kt
@@ -26,7 +26,7 @@ import dev.octoshrimpy.quik.common.base.QkViewHolder
 import dev.octoshrimpy.quik.model.PhoneNumber
 import kotlinx.android.synthetic.main.contact_number_list_item.*
 
-class PhoneNumberAdapter : QkAdapter<PhoneNumber>() {
+class PhoneNumberAdapter : QkAdapter<PhoneNumber, QkViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
         val inflater = LayoutInflater.from(parent.context)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/PhoneNumberPickerAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/PhoneNumberPickerAdapter.kt
@@ -36,7 +36,7 @@ import javax.inject.Inject
 
 class PhoneNumberPickerAdapter @Inject constructor(
     private val context: Context
-) : QkAdapter<PhoneNumber>() {
+) : QkAdapter<PhoneNumber, QkViewHolder>() {
 
     val selectedItemChanges: Subject<Optional<Long>> = BehaviorSubject.create()
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/part/AudioBinder.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/part/AudioBinder.kt
@@ -107,6 +107,9 @@ class AudioBinder @Inject constructor(colors: Colors, private val context: Conte
         canGroupWithPrevious: Boolean,
         canGroupWithNext: Boolean,
     ) {
+        // click on background - passes back to compose view model
+        holder.containerView.setOnClickListener { clicks.onNext(part.id) }
+
         // play/pause button click handling
         holder.playPause.setOnClickListener {
             when (holder.playPause.tag) {
@@ -177,14 +180,6 @@ class AudioBinder @Inject constructor(colors: Colors, private val context: Conte
             }
         }
 
-        // share button click handling
-        holder.share.setOnClickListener {
-            navigator.shareFile(
-                MmsPartProvider.getUriForMmsPartId(part.id, part.getBestFilename()),
-                part.type
-            )
-        }
-
         // if this item is the active active audio item update the active view holder
         if (audioState.partId == part.id)
             audioState.viewHolder = holder
@@ -237,10 +232,6 @@ class AudioBinder @Inject constructor(colors: Colors, private val context: Conte
             setTint(secondaryColor)
             setBackgroundTint(primaryColor)
         }
-
-        // share button
-        holder.share.setTint(secondaryColor)
-        holder.share.setBackgroundTint(primaryColor)
 
         MediaMetadataRetriever().use {
             it.setDataSource(context, part.getUri())

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/part/FileBinder.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/part/FileBinder.kt
@@ -36,7 +36,6 @@ import dev.octoshrimpy.quik.model.MmsPart
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-import kotlinx.android.synthetic.main.mms_audio_preview_list_item.share
 import kotlinx.android.synthetic.main.mms_file_list_item.*
 import javax.inject.Inject
 
@@ -76,33 +75,18 @@ class FileBinder @Inject constructor(colors: Colors, private val context: Contex
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe { size -> holder.size.text = size }
 
-        // share button click handling
-        holder.share.setOnClickListener {
-            navigator.shareFile(
-                MmsPartProvider.getUriForMmsPartId(part.id, part.getBestFilename()),
-                part.type
-            )
-        }
-
         holder.filename.text = part.name
 
-        val params = holder.fileBackground.layoutParams as FrameLayout.LayoutParams
         if (!message.isMe()) {
-            holder.fileBackground.layoutParams = params.apply { gravity = Gravity.START }
             holder.fileBackground.setBackgroundTint(theme.theme)
             holder.icon.setTint(theme.textPrimary)
             holder.filename.setTextColor(theme.textPrimary)
             holder.size.setTextColor(theme.textTertiary)
-            holder.share.setTint(theme.theme)
-            holder.share.setBackgroundTint(theme.textPrimary)
         } else {
-            holder.fileBackground.layoutParams = params.apply { gravity = Gravity.END }
             holder.fileBackground.setBackgroundTint(holder.containerView.context.resolveThemeColor(R.attr.bubbleColor))
             holder.icon.setTint(holder.containerView.context.resolveThemeColor(android.R.attr.textColorSecondary))
             holder.filename.setTextColor(holder.containerView.context.resolveThemeColor(android.R.attr.textColorPrimary))
             holder.size.setTextColor(holder.containerView.context.resolveThemeColor(android.R.attr.textColorTertiary))
-            holder.share.setTint(holder.containerView.context.resolveThemeColor(R.attr.bubbleColor))
-            holder.share.setBackgroundTint(holder.containerView.context.resolveThemeColor(android.R.attr.textColorTertiary))
         }
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/part/VCardBinder.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/part/VCardBinder.kt
@@ -71,15 +71,12 @@ class VCardBinder @Inject constructor(colors: Colors, private val context: Conte
                     holder.name.isVisible = displayName.isNotEmpty()
                 }
 
-        val params = holder.vCardBackground.layoutParams as FrameLayout.LayoutParams
         if (!message.isMe()) {
-            holder.vCardBackground.layoutParams = params.apply { gravity = Gravity.START }
             holder.vCardBackground.setBackgroundTint(theme.theme)
             holder.vCardAvatar.setTint(theme.textPrimary)
             holder.name.setTextColor(theme.textPrimary)
             holder.label.setTextColor(theme.textTertiary)
         } else {
-            holder.vCardBackground.layoutParams = params.apply { gravity = Gravity.END }
             holder.vCardBackground.setBackgroundTint(holder.containerView.context.resolveThemeColor(R.attr.bubbleColor))
             holder.vCardAvatar.setTint(holder.containerView.context.resolveThemeColor(android.R.attr.textColorSecondary))
             holder.name.setTextColor(holder.containerView.context.resolveThemeColor(android.R.attr.textColorPrimary))

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoAdapter.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class ConversationInfoAdapter @Inject constructor(
     private val context: Context,
     private val colors: Colors
-) : QkAdapter<ConversationInfoItem>() {
+) : QkAdapter<ConversationInfoItem, QkViewHolder>() {
 
     val recipientClicks: Subject<Long> = PublishSubject.create()
     val recipientLongClicks: Subject<Long> = PublishSubject.create()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryActivity.kt
@@ -107,7 +107,7 @@ class GalleryActivity : QkActivity(), GalleryView {
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(R.menu.gallery, menu)
+        menuInflater.inflate(R.menu.mms_part_menu, menu)
         return super.onCreateOptionsMenu(menu)
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryPagerAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryPagerAdapter.kt
@@ -114,7 +114,7 @@ class GalleryPagerAdapter @Inject constructor(private val context: Context) : Qk
                 holder.video.player = exoPlayer
                 exoPlayers.add(exoPlayer)
 
-                val dataSourceFactory = DefaultDataSourceFactory(context, Util.getUserAgent(context, "QKSMS"))
+                val dataSourceFactory = DefaultDataSourceFactory(context, Util.getUserAgent(context, "QUIK"))
                 val videoSource = ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(part.getUri())
                 exoPlayer?.prepare(videoSource)
             }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryViewModel.kt
@@ -31,6 +31,8 @@ import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.repository.MessageRepository
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
+import dev.octoshrimpy.quik.common.widget.QkContextMenuRecyclerView
+import dev.octoshrimpy.quik.model.MmsPart
 import io.reactivex.Flowable
 import io.reactivex.rxkotlin.plusAssign
 import io.reactivex.rxkotlin.withLatestFrom
@@ -75,7 +77,7 @@ class GalleryViewModel @Inject constructor(
 
         // Save image to device
         view.optionsItemSelected()
-                .filter { itemId -> itemId == R.id.save }
+                .filter { it == R.id.save }
                 .filter { permissions.hasStorage().also { if (!it) view.requestStoragePermission() } }
                 .withLatestFrom(view.pageChanged()) { _, part -> part.id }
                 .autoDisposable(view.scope())
@@ -83,7 +85,7 @@ class GalleryViewModel @Inject constructor(
 
         // Share image externally
         view.optionsItemSelected()
-                .filter { itemId -> itemId == R.id.share }
+                .filter { it == R.id.share }
                 .withLatestFrom(view.pageChanged()) { _, part -> part }
                 .autoDisposable(view.scope())
                 .subscribe {
@@ -92,6 +94,25 @@ class GalleryViewModel @Inject constructor(
                         it.type
                     )
                 }
+
+        // message part context menu item selected - forward
+        view.optionsItemSelected()
+            .filter { it == R.id.forward }
+            .withLatestFrom(view.pageChanged()) { _, part -> part }
+            .autoDisposable(view.scope())
+            .subscribe { navigator.showCompose("", listOf(it.getUri())) }
+
+        // message part context menu item selected - open externally
+        view.optionsItemSelected()
+            .filter { it == R.id.openExternally }
+            .withLatestFrom(view.pageChanged()) { _, part -> part }
+            .autoDisposable(view.scope())
+            .subscribe {
+                navigator.viewFile(
+                    MmsPartProvider.getUriForMmsPartId(it.id, it.getBestFilename()),
+                    it.type
+                )
+            }
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/SearchAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/SearchAdapter.kt
@@ -42,7 +42,7 @@ class SearchAdapter @Inject constructor(
     private val context: Context,
     private val dateFormatter: DateFormatter,
     private val navigator: Navigator
-) : QkAdapter<SearchResult>() {
+) : QkAdapter<SearchResult, QkViewHolder>() {
 
     private val highlightColor: Int by lazy { colors.theme().highlight }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAttachmentAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAttachmentAdapter.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
 
 class ScheduledMessageAttachmentAdapter @Inject constructor(
     private val context: Context
-) : QkAdapter<Uri>() {
+) : QkAdapter<Uri, QkViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
         return QkViewHolder(

--- a/presentation/src/main/java/com/moez/QKSMS/feature/themepicker/ThemeAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/themepicker/ThemeAdapter.kt
@@ -43,7 +43,7 @@ import javax.inject.Inject
 class ThemeAdapter @Inject constructor(
     private val context: Context,
     private val colors: Colors
-) : QkAdapter<List<Int>>() {
+) : QkAdapter<List<Int>, QkViewHolder>() {
 
     val colorSelected: Subject<Int> = PublishSubject.create()
 

--- a/presentation/src/main/res/layout/compose_activity.xml
+++ b/presentation/src/main/res/layout/compose_activity.xml
@@ -133,7 +133,7 @@
         android:id="@+id/composeBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:constraint_referenced_ids="messageBackground,attachments,attach,message,counter,send" />
+        app:constraint_referenced_ids="messageBackground,parts,attach,message,counter,send" />
 
     <View
         android:id="@+id/composeDivider"
@@ -211,12 +211,12 @@
         android:layout_width="0dp"
         android:layout_height="1dp"
         android:background="?android:attr/divider"
-        app:layout_constraintBottom_toTopOf="@id/attachments"
+        app:layout_constraintBottom_toTopOf="@id/parts"
         app:layout_constraintEnd_toEndOf="@id/messageBackground"
         app:layout_constraintStart_toStartOf="@id/messageBackground" />
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/attachments"
+        android:id="@+id/parts"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:clipChildren="false"

--- a/presentation/src/main/res/layout/message_list_item_in.xml
+++ b/presentation/src/main/res/layout/message_list_item_in.xml
@@ -95,8 +95,8 @@
                 android:layout_marginStart="12dp"
                 android:orientation="vertical">
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/attachments"
+                <dev.octoshrimpy.quik.common.widget.QkContextMenuRecyclerViewLongMmsPart
+                    android:id="@+id/parts"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:nestedScrollingEnabled="false"

--- a/presentation/src/main/res/layout/message_list_item_out.xml
+++ b/presentation/src/main/res/layout/message_list_item_out.xml
@@ -77,8 +77,8 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/attachments"
+        <dev.octoshrimpy.quik.common.widget.QkContextMenuRecyclerViewLongMmsPart
+            android:id="@+id/parts"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
@@ -155,8 +155,7 @@
                     android:backgroundTint="?attr/bubbleColor"
                     android:gravity="start|center_vertical"
                     android:minHeight="36dp"
-                    android:textIsSelectable="true"
-                    tools:text="@tools:sample/lorem/random[0]" />
+                    android:textIsSelectable="true" />
             </LinearLayout>
 
             <ImageView
@@ -178,18 +177,38 @@
 
         </RelativeLayout>
 
-        <dev.octoshrimpy.quik.common.widget.QkTextView
-            android:id="@+id/status"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
-            android:layout_marginTop="4dp"
-            android:layout_marginEnd="24dp"
-            android:layout_marginBottom="4dp"
-            android:contentDescription="@string/compose_message_attachment"
-            android:textColor="?android:attr/textColorSecondary"
-            app:textSize="tertiary"
-            tools:text="Sending..." />
+            android:orientation="horizontal">
+
+            <dev.octoshrimpy.quik.common.widget.QkTextView
+                android:id="@+id/status"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="12dp"
+                android:contentDescription="@string/compose_message_attachment"
+                android:textColor="?android:attr/textColorSecondary"
+                app:textSize="tertiary"
+                tools:text="Sending..." />
+
+            <ImageView
+                android:id="@+id/resendIcon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/circle"
+                android:backgroundTint="?attr/bubbleColor"
+                android:baselineAlignBottom="false"
+                android:contentDescription="@string/compose_message_send_now"
+                android:padding="6dp"
+                android:src="@drawable/ic_sync_black_24dp"
+                android:visibility="gone"
+                tools:tint="@color/tools_theme"
+                tools:visibility="visible" />
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/presentation/src/main/res/layout/mms_audio_preview_list_item.xml
+++ b/presentation/src/main/res/layout/mms_audio_preview_list_item.xml
@@ -92,22 +92,9 @@
             android:text="@tools:sample/lorem/random[0]"
             android:textColor="@color/black"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/share"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/playPause" />
 
-        <ImageView
-            android:id="@+id/share"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
-            android:layout_gravity="bottom"
-            android:layout_marginEnd="12dp"
-            android:background="@drawable/circle"
-            android:elevation="4dp"
-            android:padding="6dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:srcCompat="?attr/actionModeShareDrawable"
-            app:tint="@color/tools_theme" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </FrameLayout>

--- a/presentation/src/main/res/layout/mms_file_list_item.xml
+++ b/presentation/src/main/res/layout/mms_file_list_item.xml
@@ -17,72 +17,62 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="2dp">
+    android:id="@+id/fileBackground"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/fileBackground"
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="6dp"
+        android:rotation="135"
+        android:src="@drawable/ic_attachment_black_24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?android:attr/textColorSecondary" />
+
+    <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-        <ImageView
-            android:id="@+id/icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginStart="12dp"
-            android:src="@drawable/ic_attachment_black_24dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:tint="?android:attr/textColorSecondary" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            app:layout_constraintEnd_toStartOf="@id/share"
-            app:layout_constraintStart_toEndOf="@id/icon">
-
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/filename"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingStart="12dp"
-                android:paddingTop="8dp"
-                android:paddingEnd="12dp"
-                android:textColor="?android:attr/textColorPrimary"
-                app:textSize="primary"
-                tools:text="Resume.pdf" />
-
-            <dev.octoshrimpy.quik.common.widget.QkTextView
-                android:id="@+id/size"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingStart="12dp"
-                android:paddingEnd="12dp"
-                android:paddingBottom="8dp"
-                android:textColor="?android:attr/textColorTertiary"
-                app:textSize="secondary"
-                tools:text="35 KB" />
-        </LinearLayout>
-
-        <ImageView
-            android:id="@+id/share"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
-            android:layout_marginEnd="12dp"
-            android:background="@drawable/circle"
-            android:padding="6dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+        <dev.octoshrimpy.quik.common.widget.QkTextView
+            android:id="@+id/filename"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:paddingStart="12dp"
+            android:paddingTop="8dp"
+            android:paddingEnd="12dp"
+            android:singleLine="true"
+            android:textColor="?android:attr/textColorPrimary"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/icon"
             app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="?attr/actionModeShareDrawable"
-            app:tint="@color/tools_theme" />
+            app:textSize="primary"
+            tools:text="a test file.pdf" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        <dev.octoshrimpy.quik.common.widget.QkTextView
+            android:id="@+id/size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="8dp"
+            android:singleLine="true"
+            android:textColor="?android:attr/textColorTertiary"
+            app:layout_constraintStart_toEndOf="@id/icon"
+            app:layout_constraintTop_toBottomOf="@id/filename"
+            app:textSize="secondary"
+            tools:text="35 KB" />
+    </LinearLayout>
 
-</FrameLayout>
+</LinearLayout>

--- a/presentation/src/main/res/layout/mms_vcard_list_item.xml
+++ b/presentation/src/main/res/layout/mms_vcard_list_item.xml
@@ -17,56 +17,60 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="2dp">
+    android:id="@+id/vCardBackground"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/vCardBackground"
+<ImageView
+    android:id="@+id/vCardAvatar"
+    android:layout_width="24dp"
+    android:layout_height="24dp"
+    android:layout_gravity="center_vertical"
+    android:layout_marginStart="6dp"
+    android:src="@drawable/ic_person_black_24dp"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:tint="?android:attr/textColorSecondary" />
+
+<LinearLayout
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <dev.octoshrimpy.quik.common.widget.QkTextView
+        android:id="@+id/name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:paddingStart="12dp"
         android:paddingTop="8dp"
-        android:paddingBottom="8dp">
+        android:paddingEnd="12dp"
+        android:singleLine="true"
+        android:textColor="?android:attr/textColorPrimary"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:textSize="primary"
+        tools:text="Person Name" />
 
-        <ImageView
-            android:id="@+id/vCardAvatar"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginStart="12dp"
-            android:src="@drawable/ic_person_black_24dp"
-            android:tint="?android:attr/textColorSecondary"
-            app:layout_constraintBottom_toBottomOf="@id/vCardBackground"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/vCardBackground" />
+    <dev.octoshrimpy.quik.common.widget.QkTextView
+        android:id="@+id/label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:paddingBottom="8dp"
+        android:singleLine="true"
+        android:text="@string/compose_vcard_label"
+        android:textColor="?android:attr/textColorTertiary"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toBottomOf="@id/filename"
+        app:textSize="secondary" />
+</LinearLayout>
 
-        <dev.octoshrimpy.quik.common.widget.QkTextView
-            android:id="@+id/name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:textColor="?android:attr/textColorPrimary"
-            app:layout_constraintStart_toEndOf="@id/vCardAvatar"
-            app:layout_constraintTop_toTopOf="parent"
-            app:textSize="primary"
-            tools:text="@tools:sample/full_names" />
-
-        <dev.octoshrimpy.quik.common.widget.QkTextView
-            android:id="@+id/label"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingStart="12dp"
-            android:paddingEnd="12dp"
-            android:text="@string/compose_vcard_label"
-            android:textColor="?android:attr/textColorTertiary"
-            app:layout_constraintStart_toStartOf="@id/name"
-            app:layout_constraintTop_toBottomOf="@id/name"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:textSize="secondary" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</FrameLayout>
+</LinearLayout>

--- a/presentation/src/main/res/menu/mms_part_menu.xml
+++ b/presentation/src/main/res/menu/mms_part_menu.xml
@@ -1,30 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (C) 2019 Moez Bhatti <moez.bhatti@gmail.com>
+  ~ Copyright (C) 2025
   ~
-  ~ This file is part of QKSMS.
+  ~ This file is part of QUIK.
   ~
-  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ QUIK is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or
   ~ (at your option) any later version.
   ~
-  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ QUIK is distributed in the hope that it will be useful,
   ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
   ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   ~ GNU General Public License for more details.
   ~
   ~ You should have received a copy of the GNU General Public License
-  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  ~ along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
         android:id="@+id/save"
-        android:title="@string/menu_save" />
+        android:title="@string/menu_mms_part_save" />
 
     <item
         android:id="@+id/share"
-        android:title="@string/menu_share" />
+        android:title="@string/menu_mms_part_share" />
+
+    <item
+        android:id="@+id/forward"
+        android:title="@string/menu_mms_part_forward" />
+
+    <item
+        android:id="@+id/openExternally"
+        android:title="@string/menu_mms_part_open" />
 
 </menu>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -38,8 +38,11 @@
     <string name="menu_add_person">Add person</string>
     <string name="menu_call">Call</string>
     <string name="menu_info">Details</string>
-    <string name="menu_save">Save to gallery</string>
-    <string name="menu_share">Share</string>
+
+    <string name="menu_mms_part_save">Save to gallery</string>
+    <string name="menu_mms_part_share">Share</string>
+    <string name="menu_mms_part_forward">Forward</string>
+    <string name="menu_mms_part_open">Open externally</string>
 
     <string name="main_drawer_open_cd">Open navigation drawer</string>
     <string name="main_title_selected">%d selected</string>


### PR DESCRIPTION
this is probably worthy to go into latest beta for test.  it is much cleaner implementation of save/share/forward/open externally based on @octoshrimpy suggestions for ui in https://github.com/octoshrimpy/quik/pull/254 and https://github.com/octoshrimpy/quik/discussions/266.

attachment context menu for save, share, forward and open externally

![image](https://github.com/user-attachments/assets/d782690e-4680-4e16-9170-e55820952240)


remove share icons from audio and file attachment types

![image](https://github.com/user-attachments/assets/13ab47ee-0080-43ea-bdad-e7a6a36d91f1) ![image](https://github.com/user-attachments/assets/190c8ae1-89fe-47dc-be38-96818673191b)


add forward and open externally to gallery menu so it matches attachment context menu

![image](https://github.com/user-attachments/assets/0a844c86-69fb-4155-8062-b28a3e069991)


new icon/button for resend message on fail to send because new single tap. long tap regime didn't play well with tap to resend.

![image](https://github.com/user-attachments/assets/ee38f0ba-645b-4241-a614-1c911b1a6018)


also includes double-tap or long press text bubble to select text;

![image](https://github.com/user-attachments/assets/56cfdf18-b7cf-4902-a4f4-cc1906a374f8)



possibly closes https://github.com/octoshrimpy/quik/discussions/266
