### PR TITLE
fix circular update of message text and db conversation in qkreply

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/qkreply/QkReplyViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/qkreply/QkReplyViewModel.kt
@@ -104,10 +104,11 @@ class QkReplyViewModel @Inject constructor(
         super.bindView(view)
 
         conversation
-                .map { conversation -> conversation.draft }
-                .distinctUntilChanged()
-                .autoDisposable(view.scope())
-                .subscribe { draft -> view.setDraft(draft) }
+            .take(1)  // only update saved draft to ui once
+            .map { conversation -> conversation.draft }
+            .distinctUntilChanged()
+            .autoDisposable(view.scope())
+            .subscribe { draft -> view.setDraft(draft) }
 
         // Mark read
         view.menuItemIntent


### PR DESCRIPTION
fix circular update of message text and db conversation draft in qkreply causing cursor return to start of edit box

closes https://github.com/octoshrimpy/quik/issues/322

closes https://github.com/octoshrimpy/quik/issues/276