### PR TITLE
fix new conversation not created for non-send-as-group multi-recipient message

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -56,7 +56,14 @@ android {
             keyPassword keystoreProps['keyPassword']
         }
     }
-
+    
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
+    
     buildTypes {
         release {
             minifyEnabled true

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -187,8 +187,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val viewQksmsPlusIntent: Subject<Unit> = PublishSubject.create()
     override val backPressedIntent: Subject<Unit> = PublishSubject.create()
     override val confirmDeleteIntent: Subject<List<Long>> = PublishSubject.create()
-    override val confirmClearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
-    override val clearCurrentMessageIntent: Subject<Unit> = PublishSubject.create()
+    override val clearCurrentMessageIntent: Subject<Boolean> = PublishSubject.create()
     override val messageLinkAskIntent: Subject<Uri> by lazy { messageAdapter.messageLinkClicks }
     override val speechRecogniserIntent by lazy { speechToTextIcon.clicks() }
     override val shadeIntent by lazy { shadeBackground.clicks() }
@@ -729,7 +728,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             .setTitle(R.string.dialog_clear_compose_title)
             .setMessage(R.string.dialog_clear_compose)
             .setPositiveButton(R.string.button_clear) { _, _ ->
-                clearCurrentMessageIntent.onNext(Unit)
+                clearCurrentMessageIntent.onNext(false)
             }
             .setNegativeButton(R.string.button_cancel, null)
             .show()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -75,8 +75,7 @@ interface ComposeView : QkView<ComposeState> {
     val viewQksmsPlusIntent: Subject<Unit>
     val backPressedIntent: Observable<Unit>
     val confirmDeleteIntent: Observable<List<Long>>
-    val confirmClearCurrentMessageIntent: Observable<Unit>
-    val clearCurrentMessageIntent: Subject<Unit>
+    val clearCurrentMessageIntent: Subject<Boolean>
     val messageLinkAskIntent: Observable<Uri>
     val speechRecogniserIntent: Observable<*>
     val shadeIntent: Observable<Unit>

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -1024,14 +1024,14 @@ class ComposeViewModel @Inject constructor(
                     return@withLatestFrom
                 }
 
-                    val subId = state.subscription?.subscriptionId ?: -1
-                    val addresses = when (conversation.recipients.isNotEmpty()) {
-                        true -> conversation.recipients.map { it.address }
-                        false -> chips.map { chip -> chip.address }
-                    }
-                    val sendAsGroup = ((addresses.size > 1) &&  // if more than one address to send to
-                            (!state.editingMode ||    // and is not a new convo
-                            state.sendAsGroup))  // or (is a new convo and) send as group is selected
+                val subId = state.subscription?.subscriptionId ?: -1
+                val addresses = when (conversation.recipients.isNotEmpty()) {
+                    true -> conversation.recipients.map { it.address }
+                    false -> chips.map { chip -> chip.address }
+                }
+                val sendAsGroup = ((addresses.size > 1) &&  // if more than one address to send to
+                        (!state.editingMode ||    // and is not a new convo
+                        state.sendAsGroup))  // or (is a new convo and) send as group is selected
 
                 when {
                     // Scheduling a message


### PR DESCRIPTION
fix no creation of a new conversation when no existing conversation to member of a multi-recipient sms not sent as group.

steps to reproduce existing bug;
1. compose new message to no recipients using floating '+' button on main activity
2. add a recipient with existing message(s) in their conversation
3. then also add a recipient with no existing messages/conversation
4. enter a message body
5. send >
6. check sent conversations list in main activity;
7. recipient with existing conversation will have sent message in their conversation
8. recipient with no existing conversation will not have a new conversation created with the new message

encountered this bug whilst testing for pr https://github.com/octoshrimpy/quik/pull/344