### PR TITLE
changes to allow editing of scheduled messages

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -81,9 +81,24 @@ class ComposeActivityModule {
 
     @Provides
     @Named("mode")
-    fun provideSharedAction(activity: ComposeActivity): String {
-        return activity.intent.getStringExtra("mode") ?: "";
-    }
+    fun provideSharedAction(activity: ComposeActivity): String =
+        activity.intent.getStringExtra("mode") ?: ""
+
+    @Provides
+    @Named("subscriptionId")
+    fun provideSubscriptionId(activity: ComposeActivity): Int =
+        activity.intent.getIntExtra("subscriptionId", -1)
+
+    @Provides
+    @Named("sendAsGroup")
+    fun provideSendAsGroup(activity: ComposeActivity): Boolean? =
+        if (!activity.intent.hasExtra("sendAsGroup")) null
+        else activity.intent.getBooleanExtra("sendAsGroup", false)
+
+    @Provides
+    @Named("scheduleDateTime")
+    fun provideSharedScheduleDateTime(activity: ComposeActivity): Long =
+        activity.intent.getLongExtra("scheduleDateTime", 0L)
 
     @Provides
     @IntoMap

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -91,8 +91,11 @@ class ComposeViewModel @Inject constructor(
     @Named("threadId") private val threadId: Long,
     @Named("addresses") private val addresses: List<String>,
     @Named("text") private val sharedText: String,
-    @Named("attachments") private val sharedAttachments: List<Attachment>,
+    @Named("attachments") val sharedAttachments: List<Attachment>,
     @Named("mode") private val mode: String,
+    @Named("subscriptionId") val sharedSubscriptionId: Int,
+    @Named("sendAsGroup") val sharedSendAsGroup: Boolean?,
+    @Named("scheduleDateTime") val sharedScheduledDateTime: Long,
     private val contactRepo: ContactRepository,
     private val context: Context,
     private val activeConversationManager: ActiveConversationManager,
@@ -134,7 +137,20 @@ class ComposeViewModel @Inject constructor(
     private var bluetoothMicManager: BluetoothMicManager? = null
 
     init {
-        // set shared attachments into state, if any
+        // set shared subscription into state if set
+        subscriptionManager.activeSubscriptionInfoList.firstOrNull {
+            it.subscriptionId == sharedSubscriptionId
+        }?.let { newState { copy(subscription = it)} }
+
+        // set shared scheduled datetime into state if set
+        if (sharedScheduledDateTime != 0L)
+            newState { copy (scheduled = sharedScheduledDateTime) }
+
+        // set shared sendAsGroup into state if set
+        if (sharedSendAsGroup != null)
+            newState { copy(sendAsGroup = sharedSendAsGroup) }
+
+        // set shared attachments into state
         newState { copy(attachments = sharedAttachments) }
 
         val initialConversation = threadId.takeIf { it != 0L }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledActivity.kt
@@ -49,6 +49,7 @@ class ScheduledActivity : QkThemedActivity(), ScheduledView {
     override val optionsItemIntent: Subject<Int> = PublishSubject.create()
     override val deleteScheduledMessages: Subject<List<Long>> = PublishSubject.create()
     override val sendScheduledMessages: Subject<List<Long>> = PublishSubject.create()
+    override val editScheduledMessage: Subject<Long> = PublishSubject.create()
     override val backPressedIntent: Subject<Unit> = PublishSubject.create()
 
     private val viewModel by lazy { ViewModelProviders.of(this, viewModelFactory)[ScheduledViewModel::class.java] }
@@ -85,12 +86,16 @@ class ScheduledActivity : QkThemedActivity(), ScheduledView {
         })
 
         // show/hide menu items
-        toolbar.menu.findItem(R.id.delete)?.isVisible =
-            ((scheduledMessageAdapter.itemCount != 0) && (state.selectedMessages != 0))
         toolbar.menu.findItem(R.id.select_all)?.isVisible =
             ((scheduledMessageAdapter.itemCount > 1) && (state.selectedMessages != 0))
-        toolbar.menu.findItem(R.id.copy)?.isVisible = (state.selectedMessages != 0)
-        toolbar.menu.findItem(R.id.send_now)?.isVisible = (state.selectedMessages != 0)
+        toolbar.menu.findItem(R.id.delete)?.isVisible =
+            ((scheduledMessageAdapter.itemCount != 0) && (state.selectedMessages != 0))
+        toolbar.menu.findItem(R.id.copy)?.isVisible =
+            ((scheduledMessageAdapter.itemCount != 0) && (state.selectedMessages != 0))
+        toolbar.menu.findItem(R.id.send_now)?.isVisible =
+            ((scheduledMessageAdapter.itemCount != 0) && (state.selectedMessages != 0))
+        toolbar.menu.findItem(R.id.edit_message)?.isVisible =
+            ((scheduledMessageAdapter.itemCount != 0) && (state.selectedMessages == 1))
 
         // show compose button
         compose.isVisible = state.upgraded
@@ -119,6 +124,17 @@ class ScheduledActivity : QkThemedActivity(), ScheduledView {
             .setTitle(R.string.main_menu_send_now)
             .setMessage(resources.getQuantityString(R.plurals.dialog_send_now, count, count))
             .setPositiveButton(R.string.main_menu_send_now) { _, _ -> sendScheduledMessages.onNext(messages) }
+            .setNegativeButton(R.string.button_cancel, null)
+            .show()
+    }
+
+    override fun showEditMessageDialog(message: Long) {
+        android.app.AlertDialog.Builder(this)
+            .setTitle(R.string.dialog_edit_scheduled_message_title)
+            .setMessage(R.string.dialog_edit_scheduled_message)
+            .setPositiveButton(R.string.dialog_edit_scheduled_message_positive_button) { _, _ ->
+                editScheduledMessage.onNext(message)
+            }
             .setNegativeButton(R.string.button_cancel, null)
             .show()
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledView.kt
@@ -29,12 +29,14 @@ interface ScheduledView : QkView<ScheduledState> {
     val optionsItemIntent: Observable<Int>
     val deleteScheduledMessages: Observable<List<Long>>
     val sendScheduledMessages: Observable<List<Long>>
+    val editScheduledMessage: Observable<Long>
     val backPressedIntent: Observable<Unit>
 
     fun clearSelection()
     fun toggleSelectAll()
     fun showDeleteDialog(messages: List<Long>)
     fun showSendNowDialog(messages: List<Long>)
+    fun showEditMessageDialog(message: Long)
     fun finishActivity()
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledViewModel.kt
@@ -81,6 +81,13 @@ class ScheduledViewModel @Inject constructor(
             .autoDisposable(view.scope())
             .subscribe { view.showSendNowDialog(it) }
 
+        // edit message menu item selected
+        view.optionsItemIntent
+            .filter { it == R.id.edit_message }
+            .withLatestFrom(view.messagesSelectedIntent) { _, selectedMessage -> selectedMessage.first() }
+            .autoDisposable(view.scope())
+            .subscribe { view.showEditMessageDialog(it) }
+
         // delete message(s) (fired after the confirmation dialog has been shown)
         view.deleteScheduledMessages
             .observeOn(AndroidSchedulers.mainThread())
@@ -98,6 +105,20 @@ class ScheduledViewModel @Inject constructor(
             .autoDisposable(view.scope())
             .subscribe {
                 it.forEach { sendScheduledMessageInteractor.execute(it) }
+                view.clearSelection()
+            }
+
+
+        // edit message (fired after the confirmation dialog has been shown)
+        view.editScheduledMessage
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeOn(Schedulers.io())
+            .autoDisposable(view.scope())
+            .subscribe {
+                scheduledMessageRepo.getScheduledMessage(it)?.let {
+                    navigator.showCompose(it)
+                    scheduledMessageRepo.deleteScheduledMessage(it.id)
+                }
                 view.clearSelection()
             }
 

--- a/presentation/src/main/res/menu/scheduled_messages.xml
+++ b/presentation/src/main/res/menu/scheduled_messages.xml
@@ -44,7 +44,14 @@
     <item
         android:id="@+id/send_now"
         android:icon="@drawable/ic_send_black_24dp"
-        android:title="@string/main_menu_send_now"
+        android:title="@string/scheduled_menu_send_now"
+        android:visible="false"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/edit_message"
+        android:icon="@drawable/ic_schedule_send_black_24dp"
+        android:title="@string/scheduled_menu_edit_message"
         android:visible="false"
         app:showAsAction="never" />
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="main_menu_unread">Mark unread</string>
     <string name="main_menu_block">Block</string>
     <string name="main_menu_send_now">Send now</string>
+    <string name="main_menu_edit_message">Edit message</string>
     <string name="main_menu_rename_conversation">Rename conversation</string>
     <string name="main_syncing">Syncing messages…</string>
     <string name="main_sender_you">You: %s</string>
@@ -76,6 +77,9 @@
     <string name="main_permission_contacts">QUIK needs permission to view your contacts</string>
     <string name="main_permission_notifications">QUIK needs permission to display notifications</string>
     <string name="main_permission_allow">Allow</string>
+
+    <string name="scheduled_menu_send_now">Send now</string>
+    <string name="scheduled_menu_edit_message">Edit message</string>
 
     <string name="drawer_inbox">Inbox</string>
     <string name="drawer_archived">Archived</string>
@@ -107,6 +111,10 @@
         <item quantity="one">Are you sure you would like to send this message now?</item>
         <item quantity="other">Are you sure you would like to send %d messages now?</item>
     </plurals>
+
+    <string name="dialog_edit_scheduled_message_title">Edit message</string>
+    <string name="dialog_edit_scheduled_message">Editing this message will remove it from the schedule.\n\nMake sure to re-submit it on the next screen, or it will be lost.\n\nDo you want to continue?</string>
+    <string name="dialog_edit_scheduled_message_positive_button">Yes, edit the message</string>
 
     <string name="dialog_clear_compose_title">Clear message</string>
     <string name="dialog_clear_compose">Clear the message? This action can\'t be undone.</string>


### PR DESCRIPTION
allows editing of scheduled messages via a new menu item on the scheduled messages activity.

this is stage 3 - and final - implementation of my feature request https://github.com/octoshrimpy/quik/issues/296. it includes prior stage 1 pr https://github.com/octoshrimpy/quik/pull/297 and stage 2 pr https://github.com/octoshrimpy/quik/pull/298.

new menu item on scheduled message activity available only when a single message is selected;

![image](https://github.com/user-attachments/assets/152ceddf-27c0-40ca-b7f9-efd720bae8d0)

confirms the possible loss of message with a dialog;

![image](https://github.com/user-attachments/assets/d6c69413-2ec8-48bb-81a8-a0318aaee873)

then starts the compose activity with the scheduled message's data - schedule date/time, send as group, subscription id, threadId, attachments, text, recipients. user can then edit the message and 'send' (re-schedule) as usual.

closes https://github.com/octoshrimpy/quik/issues/296