### PR TITLE
changes to bring scheduled messages activity into ui alignment with the rest of the app

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/ScheduledMessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/ScheduledMessageRepositoryImpl.kt
@@ -69,6 +69,10 @@ class ScheduledMessageRepositoryImpl @Inject constructor() : ScheduledMessageRep
         disposables.add(subscription)
     }
 
+    override fun deleteScheduledMessages(ids: List<Long>) {
+        ids.forEach { deleteScheduledMessage(it) }
+    }
+
     // Ensure to clear disposables when the repository is no longer needed
     fun clearDisposables() {
         disposables.clear()

--- a/domain/src/main/java/com/moez/QKSMS/repository/ScheduledMessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/ScheduledMessageRepository.kt
@@ -50,4 +50,7 @@ interface ScheduledMessageRepository {
      */
     fun deleteScheduledMessage(id: Long)
 
+    // delete multiple scheduled messages by id list
+    fun deleteScheduledMessages(ids: List<Long>)
+
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -185,6 +185,8 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val viewQksmsPlusIntent: Subject<Unit> = PublishSubject.create()
     override val backPressedIntent: Subject<Unit> = PublishSubject.create()
     override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
+    override val confirmClearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
+    override val clearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
     override val messageLinkAskIntent: Subject<Uri> by lazy { messageAdapter.messageLinkClicks }
     override val speechRecogniserIntent by lazy { speechToTextIcon.clicks() }
     override val shadeIntent by lazy { shadeBackground.clicks() }
@@ -470,7 +472,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                 && state.query.isEmpty()
         toolbar.menu.findItem(R.id.copy)?.isVisible = !state.editingMode && state.selectedMessages > 0
         toolbar.menu.findItem(R.id.details)?.isVisible = !state.editingMode && state.selectedMessages == 1
-        toolbar.menu.findItem(R.id.delete)?.isVisible = !state.editingMode && state.selectedMessages > 0
+        toolbar.menu.findItem(R.id.delete)?.isVisible = !state.editingMode && ((state.selectedMessages > 0) || state.canSend)
         toolbar.menu.findItem(R.id.forward)?.isVisible = !state.editingMode && state.selectedMessages == 1
         toolbar.menu.findItem(R.id.show_status)?.isVisible = !state.editingMode && state.selectedMessages > 0
         toolbar.menu.findItem(R.id.previous)?.isVisible = state.selectedMessages == 0 && state.query.isNotEmpty()
@@ -710,6 +712,17 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                 .setPositiveButton(R.string.button_delete) { _, _ -> confirmDeleteIntent.onNext(messages) }
                 .setNegativeButton(R.string.button_cancel, null)
                 .show()
+    }
+
+    override fun showClearCurrentMessageDialog() {
+        android.app.AlertDialog.Builder(this)
+            .setTitle(R.string.dialog_clear_compose_title)
+            .setMessage(R.string.dialog_clear_compose)
+            .setPositiveButton(R.string.button_clear) { _, _ ->
+                clearCurrentMessageIntent.onNext(Unit)
+            }
+            .setNegativeButton(R.string.button_cancel, null)
+            .show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -75,6 +75,8 @@ interface ComposeView : QkView<ComposeState> {
     val viewQksmsPlusIntent: Subject<Unit>
     val backPressedIntent: Observable<Unit>
     val confirmDeleteIntent: Observable<List<Long>>
+    val confirmClearCurrentMessageIntent: Observable<Unit>
+    val clearCurrentMessageIntent: Subject<Unit>
     val messageLinkAskIntent: Observable<Uri>
     val speechRecogniserIntent: Observable<*>
     val shadeIntent: Observable<Unit>
@@ -109,6 +111,7 @@ interface ComposeView : QkView<ComposeState> {
     fun scrollToMessage(id: Long)
     fun showQksmsPlusSnackbar(@StringRes message: Int)
     fun showDeleteDialog( messages: List<Long>)
+    fun showClearCurrentMessageDialog()
     fun startSpeechRecognition()
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -1102,23 +1102,14 @@ class ComposeViewModel @Inject constructor(
                 view.setDraft("")
                 // if choosing contacts, don't remove attachments. they may have come from an
                 // external share
-                if (it.editingMode)
-                    newState {
-                        copy(
-                            editingMode = false,
-                            hasError = !sendAsGroup,
-                            scheduled = 0,
-                        )
-                    }
-                else
-                    newState {
-                        copy(
-                            editingMode = false,
-                            hasError = !sendAsGroup,
-                            attachments = listOf(),
-                            scheduled = 0,
-                        )
-                    }
+                newState {
+                    copy(
+                        editingMode = false,
+                        hasError = !sendAsGroup,
+                        attachments = listOf(),
+                        scheduled = 0,
+                    )
+                }
             }
 
         // when activity changes visibility, delete old recording cache files in background thread

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -132,17 +132,6 @@ class MessagesAdapter @Inject constructor(
     private val conversation: Conversation?
         get() = data?.first?.takeIf { it.isValid }
 
-    /**
-     * Mark this message as highlighted
-     */
-    var highlight: Long = -1L
-        set(value) {
-            if (field == value) return
-
-            field = value
-            notifyDataSetChanged()
-        }
-
     private val contactCache = ContactCache()
     private val expanded = HashMap<Long, Boolean>()
     private val subs = subscriptionManager.activeSubscriptionInfoList
@@ -403,30 +392,6 @@ class MessagesAdapter @Inject constructor(
             true -> VIEW_TYPE_MESSAGE_OUT
             false -> VIEW_TYPE_MESSAGE_IN
         }
-    }
-
-    fun toggleSelectAll() {
-        var needToSelectAll = false
-
-        // if a non-selected item is found, then we need to select all, otherwise deselect all
-        for (position in 0 until itemCount)
-            if (!isSelected(getItemId(position))) {
-                needToSelectAll = true
-                break
-            }
-
-        // select or deselect item based on if toggling all selected of deselected
-        for (position in 0 until itemCount) {
-            val messageId = getItemId(position)
-            // if deselecting all then toggle selection (we know all items are selected)
-            if (!needToSelectAll)
-                toggleSelection(messageId)
-            // else, selecting all, toggle if not already selected
-            else if (!isSelected(messageId))
-                toggleSelection(messageId)
-        }
-
-        notifyDataSetChanged()
     }
 
     fun expandMessages(messageIds: List<Long>, expand: Boolean) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
@@ -131,27 +131,4 @@ class ConversationsAdapter @Inject constructor(
         return if (getItem(position)?.unread == false) 0 else 1
     }
 
-    fun toggleSelectAll() {
-        var needToSelectAll = false
-
-        // if a non-selected item is found, then we need to select all, otherwise deselect all
-        for (position in 0 until itemCount)
-            if (!isSelected(getItemId(position))) {
-                needToSelectAll = true
-                break
-            }
-
-        // select or deselect item based on if toggling all selected of deselected
-        for (position in 0 until itemCount) {
-            val threadId = getItemId(position)
-            // if deselecting all then toggle selection (we know all items are selected)
-            if (!needToSelectAll)
-                toggleSelection(threadId)
-            // else, selecting all, toggle if not already selected
-            else if (!isSelected(threadId))
-                toggleSelection(threadId)
-        }
-
-        notifyDataSetChanged()
-    }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledActivity.kt
@@ -116,7 +116,7 @@ class ScheduledActivity : QkThemedActivity(), ScheduledView {
     override fun showSendNowDialog(messages: List<Long>) {
         val count = messages.size
         android.app.AlertDialog.Builder(this)
-            .setTitle(R.string.dialog_delete_title)
+            .setTitle(R.string.main_menu_send_now)
             .setMessage(resources.getQuantityString(R.plurals.dialog_send_now, count, count))
             .setPositiveButton(R.string.main_menu_send_now) { _, _ -> sendScheduledMessages.onNext(messages) }
             .setNegativeButton(R.string.button_cancel, null)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAdapter.kt
@@ -61,7 +61,13 @@ class ScheduledMessageAdapter @Inject constructor(
         return QkViewHolder(view).apply {
             view.setOnClickListener {
                 val message = getItem(adapterPosition) ?: return@setOnClickListener
-                clicks.onNext(message.id)
+                if (toggleSelection(message.id, false))
+                    view.isActivated = isSelected(message.id)
+            }
+            view.setOnClickListener {
+                val message = getItem(adapterPosition) ?: return@setOnClickListener
+                toggleSelection(message.id)
+                view.isActivated = isSelected(message.id)
             }
         }
     }
@@ -79,9 +85,16 @@ class ScheduledMessageAdapter @Inject constructor(
         holder.date.text = dateFormatter.getScheduledTimestamp(message.date)
         holder.body.text = message.body
 
+        // update the selected/highlighted state
+        holder.containerView.isActivated = isSelected(message.id) || highlight == message.id
+
         val adapter = holder.attachments.adapter as ScheduledMessageAttachmentAdapter
         adapter.data = message.attachments.map(Uri::parse)
         holder.attachments.isVisible = message.attachments.isNotEmpty()
+    }
+
+    override fun getItemId(position: Int): Long {
+        return getItem(position)?.id ?: -1
     }
 
     /**

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledState.kt
@@ -23,5 +23,6 @@ import io.realm.RealmResults
 
 data class ScheduledState(
     val scheduledMessages: RealmResults<ScheduledMessage>? = null,
-    val upgraded: Boolean = true
+    val upgraded: Boolean = true,
+    val selectedMessages: Int = 0,
 )

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledView.kt
@@ -23,11 +23,18 @@ import io.reactivex.Observable
 
 interface ScheduledView : QkView<ScheduledState> {
 
-    val messageClickIntent: Observable<Long>
-    val messageMenuIntent: Observable<Int>
     val composeIntent: Observable<*>
     val upgradeIntent: Observable<*>
+    val messagesSelectedIntent: Observable<List<Long>>
+    val optionsItemIntent: Observable<Int>
+    val deleteScheduledMessages: Observable<List<Long>>
+    val sendScheduledMessages: Observable<List<Long>>
+    val backPressedIntent: Observable<Unit>
 
-    fun showMessageOptions()
+    fun clearSelection()
+    fun toggleSelectAll()
+    fun showDeleteDialog(messages: List<Long>)
+    fun showSendNowDialog(messages: List<Long>)
+    fun finishActivity()
 
 }

--- a/presentation/src/main/res/layout/scheduled_activity.xml
+++ b/presentation/src/main/res/layout/scheduled_activity.xml
@@ -17,145 +17,177 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout  xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <androidx.core.widget.NestedScrollView
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        style="@style/Toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintHeight_max="140dp"
+        app:layout_constraintTop_toTopOf="parent">
 
         <LinearLayout
+
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:animateLayoutChanges="true"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
             android:orientation="vertical">
 
-            <LinearLayout
-                android:id="@+id/empty"
-                android:layout_width="match_parent"
+            <dev.octoshrimpy.quik.common.widget.QkTextView
+                android:id="@+id/toolbarTitle"
+                style="@style/ToolbarText"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:paddingStart="24dp"
-                android:paddingEnd="24dp">
-
-                <dev.octoshrimpy.quik.common.widget.QkTextView
-                    style="@style/TextPrimary"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="8dp"
-                    android:text="@string/scheduled_empty_description"
-                    android:textColor="?android:attr/textColorSecondary" />
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="56dp" />
-
-                <dev.octoshrimpy.quik.common.widget.TightTextView
-                    style="@style/ScheduledSampleTextStyle"
-                    android:layout_gravity="end"
-                    android:text="@string/scheduled_empty_message_1" />
-
-                <dev.octoshrimpy.quik.common.widget.TightTextView
-                    android:id="@+id/sampleMessage"
-                    style="@style/ScheduledSampleTextStyle"
-                    android:layout_marginTop="16dp"
-                    android:background="@drawable/rounded_rectangle_22dp"
-                    android:text="@string/scheduled_empty_message_2"
-                    tools:backgroundTint="@color/tools_theme"
-                    tools:textColor="@color/textPrimaryDark" />
-
-                <dev.octoshrimpy.quik.common.widget.TightTextView
-                    style="@style/ScheduledSampleTextStyle"
-                    android:layout_gravity="end"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/scheduled_empty_message_3" />
-
-                <dev.octoshrimpy.quik.common.widget.QkTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="end"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginEnd="16dp"
-                    android:gravity="end"
-                    android:text="@string/scheduled_empty_message_3_timestamp"
-                    android:textColor="?android:attr/textColorSecondary"
-                    android:textStyle="italic"
-                    app:textSize="secondary" />
-
-                <Space
-                    android:layout_width="match_parent"
-                    android:layout_height="56dp" />
-
-            </LinearLayout>
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/messages"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="8dp"
-                android:paddingBottom="8dp"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                tools:listitem="@layout/scheduled_message_list_item" />
+                android:textDirection="ltr"
+                tools:text="Moez Bhatti" />
 
         </LinearLayout>
 
-    </androidx.core.widget.NestedScrollView>
+    </androidx.appcompat.widget.Toolbar>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/compose"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="16dp"
-        android:contentDescription="@string/scheduled_compose_cd"
-        android:src="@drawable/ic_schedule_send_black_24dp"
-        android:tint="@color/white"
-        android:visibility="visible"
-        tools:backgroundTint="@color/tools_theme" />
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/upgrade"
-        android:layout_width="wrap_content"
-        android:layout_height="48dp"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="16dp"
-        android:background="@drawable/rounded_rectangle_24dp"
-        android:elevation="4dp"
-        android:gravity="center"
-        android:visibility="gone"
-        tools:backgroundTint="@color/tools_theme">
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <ImageView
-            android:id="@+id/upgradeIcon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginStart="12dp"
-            android:src="@drawable/ic_star_black_24dp"
-            tools:tint="@color/textPrimaryDark" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:orientation="vertical">
 
-        <dev.octoshrimpy.quik.common.widget.QkTextView
-            android:id="@+id/upgradeLabel"
+                <LinearLayout
+                    android:id="@+id/empty"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingStart="24dp"
+                    android:paddingEnd="24dp">
+
+                    <dev.octoshrimpy.quik.common.widget.QkTextView
+                        style="@style/TextPrimary"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:text="@string/scheduled_empty_description"
+                        android:textColor="?android:attr/textColorSecondary" />
+
+                    <Space
+                        android:layout_width="match_parent"
+                        android:layout_height="56dp" />
+
+                    <dev.octoshrimpy.quik.common.widget.TightTextView
+                        style="@style/ScheduledSampleTextStyle"
+                        android:layout_gravity="end"
+                        android:text="@string/scheduled_empty_message_1" />
+
+                    <dev.octoshrimpy.quik.common.widget.TightTextView
+                        android:id="@+id/sampleMessage"
+                        style="@style/ScheduledSampleTextStyle"
+                        android:layout_marginTop="16dp"
+                        android:background="@drawable/rounded_rectangle_22dp"
+                        android:text="@string/scheduled_empty_message_2"
+                        tools:backgroundTint="@color/tools_theme"
+                        tools:textColor="@color/textPrimaryDark" />
+
+                    <dev.octoshrimpy.quik.common.widget.TightTextView
+                        style="@style/ScheduledSampleTextStyle"
+                        android:layout_gravity="end"
+                        android:layout_marginTop="16dp"
+                        android:text="@string/scheduled_empty_message_3" />
+
+                    <dev.octoshrimpy.quik.common.widget.QkTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_marginTop="8dp"
+                        android:layout_marginEnd="16dp"
+                        android:gravity="end"
+                        android:text="@string/scheduled_empty_message_3_timestamp"
+                        android:textColor="?android:attr/textColorSecondary"
+                        android:textStyle="italic"
+                        app:textSize="secondary" />
+
+                    <Space
+                        android:layout_width="match_parent"
+                        android:layout_height="56dp" />
+
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/messages"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                    tools:listitem="@layout/scheduled_message_list_item" />
+
+            </LinearLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/compose"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="@string/title_qksms_plus"
-            android:textColor="@color/textPrimaryDark"
-            android:textStyle="bold"
-            app:textSize="primary" />
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:contentDescription="@string/scheduled_compose_cd"
+            android:src="@drawable/ic_schedule_send_black_24dp"
+            android:tint="@color/white"
+            android:visibility="visible"
+            tools:backgroundTint="@color/tools_theme" />
 
-    </LinearLayout>
+        <LinearLayout
+            android:id="@+id/upgrade"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:background="@drawable/rounded_rectangle_24dp"
+            android:elevation="4dp"
+            android:gravity="center"
+            android:visibility="gone"
+            tools:backgroundTint="@color/tools_theme">
 
-    <include layout="@layout/collapsing_toolbar" />
+            <ImageView
+                android:id="@+id/upgradeIcon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="12dp"
+                android:src="@drawable/ic_star_black_24dp"
+                tools:tint="@color/textPrimaryDark" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_gravity="bottom"
-        android:background="?android:attr/divider" />
+            <dev.octoshrimpy.quik.common.widget.QkTextView
+                android:id="@+id/upgradeLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/title_qksms_plus"
+                android:textColor="@color/textPrimaryDark"
+                android:textStyle="bold"
+                app:textSize="primary" />
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_gravity="bottom"
+            android:background="?android:attr/divider" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>

--- a/presentation/src/main/res/menu/compose.xml
+++ b/presentation/src/main/res/menu/compose.xml
@@ -42,23 +42,21 @@
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/info"
-        android:icon="@drawable/ic_more_vert_black_24dp"
-        android:title="@string/menu_info"
-        android:visible="false"
-        app:showAsAction="always" />
-
-    <item
         android:id="@+id/details"
         android:icon="@drawable/ic_info_black_24dp"
         android:title="@string/compose_menu_copy"
         android:visible="false"
         app:showAsAction="always" />
-
     <item
         android:id="@+id/delete"
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/compose_menu_delete"
+        android:visible="false"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/info"
+        android:icon="@drawable/ic_more_vert_black_24dp"
+        android:title="@string/menu_info"
         android:visible="false"
         app:showAsAction="always" />
 

--- a/presentation/src/main/res/menu/scheduled_messages.xml
+++ b/presentation/src/main/res/menu/scheduled_messages.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2025
+  ~
+  ~ This file is part of QUIK.
+  ~
+  ~ QUIK is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QUIK is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QUIK.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/select_all"
+        android:icon="?attr/actionModeSelectAllDrawable"
+        android:title="@string/main_menu_select_all"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/delete"
+        android:icon="@drawable/ic_delete_white_24dp"
+        android:title="@string/main_menu_delete"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/copy"
+        android:icon="@drawable/ic_content_copy_black_24dp"
+        android:title="@string/compose_menu_copy"
+        android:visible="false"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/send_now"
+        android:icon="@drawable/ic_send_black_24dp"
+        android:title="@string/main_menu_send_now"
+        android:visible="false"
+        app:showAsAction="never" />
+
+</menu>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -103,6 +103,9 @@
         <item quantity="other">Are you sure you would like to delete %d messages?</item>
     </plurals>
 
+    <string name="dialog_clear_compose_title">Clear message</string>
+    <string name="dialog_clear_compose">Clear the message? This action can\'t be undone.</string>
+
     <string-array name="message_options">
         <item>Copy text</item>
         <item>Forward</item>
@@ -453,6 +456,7 @@
     <string name="button_more">More</string>
     <string name="button_set">Set</string>
     <string name="button_undo">Undo</string>
+    <string name="button_clear">Clear</string>
 
     <string name="toast_copied">Copied</string>
     <plurals name="toast_archived">

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="main_menu_read">Mark read</string>
     <string name="main_menu_unread">Mark unread</string>
     <string name="main_menu_block">Block</string>
+    <string name="main_menu_send_now">Send now</string>
     <string name="main_menu_rename_conversation">Rename conversation</string>
     <string name="main_syncing">Syncing messages…</string>
     <string name="main_sender_you">You: %s</string>
@@ -101,6 +102,10 @@
     <plurals name="dialog_delete_chat">
         <item quantity="one">Are you sure you would like to delete this message?</item>
         <item quantity="other">Are you sure you would like to delete %d messages?</item>
+    </plurals>
+    <plurals name="dialog_send_now">
+        <item quantity="one">Are you sure you would like to send this message now?</item>
+        <item quantity="other">Are you sure you would like to send %d messages now?</item>
     </plurals>
 
     <string name="dialog_clear_compose_title">Clear message</string>
@@ -234,11 +239,6 @@
     <string name="scheduled_compose_cd">Schedule a message</string>
     <string name="scheduled_options_title">Scheduled message</string>
     <string name="attachment_missing">Missing</string>
-    <string-array name="scheduled_options">
-        <item>Send now</item>
-        <item>Copy text</item>
-        <item>Delete</item>
-    </string-array>
 
     <string name="settings_category_appearance">Appearance</string>
     <string name="settings_category_general">General</string>


### PR DESCRIPTION
scheduled messages ui activity now matches the ui of other message listing activities in the app with selection and menu icons instead of menu-dialog.

this is stage 2 - but independent of - implementation of my feature request https://github.com/octoshrimpy/quik/issues/296. it includes prior stage 1 pr https://github.com/octoshrimpy/quik/pull/297.

there is _no loss of functionality from previous_, but can now send now or delete multiple scheduled messages at once.

the scheduled messages ui now has proper title bar and ability to select one or many scheduled messages;

![image](https://github.com/user-attachments/assets/8c545bcc-3d5d-448a-a570-6d5aeee55564)

when one or more messages are selected menu items are shown like in other screens; toggle select all/none, delete, copy text, and send now.

![image](https://github.com/user-attachments/assets/35a341b8-4641-480e-83c2-9961a6f83f4e)  ![image](https://github.com/user-attachments/assets/d181f39c-a8d7-4f7e-ac80-2b3f9c5a7bf5)

both send now and delete have confirmation dialogs;

![image](https://github.com/user-attachments/assets/ea8a721a-0716-463b-8757-219e38e7768d)  ![image](https://github.com/user-attachments/assets/eccea345-2b30-4add-bedf-a8a51ba524e5)



