### PR TITLE
ui changes to make attach menu properly visible in dark (and light) theme

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ViewExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ViewExtensions.kt
@@ -59,6 +59,12 @@ fun ImageView.setTint(color: Int?) {
         else ColorStateList.valueOf(color)
 }
 
+fun TextView.setTint(color: Int?) {
+    foregroundTintList =
+        if (color == null) null
+        else ColorStateList.valueOf(color)
+}
+
 fun ProgressBar.setTint(color: Int?) {
     indeterminateTintList =
         if (color == null) null
@@ -66,7 +72,6 @@ fun ProgressBar.setTint(color: Int?) {
     progressTintList =
         if (color == null) null
         else ColorStateList.valueOf(color)
-
 }
 
 fun View.setBackgroundTint(color: Int?) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -68,6 +68,7 @@ import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkThemedActivity
 import dev.octoshrimpy.quik.common.util.DateFormatter
 import dev.octoshrimpy.quik.common.util.extensions.autoScrollToStart
+import dev.octoshrimpy.quik.common.util.extensions.dpToPx
 import dev.octoshrimpy.quik.common.util.extensions.hideKeyboard
 import dev.octoshrimpy.quik.common.util.extensions.makeToast
 import dev.octoshrimpy.quik.common.util.extensions.scrapViews
@@ -268,22 +269,40 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             message.supportsInputContent = true
 
             theme
-                .doOnNext { loading.setTint(it.theme) }
-                .doOnNext { attach.setBackgroundTint(it.theme) }
-                .doOnNext { attach.setTint(it.textPrimary) }
-                .doOnNext { speechToTextIconBorder.setBackgroundTint(it.theme) }
-                .doOnNext { speechToTextIcon.setBackgroundTint(it.textPrimary) }
-                .doOnNext { speechToTextIcon.setTint(it.theme) }
-                .doOnNext { audioMsgRecord.setColor(it.theme) }
-                .doOnNext { audioMsgPlayerPlayPause.setTint(it.theme) }
                 .doOnNext {
+                    loading.setTint(it.theme)
+
+                    // entire attach menu
+                    attach.setBackgroundTint(it.theme); attach.setTint(it.textPrimary)
+                    contact.setBackgroundTint(it.theme); contact.setTint(it.textPrimary)
+                    contactLabel.setBackgroundTint(it.theme); contactLabel.setTint(it.textPrimary)
+                    schedule.setBackgroundTint(it.theme); schedule.setTint(it.textPrimary)
+                    scheduleLabel.setBackgroundTint(it.theme); scheduleLabel.setTint(it.textPrimary)
+                    attachAFileIcon.setBackgroundTint(it.theme); attachAFileIcon.setTint(it.textPrimary)
+                    attachAFileLabel.setBackgroundTint(it.theme); attachAFileLabel.setTint(it.textPrimary)
+                    attachAnAudioMessageIcon.setBackgroundTint(it.theme); attachAnAudioMessageIcon.setTint(it.textPrimary)
+                    attachAnAudioMessageLabel.setBackgroundTint(it.theme); attachAnAudioMessageLabel.setTint(it.textPrimary)
+                    gallery.setBackgroundTint(it.theme); gallery.setTint(it.textPrimary)
+                    galleryLabel.setBackgroundTint(it.theme); galleryLabel.setTint(it.textPrimary)
+                    camera.setBackgroundTint(it.theme); camera.setTint(it.textPrimary)
+                    cameraLabel.setBackgroundTint(it.theme); cameraLabel.setTint(it.textPrimary)
+
+                    // speech to text floating button
+                    speechToTextIconBorder.setBackgroundTint(it.theme)
+                    speechToTextIcon.setBackgroundTint(it.textPrimary)
+                    speechToTextIcon.setTint(it.theme)
+
+                    // audio message recording
+                    audioMsgRecord.setColor(it.theme)
+                    audioMsgPlayerPlayPause.setTint(it.theme)
                     audioMsgPlayerSeekBar.apply {
                         thumbTintList = ColorStateList.valueOf(it.theme)
                         progressBackgroundTintList = ColorStateList.valueOf(it.theme)
                         progressTintList = ColorStateList.valueOf(it.theme)
                     }
+
+                    messageAdapter.theme = it
                 }
-                .doOnNext { messageAdapter.theme = it }
                 .autoDisposable(scope())
                 .subscribe()
 
@@ -505,9 +524,21 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
         attach.animate().rotation(if (state.attaching) 135f else 0f).start()
         attaching.isVisible = state.attaching
 
-        shadeBackground.visibility =
-            if (state.attaching || state.audioMsgRecording) View.VISIBLE
-            else View.GONE
+        shadeBackground.apply {
+            when {
+                state.attaching -> {
+                    visibility = View.VISIBLE
+                    elevation = 4.dpToPx(context).toFloat() // below attach menu
+                }
+
+                state.audioMsgRecording -> {
+                    visibility = View.VISIBLE
+                    elevation = 5.dpToPx(context).toFloat() // above attach menu
+                }
+
+                else-> visibility = View.GONE
+            }
+        }
 
         // show or hide audio message recording panel and shade background
         audioMsgBackground.isVisible = state.audioMsgRecording

--- a/presentation/src/main/res/layout/compose_activity.xml
+++ b/presentation/src/main/res/layout/compose_activity.xml
@@ -33,7 +33,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="12dp"
         android:layout_marginEnd="12dp"
-        android:elevation="4dp"
+        android:elevation="3dp"
         android:padding="8dp"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
@@ -406,7 +406,7 @@
         android:id="@+id/shadeBackground"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:background="#44000000"
+        android:background="#aa000000"
         android:elevation="4dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -421,7 +421,7 @@
         android:layout_height="40dp"
         android:layout_marginBottom="12dp"
         android:background="@drawable/circle"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:contentDescription="@string/compose_contact_cd"
         android:elevation="4dp"
         android:padding="10dp"
@@ -430,7 +430,7 @@
         app:layout_constraintBottom_toTopOf="@id/schedule"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach"
-        app:tint="?android:attr/textColorSecondary" />
+        app:tint="@color/textPrimaryDark" />
 
     <dev.octoshrimpy.quik.common.widget.QkTextView
         android:id="@+id/contactLabel"
@@ -438,13 +438,13 @@
         android:layout_height="32dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/rounded_rectangle_4dp"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:elevation="4dp"
         android:gravity="center_vertical"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:text="@string/compose_contact_cd"
-        android:textColor="?android:attr/textColorPrimary"
+        android:textColor="@color/textPrimaryDark"
         app:layout_constraintBottom_toBottomOf="@id/contact"
         app:layout_constraintStart_toEndOf="@id/contact"
         app:layout_constraintTop_toTopOf="@id/contact" />
@@ -455,7 +455,7 @@
         android:layout_height="40dp"
         android:layout_marginBottom="12dp"
         android:background="@drawable/circle"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:contentDescription="@string/compose_schedule_cd"
         android:elevation="4dp"
         android:padding="10dp"
@@ -464,7 +464,7 @@
         app:layout_constraintBottom_toTopOf="@id/attachAFileIcon"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach"
-        app:tint="?android:attr/textColorSecondary" />
+        app:tint="@color/textPrimaryDark" />
 
     <dev.octoshrimpy.quik.common.widget.QkTextView
         android:id="@+id/scheduleLabel"
@@ -472,13 +472,13 @@
         android:layout_height="32dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/rounded_rectangle_4dp"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:elevation="4dp"
         android:gravity="center_vertical"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:text="@string/compose_schedule_cd"
-        android:textColor="?android:attr/textColorPrimary"
+        android:textColor="@color/textPrimaryDark"
         app:layout_constraintBottom_toBottomOf="@id/schedule"
         app:layout_constraintStart_toEndOf="@id/schedule"
         app:layout_constraintTop_toTopOf="@id/schedule" />
@@ -489,7 +489,7 @@
         android:layout_height="40dp"
         android:layout_marginBottom="12dp"
         android:background="@drawable/circle"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:contentDescription="@string/compose_attach_file_cd"
         android:elevation="4dp"
         android:padding="10dp"
@@ -499,7 +499,7 @@
         app:layout_constraintBottom_toTopOf="@id/attachAnAudioMessageIcon"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach"
-        app:tint="?android:attr/textColorSecondary" />
+        app:tint="@color/textPrimaryDark" />
 
     <dev.octoshrimpy.quik.common.widget.QkTextView
         android:id="@+id/attachAFileLabel"
@@ -507,13 +507,13 @@
         android:layout_height="32dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/rounded_rectangle_4dp"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:elevation="4dp"
         android:gravity="center_vertical"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:text="@string/compose_attach_file_cd"
-        android:textColor="?android:attr/textColorPrimary"
+        android:textColor="@color/textPrimaryDark"
         app:layout_constraintBottom_toBottomOf="@id/attachAFileIcon"
         app:layout_constraintStart_toEndOf="@id/attachAFileIcon"
         app:layout_constraintTop_toTopOf="@id/attachAFileIcon" />
@@ -524,7 +524,7 @@
         android:layout_height="40dp"
         android:layout_marginBottom="12dp"
         android:background="@drawable/circle"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:contentDescription="@string/compose_audio_message_cd"
         android:elevation="4dp"
         android:padding="10dp"
@@ -533,7 +533,7 @@
         app:layout_constraintBottom_toTopOf="@id/gallery"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach"
-        app:tint="?android:attr/textColorSecondary" />
+        app:tint="@color/textPrimaryDark" />
 
     <dev.octoshrimpy.quik.common.widget.QkTextView
         android:id="@+id/attachAnAudioMessageLabel"
@@ -541,13 +541,13 @@
         android:layout_height="32dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/rounded_rectangle_4dp"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:elevation="4dp"
         android:gravity="center_vertical"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:text="@string/compose_audio_message_cd"
-        android:textColor="?android:attr/textColorPrimary"
+        android:textColor="@color/textPrimaryDark"
         app:layout_constraintBottom_toBottomOf="@id/attachAnAudioMessageIcon"
         app:layout_constraintStart_toEndOf="@id/attachAnAudioMessageIcon"
         app:layout_constraintTop_toTopOf="@id/attachAnAudioMessageIcon" />
@@ -558,7 +558,7 @@
         android:layout_height="40dp"
         android:layout_marginBottom="12dp"
         android:background="@drawable/circle"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:contentDescription="@string/compose_gallery_cd"
         android:elevation="4dp"
         android:padding="10dp"
@@ -567,7 +567,7 @@
         app:layout_constraintBottom_toTopOf="@id/camera"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach"
-        app:tint="?android:attr/textColorSecondary" />
+        app:tint="@color/textPrimaryDark" />
 
     <dev.octoshrimpy.quik.common.widget.QkTextView
         android:id="@+id/galleryLabel"
@@ -575,13 +575,13 @@
         android:layout_height="32dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/rounded_rectangle_4dp"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:elevation="4dp"
         android:gravity="center_vertical"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:text="@string/compose_gallery_cd"
-        android:textColor="?android:attr/textColorPrimary"
+        android:textColor="@color/textPrimaryDark"
         app:layout_constraintBottom_toBottomOf="@id/gallery"
         app:layout_constraintStart_toEndOf="@id/gallery"
         app:layout_constraintTop_toTopOf="@id/gallery" />
@@ -592,7 +592,7 @@
         android:layout_height="40dp"
         android:layout_marginBottom="16dp"
         android:background="@drawable/circle"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:contentDescription="@string/compose_camera_cd"
         android:elevation="4dp"
         android:padding="10dp"
@@ -601,7 +601,7 @@
         app:layout_constraintBottom_toTopOf="@id/attach"
         app:layout_constraintEnd_toEndOf="@id/attach"
         app:layout_constraintStart_toStartOf="@id/attach"
-        app:tint="?android:attr/textColorSecondary" />
+        app:tint="@color/textPrimaryDark" />
 
     <dev.octoshrimpy.quik.common.widget.QkTextView
         android:id="@+id/cameraLabel"
@@ -609,13 +609,13 @@
         android:layout_height="32dp"
         android:layout_marginStart="8dp"
         android:background="@drawable/rounded_rectangle_4dp"
-        android:backgroundTint="?attr/bubbleColor"
+        android:backgroundTint="@color/tools_theme"
         android:elevation="4dp"
         android:gravity="center_vertical"
         android:paddingStart="8dp"
         android:paddingEnd="8dp"
         android:text="@string/compose_camera_cd"
-        android:textColor="?android:attr/textColorPrimary"
+        android:textColor="@color/textPrimaryDark"
         app:layout_constraintBottom_toBottomOf="@id/camera"
         app:layout_constraintStart_toEndOf="@id/gallery"
         app:layout_constraintTop_toTopOf="@id/camera" />


### PR DESCRIPTION
made background shade darker on compose activity (when attach menu activated and when audio record panel activated)

changed attach menu items to match back and fore theme of attach button

also fixed bug of attach button being touchable when audio record panel visible


closes https://github.com/octoshrimpy/quik/issues/336

new look - dark;
![image](https://github.com/user-attachments/assets/45daa89f-a3eb-41f2-b97b-791b5c64e5ac)


new look - light;
![image](https://github.com/user-attachments/assets/780ec95c-187b-4a0a-8f7c-af3911d97796)

