### PR TITLE
Adds contributing guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ To do this, navigate to the release tab in this repository and click on releases
 Once you have done this, simply use the app as normal, and report any bugs you come across.
 ## Translating 
 To translate this app navigate to `presentation/src/main/res` and find or make a values file with the language you wish to edit. Then copy over the `strings.xml` file from `presentation/src/main/res/values` and translate it. Please do not translate any string with the `translatable=false` attribute. Also, remember to make sure to insert a backslash `\` before any apostrophe `'` or quotes `"`.
+<!--
+## Translations
+
+If you'd like to add translations to QUIK, please join the project on [Crowdin](https://crowdin.com/project/qksms). Translations that are committed directly to source files will not be accepted.
+-->
 ## Updating the Wiki 
 To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshrimpy/quik/wiki) in this repository, find the file that you need to edit, and then click `Edit Page`. Then you can edit and commit your change. For more sizeable changes, and for feedback and questions please comment in [this discussion](https://github.com/octoshrimpy/quik/discussions/174).
 ## Fix Bugs 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 Contributions are greatly appreciated! There are many ways to contribute to this repository:
-* [Submitting Issues](#submitting-Issues)
+* [Submitting Issues](#submitting-issues)
 * [Testing Latest Versions](#testing-latest-versions)
 * [Translating](#translating)
 * [Updating the Wiki](#updating-the-wiki)
@@ -29,7 +29,7 @@ To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshr
 2. Fork the repository.
 3. Create a new branch.
 4. Make your change.
-5. Test your change, either by building an apk or running on an emulator.
+5. Test your change, either by building an apk or running on an emulator. 
 6. Submit a pull request with your change.
 **We have a build action on each pull request, if this build fails, please edit the pull request in order to make the build succeed.**
 ## Add Features 
@@ -37,6 +37,44 @@ To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshr
 2. Fork the repository.
 3. Create a new branch.
 4. Make your change. **Note: Please make sure to provide detailed comments within your code to make reviewers and future contributors lives easier.**
-5. Test your change, either by building an apk or running on an emulator.
+5. Test your change, either by building an apk or running on an emulator. 
 6. Submit a pull request with your change.
 **We have a build action on each pull request, if this build fails, please edit the pull request in order to make the build succeed.**
+## Helpful Tips
+### [build.gradle](https://github.com/octoshrimpy/quik/blob/master/presentation/build.gradle) configuration for building locally
+```
+
+/*
+    signingConfigs {
+        release {
+            def keystoreProps = new Properties()
+            def keystorePropsFile = rootProject.file('./.gradle/.gradlerc')
+            storeFile file('./my-release-key.keystore')
+            keyAlias 'quik_release'
+            if (keystorePropsFile.exists()) {
+                keystoreProps.load(new FileInputStream(keystorePropsFile))
+            } else if (System.getenv("CI") == "true") {
+//                do nothing
+            } else {
+                throw new GradleException("Keystore properties file not found.")
+            }
+            storePassword keystoreProps['storePassword']
+            keyPassword keystoreProps['keyPassword']
+        }
+    }
+*/
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+       //     signingConfig signingConfigs.release
+        }
+    }
+
+    productFlavors {
+        withAnalytics { dimension "analytics" }
+        noAnalytics {
+        //    signingConfig signingConfigs.release
+        }
+    }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Once you have done this, simply use the app as normal, and report any bugs you c
 ## Translating 
 To translate this app navigate to `presentation/src/main/res` and find or make a values file with the language you wish to edit. Then copy over the `strings.xml` file from `presentation/src/main/res/values` and translate it. Please do not translate any string with the `translatable=false` attribute. Also, remember to make sure to insert a backslash `\` before any apostrophe `'` or quotes `"`.
 ## Updating the Wiki 
-To update the wiki, simply navigate to the wiki tab in this repository, find the file that you need to edit, and then click `Edit Page`. Then you can edit and commit your change. For more sizeable changes, and for feedback and questions please comment in [this discussion](https://github.com/octoshrimpy/quik/discussions/174).\
+To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshrimpy/quik/wiki) in this repository, find the file that you need to edit, and then click `Edit Page`. Then you can edit and commit your change. For more sizeable changes, and for feedback and questions please comment in [this discussion](https://github.com/octoshrimpy/quik/discussions/174).
 ## Fix Bugs 
 1. Find a bug that needs fixing, please check the issues tab, and if the bug isn't reported, please do so before fixing it.
 2. Fork the repository.
@@ -26,12 +26,12 @@ To update the wiki, simply navigate to the wiki tab in this repository, find the
 4. Make your change.
 5. Test your change, either by building an apk or running on an emulator.
 6. Submit a pull request with your change.
-**We have a build action on each pull request, if this build fails, please edit the pull request in order to make this build succed.**
+**We have a build action on each pull request, if this build fails, please edit the pull request in order to make the build succeed.**
 ## Add Features 
 1. Submit a feature request to the issue tab, or search through the issues for a feature request that has already been submitted.
 2. Fork the repository.
 3. Create a new branch.
-4. Make your change. **Note: Please make sure to provide detailed comments within your code to make reviewers and future contributers lives easier.**
+4. Make your change. **Note: Please make sure to provide detailed comments within your code to make reviewers and future contributors lives easier.**
 5. Test your change, either by building an apk or running on an emulator.
 6. Submit a pull request with your change.
-**We have a build action on each pull request, if this build fails, please edit the pull request in order to make this build succed.**
+**We have a build action on each pull request, if this build fails, please edit the pull request in order to make the build succeed.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,28 @@
 # Contributing
 Contributions are greatly appreciated! There are many ways to contribute to this repository:
-* [Submitting Issues](#submitting-issues)
-* [Testing Latest Versions](#testing-latest-versions)
-* [Translating](#translating)
-* [Updating the Wiki](#updating-the-wiki)
+* [Submitt Issues](#submitt-issues)
+* [Test Latest Versions](#test-latest-versions)
+* [Translate](#translate)
+* [Update the Wiki](#update-the-wiki)
 * [Fix Bugs](#fix-bugs)
 * [Add Features](#add-features)
-## Submitting Issues
+## Submitt Issues
 A great bug report contains a description of the problem and steps to reproduce the problem. We need to know what we're looking for and where to look for it.
 When reporting a bug, please make sure to provide the following information:
 * Steps to reproduce the issue
 * QUIK version
 * Device / OS information
-## Testing Latest Versions
-To do this, navigate to the release tab in this repository and click on releases. There are two types of releases in Quik. The first is the `Latest Release`.  It is colored green and is the version that goes out over the app stores. The other type is `Pre-Release`, which contains the latest features and may have bugs. To install this, download the apk from the release tab and install it on your phone. (Instructions can be found in the wiki for a more detailed explanation).
+## Test Latest Versions
+To do this, navigate to the release tab in this repository and click on releases. There are two types of releases in Quik. The first is the `Latest Release`.  This is the version that is distributed over the app stores. The other type is `Pre-Release`, which contains the latest features and may have bugs. To install this, download the apk from the release tab and install it on your phone. (Instructions can be found in the wiki for a more detailed explanation).
 Once you have done this, simply use the app as normal, and report any bugs you come across.
-## Translating 
+## Translate
 To translate this app navigate to `presentation/src/main/res` and find or make a values file with the language you wish to edit. Then copy over the `strings.xml` file from `presentation/src/main/res/values` and translate it. Please do not translate any string with the `translatable=false` attribute. Also, remember to make sure to insert a backslash `\` before any apostrophe `'` or quotes `"`.
 <!--
 ## Translations
 
 If you'd like to add translations to QUIK, please join the project on [Crowdin](https://crowdin.com/project/qksms). Translations that are committed directly to source files will not be accepted.
 -->
-## Updating the Wiki 
+## Update the Wiki 
 To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshrimpy/quik/wiki) in this repository, find the file that you need to edit, and then click `Edit Page`. Then you can edit and commit your change. For more sizeable changes, and for feedback and questions please comment in [this discussion](https://github.com/octoshrimpy/quik/discussions/174).
 ## Fix Bugs 
 1. Find a bug that needs fixing, please check the issues tab, and if the bug isn't reported, please do so before fixing it.
@@ -78,3 +78,4 @@ To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshr
         //    signingConfig signingConfigs.release
         }
     }
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 Contributions are greatly appreciated! There are many ways to contribute to this repository:
-* [Submitt Issues](#submitt-issues)
+* [Submit Issues](#submit-issues)
 * [Test Latest Versions](#test-latest-versions)
 * [Translate](#translate)
 * [Update the Wiki](#update-the-wiki)
 * [Fix Bugs](#fix-bugs)
 * [Add Features](#add-features)
-## Submitt Issues
+## Submit Issues
 A great bug report contains a description of the problem and steps to reproduce the problem. We need to know what we're looking for and where to look for it.
 When reporting a bug, please make sure to provide the following information:
 * Steps to reproduce the issue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+Contributions are greatly appreciated! There are many ways to contribute to this repository:
+* Submitting Issues
+* Testing Latest Versions
+* Translating
+* Updating the Wiki
+* Fix Bugs
+* Add Features
+## Submitting Issues
+A great bug report contains a description of the problem and steps to reproduce the problem. We need to know what we're looking for and where to look for it.
+When reporting a bug, please make sure to provide the following information:
+* Steps to reproduce the issue
+* QUIK version
+* Device / OS information
+## Testing Latest Versions
+To do this, navigate to the release tab in this repository and click on releases. There are two types of releases in Quik. The first is the `Latest Release`.  It is colored green and is the version that goes out over the app stores. The other type is `Pre-Release`, which contains the latest features and may have bugs. To install this, download the apk from the release tab and install it on your phone. (Instructions can be found in the wiki for a more detailed explanation).
+Once you have done this, simply use the app as normal, and report any bugs you come across.
+## Translating
+## Updating the Wiki
+## Fix Bugs
+## Add Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing
 Contributions are greatly appreciated! There are many ways to contribute to this repository:
-* Submitting Issues
-* Testing Latest Versions
-* Translating
-* Updating the Wiki
-* Fix Bugs
-* Add Features
+* [Submitting Issues](#submitting-Issues)
+* [Testing Latest Versions](#testing-latest-versions)
+* [Translating](#translating)
+* [Updating the Wiki](#updating-the-wiki)
+* [Fix Bugs](#fix-bugs)
+* [Add Features](#add-features)
 ## Submitting Issues
 A great bug report contains a description of the problem and steps to reproduce the problem. We need to know what we're looking for and where to look for it.
 When reporting a bug, please make sure to provide the following information:
@@ -15,7 +15,23 @@ When reporting a bug, please make sure to provide the following information:
 ## Testing Latest Versions
 To do this, navigate to the release tab in this repository and click on releases. There are two types of releases in Quik. The first is the `Latest Release`.  It is colored green and is the version that goes out over the app stores. The other type is `Pre-Release`, which contains the latest features and may have bugs. To install this, download the apk from the release tab and install it on your phone. (Instructions can be found in the wiki for a more detailed explanation).
 Once you have done this, simply use the app as normal, and report any bugs you come across.
-## Translating
-## Updating the Wiki
-## Fix Bugs
-## Add Features
+## Translating 
+To translate this app navigate to `presentation/src/main/res` and find or make a values file with the language you wish to edit. Then copy over the `strings.xml` file from `presentation/src/main/res/values` and translate it. Please do not translate any string with the `translatable=false` attribute. Also, remember to make sure to insert a backslash `\` before any apostrophe `'` or quotes `"`.
+## Updating the Wiki 
+To update the wiki, simply navigate to the wiki tab in this repository, find the file that you need to edit, and then click `Edit Page`. Then you can edit and commit your change. For more sizeable changes, and for feedback and questions please comment in [this discussion](https://github.com/octoshrimpy/quik/discussions/174).\
+## Fix Bugs 
+1. Find a bug that needs fixing, please check the issues tab, and if the bug isn't reported, please do so before fixing it.
+2. Fork the repository.
+3. Create a new branch.
+4. Make your change.
+5. Test your change, either by building an apk or running on an emulator.
+6. Submit a pull request with your change.
+**We have a build action on each pull request, if this build fails, please edit the pull request in order to make this build succed.**
+## Add Features 
+1. Submit a feature request to the issue tab, or search through the issues for a feature request that has already been submitted.
+2. Fork the repository.
+3. Create a new branch.
+4. Make your change. **Note: Please make sure to provide detailed comments within your code to make reviewers and future contributers lives easier.**
+5. Test your change, either by building an apk or running on an emulator.
+6. Submit a pull request with your change.
+**We have a build action on each pull request, if this build fails, please edit the pull request in order to make this build succed.**

--- a/README.md
+++ b/README.md
@@ -33,11 +33,8 @@ When reporting a bug, please make sure to provide the following information:
 - QUIK version
 - Device / OS information
 
-<!--
-## Translations
-
-If you'd like to add translations to QUIK, please join the project on [Crowdin](https://crowdin.com/project/qksms). Translations that are committed directly to source files will not be accepted.
--->
+## Contributing
+Contributions welcome! Please see the [contributing guidelines](https://github.com/Inhishonor/quik/blob/contributing/CONTRIBUTING.md) for details.
 
 ## Thank you
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ When reporting a bug, please make sure to provide the following information:
 - Device / OS information
 
 ## Contributing
-Contributions welcome! Please see the [contributing guidelines](https://github.com/Inhishonor/quik/blob/contributing/CONTRIBUTING.md) for details.
+Contributions welcome! Please see the [contributing guidelines](https://github.com/octoshrimpy/quik/blob/contributing/CONTRIBUTING.md) for details.
 
 ## Thank you
 


### PR DESCRIPTION
This is the same file as the one I suggested in the wiki, does it look good? If there is a better way to build locally, I can change the build configuration example. It is generally recommended to have contributing guidelines within a repository, so I thought I would add it here along with the Wiki. Please let me know if you have any changes, and I apologize if I am being presumptuous in suggesting this. Thanks!