### PR TITLE
fix bug causing compose activity to finish() when it wasn't supposed to

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -187,8 +187,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val viewQksmsPlusIntent: Subject<Unit> = PublishSubject.create()
     override val backPressedIntent: Subject<Unit> = PublishSubject.create()
     override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
-    override val confirmClearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
-    override val clearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
+    override val clearCurrentMessageIntent: Subject<Boolean> = PublishSubject.create()
     override val messageLinkAskIntent: Subject<Uri> by lazy { messageAdapter.messageLinkClicks }
     override val speechRecogniserIntent by lazy { speechToTextIcon.clicks() }
     override val shadeIntent by lazy { shadeBackground.clicks() }
@@ -729,7 +728,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             .setTitle(R.string.dialog_clear_compose_title)
             .setMessage(R.string.dialog_clear_compose)
             .setPositiveButton(R.string.button_clear) { _, _ ->
-                clearCurrentMessageIntent.onNext(Unit)
+                clearCurrentMessageIntent.onNext(false)
             }
             .setNegativeButton(R.string.button_cancel, null)
             .show()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -75,8 +75,7 @@ interface ComposeView : QkView<ComposeState> {
     val viewQksmsPlusIntent: Subject<Unit>
     val backPressedIntent: Observable<Unit>
     val confirmDeleteIntent: Observable<List<Long>>
-    val confirmClearCurrentMessageIntent: Observable<Unit>
-    val clearCurrentMessageIntent: Subject<Unit>
+    val clearCurrentMessageIntent: Subject<Boolean>
     val messageLinkAskIntent: Observable<Uri>
     val speechRecogniserIntent: Observable<*>
     val shadeIntent: Observable<Unit>


### PR DESCRIPTION
fix setting haserror (which is a bit  misused to finish() the compose activity) when sending from a new convo as group.

also fix associated bug that was sending sms to individual recipients in 'send as group mode' when send as group pref was saved as true.

possibly closes https://github.com/octoshrimpy/quik/issues/320

possibly closes https://github.com/octoshrimpy/quik/issues/338

this pr _may_ also fix https://github.com/octoshrimpy/quik/issues/335 and https://github.com/octoshrimpy/quik/issues/117 because some single-recipient messages may previously have been wrongly sent using the 'send as group' code path which does not necessarily match messages to existing conversations.