### PR TITLE
upgrade glide library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     ext.dagger_version = "2.18"
     ext.espresso_version = '3.1.0-alpha3'
     ext.exoplayer_version = "r2.9.0"
-    ext.glide_version = "4.8.0"
+    ext.glide_version = "4.16.0"
     ext.junit_version = '4.12'
     ext.kotlin_version = '1.7.20'
     ext.lifecycle_version = '2.1.0'

--- a/presentation/src/main/java/com/moez/QKSMS/common/GlideCompletionListener.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/GlideCompletionListener.kt
@@ -24,13 +24,23 @@ import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.target.Target
 
 class GlideCompletionListener<T>(private val listener: () -> Unit) : RequestListener<T> {
-
-    override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<T>?, isFirstResource: Boolean): Boolean {
+    override fun onLoadFailed(
+        e: GlideException?,
+        model: Any?,
+        target: Target<T>,
+        isFirstResource: Boolean
+    ): Boolean {
         listener()
         return false
     }
 
-    override fun onResourceReady(resource: T, model: Any?, target: Target<T>?, dataSource: DataSource?, isFirstResource: Boolean): Boolean {
+    override fun onResourceReady(
+        resource: T,
+        model: Any,
+        target: Target<T>?,
+        dataSource: DataSource,
+        isFirstResource: Boolean
+    ): Boolean {
         listener()
         return false
     }


### PR DESCRIPTION
upgrade glide library to v4.16.0 (latest non release candidate version at this time)

possibly helpful for issues relating to images including https://github.com/octoshrimpy/quik/issues/165