### PR TITLE
Fix wrong string when long-pressing detail button.

### DIFF
--- a/presentation/src/main/res/menu/compose.xml
+++ b/presentation/src/main/res/menu/compose.xml
@@ -51,7 +51,7 @@
     <item
         android:id="@+id/details"
         android:icon="@drawable/ic_info_black_24dp"
-        android:title="@string/compose_menu_copy"
+        android:title="@string/compose_details_title"
         android:visible="false"
         app:showAsAction="always" />
 


### PR DESCRIPTION
Fixed showing the copy text details, rather than message details, when the info/details button was held down. This closes #292. This was a problem across all languages. 