### PR TITLE
ingest attachments in standard manner

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -392,8 +392,8 @@ class MessageRepositoryImpl @Inject constructor(
                 .filter { it.getResourceBytes(context).isNotEmpty() }
                 .associateWith {
                     when (it.getType(context) == "image/gif") {
-                        true -> ImageUtils.getScaledGif(context, it.getUri(), maxWidth, maxHeight)
-                        false -> ImageUtils.getScaledImage(context, it.getUri(), maxWidth, maxHeight)
+                        true -> ImageUtils.getScaledGif(context, it.uri, maxWidth, maxHeight)
+                        false -> ImageUtils.getScaledImage(context, it.uri, maxWidth, maxHeight)
                     }
                 }
                 .toMutableMap()
@@ -401,7 +401,7 @@ class MessageRepositoryImpl @Inject constructor(
             val imageByteCount = imageBytesByAttachment.values.sumOf { it.size }
             if (imageByteCount > remainingBytes) {
                 imageBytesByAttachment.forEach { (attachment, originalBytes) ->
-                    val uri = attachment.getUri() ?: return@forEach
+                    val uri = attachment.uri ?: return@forEach
                     val maxBytes = originalBytes.size / imageByteCount.toFloat() * remainingBytes
 
                     // Get the image dimensions
@@ -429,8 +429,8 @@ class MessageRepositoryImpl @Inject constructor(
 
                         attempts++
                         scaledBytes = when (attachment.getType(context) == "image/gif") {
-                            true -> ImageUtils.getScaledGif(context, attachment.getUri(), newWidth, newHeight)
-                            false -> ImageUtils.getScaledImage(context, attachment.getUri(), newWidth, newHeight)
+                            true -> ImageUtils.getScaledGif(context, attachment.uri, newWidth, newHeight)
+                            false -> ImageUtils.getScaledImage(context, attachment.uri, newWidth, newHeight)
                         }
 
                         Timber.d("Compression attempt $attempts: ${scaledBytes.size / 1024}/${maxBytes.toInt() / 1024}Kb ($width*$height -> $newWidth*$newHeight)")

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendScheduledMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendScheduledMessage.kt
@@ -47,7 +47,7 @@ class SendScheduledMessage @Inject constructor(
                 }
                 .map { message ->
                     val threadId = TelephonyCompat.getOrCreateThreadId(context, message.recipients)
-                    val attachments = message.attachments.mapNotNull(Uri::parse).map { Attachment(it) }
+                    val attachments = message.attachments.mapNotNull(Uri::parse).map { Attachment(context, it) }
                     SendMessage.Params(message.subId, threadId, message.recipients, message.body, attachments)
                 }
                 .flatMap(sendMessage::buildObservable)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/AttachmentAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/AttachmentAdapter.kt
@@ -93,14 +93,14 @@ class AttachmentAdapter @Inject constructor(
         holder.fileName.visibility = View.GONE
 
         // if attachment uri is missing
-        if (!attachment.getUri().resourceExists(context)) {
+        if (!attachment.uri.resourceExists(context)) {
             holder.thumbnail.setImageResource(android.R.drawable.ic_delete)
             holder.fileName.text = context.getString(R.string.attachment_missing)
             holder.fileName.visibility = View.VISIBLE
             return
         }
 
-        val uri = attachment.getUri()
+        val uri = attachment.uri
         val mimeType = attachment.getType(context)
 
         // if attachment mime type is image/* or video/*, use image/frame

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -446,7 +446,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
 
     override fun requestContact() {
         val intent = Intent(Intent.ACTION_PICK)
-                .setType(ContactsContract.CommonDataKinds.Phone.CONTENT_TYPE)
+                .setType(ContactsContract.Contacts.CONTENT_TYPE)
 
         startActivityForResult(Intent.createChooser(intent, null), ComposeView.AttachContactRequestCode)
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -79,7 +79,7 @@ class ComposeActivityModule {
         activity.intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::add)
         activity.intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::addAll)
 
-        return Attachments(uris.mapNotNull { Attachment(it) })
+        return Attachments(uris.mapNotNull { Attachment(activity, it) })
     }
 
     @Provides


### PR DESCRIPTION
changes to ingest all attachments in a standard manner. non-functional change.

this pr's primary use - apart from a slightly cleaner code-base - is to enable possible future pr's
1. using storage access framework (saf/files app) for all attachment types (contact, any file, and photo)
2. using a single 'attach anything' menu item to replace attach a photo, attach a file and attach a contact items