### PR TITLE
bug fix remove extraneous controls on compose (sim and mic) when no reply possible

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -521,6 +521,8 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         // hide controls that allow constructing a reply and inform user no valid recipients
         if (!state.editingMode && (state.validRecipientNumbers == 0)) {
             composeBar.visibility = View.GONE
+            sim.visibility = View.GONE
+            recordAudioMsg.visibility = View.GONE
             noValidRecipients.visibility = View.VISIBLE
 
             // change constraint of messageList to constrain bottom to top of noValidRecipients

--- a/presentation/src/main/res/layout/compose_activity.xml
+++ b/presentation/src/main/res/layout/compose_activity.xml
@@ -299,7 +299,7 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@id/messageBackground"
         app:layout_constraintEnd_toEndOf="@id/messageBackground"
-        app:tint="?android:attr/textColorSecondary" />
+        app:tint="?android:attr/textColorPrimary" />
 
     <dev.octoshrimpy.quik.common.widget.QkTextView
         android:id="@+id/simIndex"
@@ -673,7 +673,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        tools:visibility="visible">
+        tools:visibility="invisible">
 
         <View
             android:id="@+id/audioMsgBackgroundShadow"


### PR DESCRIPTION
remove extraneous controls - sim and mic - when no reply possible in compose activity

closes https://github.com/octoshrimpy/quik/issues/304
closes https://github.com/octoshrimpy/quik/issues/299