### PR TITLE
changes to enable a delete/clear menu icon on compose screen

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -185,6 +185,8 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val viewQksmsPlusIntent: Subject<Unit> = PublishSubject.create()
     override val backPressedIntent: Subject<Unit> = PublishSubject.create()
     override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
+    override val confirmClearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
+    override val clearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
     override val messageLinkAskIntent: Subject<Uri> by lazy { messageAdapter.messageLinkClicks }
     override val speechRecogniserIntent by lazy { speechToTextIcon.clicks() }
     override val shadeIntent by lazy { shadeBackground.clicks() }
@@ -470,7 +472,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                 && state.query.isEmpty()
         toolbar.menu.findItem(R.id.copy)?.isVisible = !state.editingMode && state.selectedMessages > 0
         toolbar.menu.findItem(R.id.details)?.isVisible = !state.editingMode && state.selectedMessages == 1
-        toolbar.menu.findItem(R.id.delete)?.isVisible = !state.editingMode && state.selectedMessages > 0
+        toolbar.menu.findItem(R.id.delete)?.isVisible = !state.editingMode && ((state.selectedMessages > 0) || state.canSend)
         toolbar.menu.findItem(R.id.forward)?.isVisible = !state.editingMode && state.selectedMessages == 1
         toolbar.menu.findItem(R.id.show_status)?.isVisible = !state.editingMode && state.selectedMessages > 0
         toolbar.menu.findItem(R.id.previous)?.isVisible = state.selectedMessages == 0 && state.query.isNotEmpty()
@@ -710,6 +712,17 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                 .setPositiveButton(R.string.button_delete) { _, _ -> confirmDeleteIntent.onNext(messages) }
                 .setNegativeButton(R.string.button_cancel, null)
                 .show()
+    }
+
+    override fun showClearCurrentMessageDialog() {
+        android.app.AlertDialog.Builder(this)
+            .setTitle(R.string.dialog_clear_compose_title)
+            .setMessage(R.string.dialog_clear_compose)
+            .setPositiveButton(R.string.button_clear) { _, _ ->
+                clearCurrentMessageIntent.onNext(Unit)
+            }
+            .setNegativeButton(R.string.button_cancel, null)
+            .show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -75,6 +75,8 @@ interface ComposeView : QkView<ComposeState> {
     val viewQksmsPlusIntent: Subject<Unit>
     val backPressedIntent: Observable<Unit>
     val confirmDeleteIntent: Observable<List<Long>>
+    val confirmClearCurrentMessageIntent: Observable<Unit>
+    val clearCurrentMessageIntent: Subject<Unit>
     val messageLinkAskIntent: Observable<Uri>
     val speechRecogniserIntent: Observable<*>
     val shadeIntent: Observable<Unit>
@@ -109,6 +111,7 @@ interface ComposeView : QkView<ComposeState> {
     fun scrollToMessage(id: Long)
     fun showQksmsPlusSnackbar(@StringRes message: Int)
     fun showDeleteDialog( messages: List<Long>)
+    fun showClearCurrentMessageDialog()
     fun startSpeechRecognition()
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -1102,23 +1102,14 @@ class ComposeViewModel @Inject constructor(
                 view.setDraft("")
                 // if choosing contacts, don't remove attachments. they may have come from an
                 // external share
-                if (it.editingMode)
-                    newState {
-                        copy(
-                            editingMode = false,
-                            hasError = !sendAsGroup,
-                            scheduled = 0,
-                        )
-                    }
-                else
-                    newState {
-                        copy(
-                            editingMode = false,
-                            hasError = !sendAsGroup,
-                            attachments = listOf(),
-                            scheduled = 0,
-                        )
-                    }
+                newState {
+                    copy(
+                        editingMode = false,
+                        hasError = !sendAsGroup,
+                        attachments = listOf(),
+                        scheduled = 0,
+                    )
+                }
             }
 
         // when activity changes visibility, delete old recording cache files in background thread

--- a/presentation/src/main/res/menu/compose.xml
+++ b/presentation/src/main/res/menu/compose.xml
@@ -42,23 +42,21 @@
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/info"
-        android:icon="@drawable/ic_more_vert_black_24dp"
-        android:title="@string/menu_info"
-        android:visible="false"
-        app:showAsAction="always" />
-
-    <item
         android:id="@+id/details"
         android:icon="@drawable/ic_info_black_24dp"
         android:title="@string/compose_menu_copy"
         android:visible="false"
         app:showAsAction="always" />
-
     <item
         android:id="@+id/delete"
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/compose_menu_delete"
+        android:visible="false"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/info"
+        android:icon="@drawable/ic_more_vert_black_24dp"
+        android:title="@string/menu_info"
         android:visible="false"
         app:showAsAction="always" />
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -103,6 +103,9 @@
         <item quantity="other">Are you sure you would like to delete %d messages?</item>
     </plurals>
 
+    <string name="dialog_clear_compose_title">Clear message</string>
+    <string name="dialog_clear_compose">Clear the message? This action can\'t be undone.</string>
+
     <string-array name="message_options">
         <item>Copy text</item>
         <item>Forward</item>
@@ -453,6 +456,7 @@
     <string name="button_more">More</string>
     <string name="button_set">Set</string>
     <string name="button_undo">Undo</string>
+    <string name="button_clear">Clear</string>
 
     <string name="toast_copied">Copied</string>
     <plurals name="toast_archived">


### PR DESCRIPTION
... when the there is message contents to clear - ie a schedule set, text input or attachment(s) added.

this is stage 1 - but independent of - implementation of my feature request https://github.com/octoshrimpy/quik/issues/296.

ui change is that if you have a schedule set, text input or attachment(s) added then a 'delete' (clear current message) icon becomes visible in the menu bar;

![image](https://github.com/user-attachments/assets/ed81bea7-a8e3-44d4-bbd3-5f695a5e5541)

clicking the delete menu icon pops up a confirmation dialog;

![image](https://github.com/user-attachments/assets/e2c151c0-4e23-4d55-a966-f86298bba720)

if 'clear' is selected in the dialog, then the message is cleared - schedule unset, text cleared, attachments removed - ready for new composition;

![image](https://github.com/user-attachments/assets/070672e7-3760-4372-8278-27187af602b9)
