### PR TITLE
Update attachment icon retrieve and manifest query to enable

### DIFF
--- a/domain/src/main/AndroidManifest.xml
+++ b/domain/src/main/AndroidManifest.xml
@@ -26,4 +26,11 @@
             android:grantUriPermissions="true">
         </provider>
     </application>
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="*" android:mimeType="*/*" />
+        </intent>
+    </queries>
 </manifest>

--- a/domain/src/main/java/com/moez/QKSMS/extensions/UriExtensions.kt
+++ b/domain/src/main/java/com/moez/QKSMS/extensions/UriExtensions.kt
@@ -136,21 +136,25 @@ fun Uri.contactToVCard(context: Context): Uri =
     }
 
 fun Uri.getDefaultActivityIconForMimeType(context: Context): Drawable? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.packageManager
-                .queryIntentActivities(
-                    Intent(Intent.ACTION_VIEW).setDataAndType(this, getType(context)),
-                    PackageManager.ResolveInfoFlags.of(
-                        PackageManager.MATCH_DEFAULT_ONLY.toLong()
-                    )
-                ).let {
-                    if (it.size > 0) it[0].loadIcon(context.packageManager)
-                    else null
-                }
-        } else {
-            context.packageManager
-                .resolveActivity(
-                    Intent(Intent.ACTION_VIEW).setDataAndType(this, getType(context)),
-                    PackageManager.MATCH_DEFAULT_ONLY)
-                ?.loadIcon(context.packageManager)
-        }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.packageManager
+            .queryIntentActivities(
+                Intent(Intent.ACTION_VIEW).setDataAndType(this, getType(context)),
+                PackageManager.ResolveInfoFlags.of(
+                    PackageManager.MATCH_DEFAULT_ONLY.toLong()
+                )
+            ).let {
+                if (it.size > 0) it[0].loadIcon(context.packageManager)
+                else null
+            }
+    } else {
+        // else, pre-tiramisu versions
+        context.packageManager
+            .queryIntentActivities(
+                Intent(Intent.ACTION_VIEW).setDataAndType(this, getType(context)),
+                PackageManager.MATCH_DEFAULT_ONLY
+            ).let {
+                if (it.size > 0) it[0].loadIcon(context.packageManager)
+                else null
+            }
+    }

--- a/presentation/src/main/res/layout/attachment_file_list_item.xml
+++ b/presentation/src/main/res/layout/attachment_file_list_item.xml
@@ -21,6 +21,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:background="?attr/bubbleColor">
 
     <FrameLayout
@@ -61,6 +62,6 @@
         android:background="@drawable/circle"
         android:backgroundTint="?attr/bubbleColor"
         android:src="@drawable/ic_cancel_black_24dp"
-        android:tint="?android:attr/textColorSecondary" />
+        app:tint="?android:attr/textColorSecondary" />
 
 </FrameLayout>

--- a/presentation/src/main/res/layout/attachment_file_list_item.xml
+++ b/presentation/src/main/res/layout/attachment_file_list_item.xml
@@ -41,11 +41,11 @@
 
         <TextView
             android:id="@+id/fileName"
-            style="@style/TextPrimary"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="#ddffffff"
+            android:background="#a7ffffff"
             android:gravity="center"
+            android:textColor="@color/black"
             android:visibility="gone"
             tools:visibility="visible" />
 

--- a/presentation/src/main/res/layout/scheduled_message_image_list_item.xml
+++ b/presentation/src/main/res/layout/scheduled_message_image_list_item.xml
@@ -34,11 +34,11 @@
 
     <TextView
         android:id="@+id/fileName"
-        style="@style/TextPrimary"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#ddffffff"
+        android:background="#a7ffffff"
         android:gravity="center"
+        android:textColor="@color/black"
         android:visibility="gone"
         tools:visibility="visible" />
 


### PR DESCRIPTION
updated code used to fetch icons from other apps for compose box attachments. enabled access to other apps icons in manifest. small adjustment to text transparency to provide greater contrast between icon and text. made text in front of icon always black.

example attaching a pdf... before - generic attach icon because default pdf app icon wasn't accessible, and hard to see text;

![image](https://github.com/user-attachments/assets/bda05814-b62f-4835-ba63-7622aab23a21)

after - uses icon from default installed pdf view app, and text easier to see;

![image](https://github.com/user-attachments/assets/552b9462-faa8-4337-aaf4-0385262f497b)

[ edit: updated the pr with same visual changes to scheduled messages activity attachment icons ]

![image](https://github.com/user-attachments/assets/643d0b99-3f91-4e6a-9698-c5f0e06cd5a2)
