### PR TITLE
Fix Backup and Restore being unable to read file.

### DIFF
--- a/presentation/proguard-rules.pro
+++ b/presentation/proguard-rules.pro
@@ -33,6 +33,17 @@
 # moshi
 # JSR 305 annotations are for embedding nullability information.
 -dontwarn javax.annotation.**
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE
+-dontwarn org.slf4j.Logger
+-dontwarn org.slf4j.LoggerFactory
 
 -keepclasseswithmembers class * {
     @com.squareup.moshi.* <methods>;
@@ -95,3 +106,17 @@
     <init>(...);
     <fields>;
 }
+# Dagger
+# This is to allow the restore functionality to work
+-keep class dagger.** { *; }
+-keep class * extends dagger.Module { *; }
+-keep class * extends dagger.Component { *; }
+-keep class * extends dagger.Subcomponent { *; }
+-keep class * {
+    @dagger.Provides <methods>;
+}
+-keep class io.reactivex.** { *; }
+-keep class io.reactivex.subjects.** { *; }
+-keep class androidx.activity.result.** { *; }
+-keep class dev.octoshrimpy.quik.** { *; }
+


### PR DESCRIPTION
Added additional proguard rules to allow the backup and restore functionality to access files and start a foreground service. The reason it worked in QKSMS is because their backup and restore code was different and used a file path as a string and not a URI. To use the URI, the app needed Dagger and RxJava, which was blocked by proguard. I also added a rule that keeps the package name, to allow the foreground service to start up. 
Closes #70, 
Closes #148.