### PR TITLE
dial last non-me party in a group convo

### DIFF
--- a/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
@@ -29,6 +29,8 @@ interface MessageRepository {
 
     fun getMessages(threadId: Long, query: String = ""): RealmResults<Message>
 
+    fun getMessagesSync(threadId: Long, query: String = ""): RealmResults<Message>
+
     fun getMessage(id: Long): Message?
 
     fun getMessageForPart(id: Long): Message?

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -359,12 +359,14 @@ class ComposeViewModel @Inject constructor(
 
         // Open the phone dialer if the call button is clicked
         view.optionsItemIntent
-                .filter { it == R.id.call }
-                .withLatestFrom(conversation) { _, conversation -> conversation }
-                .mapNotNull { conversation -> conversation.recipients.firstOrNull() }
-                .map { recipient -> recipient.address }
-                .autoDisposable(view.scope())
-                .subscribe { address -> navigator.makePhoneCall(address) }
+            .filter { it == R.id.call }
+            .withLatestFrom(state, conversation)
+            .mapNotNull { (_, state, conversation) ->
+                state.messages?.second?.lastOrNull { !it.isMe() }?.address // most recent non-me msg address
+                    ?: conversation.recipients.firstOrNull()?.address  // first recipient in convo
+            }
+            .autoDisposable(view.scope())
+            .subscribe { navigator.makePhoneCall(it) }
 
         // Open the conversation settings if info button is clicked
         view.optionsItemIntent


### PR DESCRIPTION
change to start dial of last 'not me' recipient in a conversation in compose, qkreply and main-activity-swipe call actions.

for single recipient convos nothing changes - the other convo party is dialled.

for group chats, convo messages are checked in reverse chrono order for the most previous message from 'not me' and that recipient is dialled. if a message from 'not me' is not found in the group convo, the present functionality is retained - ie  the first recipient listed in the group chat is dialled.

closes https://github.com/octoshrimpy/quik/issues/59