### PR TITLE
use storage access framework (saf / files app) for picking all attachment types

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -392,8 +392,8 @@ class MessageRepositoryImpl @Inject constructor(
                 .filter { it.getResourceBytes(context).isNotEmpty() }
                 .associateWith {
                     when (it.getType(context) == "image/gif") {
-                        true -> ImageUtils.getScaledGif(context, it.getUri(), maxWidth, maxHeight)
-                        false -> ImageUtils.getScaledImage(context, it.getUri(), maxWidth, maxHeight)
+                        true -> ImageUtils.getScaledGif(context, it.uri, maxWidth, maxHeight)
+                        false -> ImageUtils.getScaledImage(context, it.uri, maxWidth, maxHeight)
                     }
                 }
                 .toMutableMap()
@@ -401,7 +401,7 @@ class MessageRepositoryImpl @Inject constructor(
             val imageByteCount = imageBytesByAttachment.values.sumOf { it.size }
             if (imageByteCount > remainingBytes) {
                 imageBytesByAttachment.forEach { (attachment, originalBytes) ->
-                    val uri = attachment.getUri() ?: return@forEach
+                    val uri = attachment.uri ?: return@forEach
                     val maxBytes = originalBytes.size / imageByteCount.toFloat() * remainingBytes
 
                     // Get the image dimensions
@@ -429,8 +429,8 @@ class MessageRepositoryImpl @Inject constructor(
 
                         attempts++
                         scaledBytes = when (attachment.getType(context) == "image/gif") {
-                            true -> ImageUtils.getScaledGif(context, attachment.getUri(), newWidth, newHeight)
-                            false -> ImageUtils.getScaledImage(context, attachment.getUri(), newWidth, newHeight)
+                            true -> ImageUtils.getScaledGif(context, attachment.uri, newWidth, newHeight)
+                            false -> ImageUtils.getScaledImage(context, attachment.uri, newWidth, newHeight)
                         }
 
                         Timber.d("Compression attempt $attempts: ${scaledBytes.size / 1024}/${maxBytes.toInt() / 1024}Kb ($width*$height -> $newWidth*$newHeight)")

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendScheduledMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendScheduledMessage.kt
@@ -47,7 +47,7 @@ class SendScheduledMessage @Inject constructor(
                 }
                 .map { message ->
                     val threadId = TelephonyCompat.getOrCreateThreadId(context, message.recipients)
-                    val attachments = message.attachments.mapNotNull(Uri::parse).map { Attachment(it) }
+                    val attachments = message.attachments.mapNotNull(Uri::parse).map { Attachment(context, it) }
                     SendMessage.Params(message.subId, threadId, message.recipients, message.body, attachments)
                 }
                 .flatMap(sendMessage::buildObservable)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/AttachmentAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/AttachmentAdapter.kt
@@ -93,14 +93,14 @@ class AttachmentAdapter @Inject constructor(
         holder.fileName.visibility = View.GONE
 
         // if attachment uri is missing
-        if (!attachment.getUri().resourceExists(context)) {
+        if (!attachment.uri.resourceExists(context)) {
             holder.thumbnail.setImageResource(android.R.drawable.ic_delete)
             holder.fileName.text = context.getString(R.string.attachment_missing)
             holder.fileName.visibility = View.VISIBLE
             return
         }
 
-        val uri = attachment.getUri()
+        val uri = attachment.uri
         val mimeType = attachment.getType(context)
 
         // if attachment mime type is image/* or video/*, use image/frame

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -446,7 +446,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
 
     override fun requestContact() {
         val intent = Intent(Intent.ACTION_PICK)
-                .setType(ContactsContract.CommonDataKinds.Phone.CONTENT_TYPE)
+                .setType(ContactsContract.Contacts.CONTENT_TYPE)
 
         startActivityForResult(Intent.createChooser(intent, null), ComposeView.AttachContactRequestCode)
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -79,7 +79,7 @@ class ComposeActivityModule {
         activity.intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::add)
         activity.intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::addAll)
 
-        return Attachments(uris.mapNotNull { Attachment(it) })
+        return Attachments(uris.mapNotNull { Attachment(activity, it) })
     }
 
     @Provides

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -34,7 +34,7 @@ interface ComposeView : QkView<ComposeState> {
     companion object {
         const val SelectContactRequestCode = 0
         const val TakePhotoRequestCode = 1
-        const val AttachAFileRequestCode = 4
+        const val AttachRequestCode = 4
         const val AttachContactRequestCode = 3
 
         const val CameraDestinationKey = "camera_destination"
@@ -63,7 +63,6 @@ interface ComposeView : QkView<ComposeState> {
     val scheduleAction: Observable<*>
     val attachContactIntent: Observable<*>
     val attachAnyFileSelectedIntent: Observable<Uri>
-    val contactSelectedIntent: Observable<Uri>
     val inputContentIntent: Observable<InputContentInfoCompat>
     val scheduleSelectedIntent: Observable<Long>
     val scheduleCancelIntent: Observable<*>
@@ -86,9 +85,8 @@ interface ComposeView : QkView<ComposeState> {
     fun themeChanged()
     fun showKeyboard()
     fun requestCamera()
-    fun requestGallery(mimeType: String, requestCode: Int)
+    fun requestSAFContent(mimeType: String, requestCode: Int)
     fun requestDatePicker()
-    fun requestContact()
     fun setDraft(draft: String)
     fun scrollToMessage(id: Long)
     fun showQksmsPlusSnackbar(@StringRes message: Int)

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -541,4 +541,6 @@
     <string name="messageLinkHandling_dialog_body">Some links may be unsafe or redirect you unexpectedly. Review the link below before proceeding:\n\n%1$s\n\nDo you want to continue?</string>
     <string name="messageLinkHandling_dialog_positive">Yes, open the link</string>
     <string name="messageLinkHandling_dialog_negative">No</string>
+
+    <string name="attachmnent_pick_title">Select a file to attach</string>
 </resources>


### PR DESCRIPTION
changes to use storage access framework (files app) for all attachment types (contact, any file, and photo).
this pr uses pr https://github.com/octoshrimpy/quik/pull/282 (ingest attachments in standard manner).

my intention is that this pr is for uat rather than immediate inclusion in the product.

i'm happy for this pr to never go into the product because i prefer old-school way of picking attachments. for me, the files app is unhelpful, inconsistent and unstructured (i think it might have been designed to be that way). for me, i think its the ms word ribbon bar of android, where i can't find any thing i want quickly and easily, and it replaced something that worked fantastically.