### PR TITLE
ui - change compose activity bubble text selection colors

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -22,6 +22,7 @@ import android.animation.ObjectAnimator
 import android.content.Context
 import android.graphics.Typeface
 import android.net.Uri
+import android.os.Build
 import android.text.Layout
 import android.text.Spannable
 import android.text.SpannableString
@@ -49,6 +50,7 @@ import dev.octoshrimpy.quik.common.util.extensions.setBackgroundTint
 import dev.octoshrimpy.quik.common.util.extensions.setPadding
 import dev.octoshrimpy.quik.common.util.extensions.setTint
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
+import dev.octoshrimpy.quik.common.util.extensions.withAlpha
 import dev.octoshrimpy.quik.compat.SubscriptionManagerCompat
 import dev.octoshrimpy.quik.extensions.isSmil
 import dev.octoshrimpy.quik.extensions.isText
@@ -276,6 +278,19 @@ class MessagesAdapter @Inject constructor(
 
             holder.body.setTextColor(theme.textPrimary)
             holder.body.setBackgroundTint(theme.theme)
+            holder.body.highlightColor = R.attr.bubbleColor.withAlpha(0x5d)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                holder.body.textSelectHandle?.setTint(R.attr.bubbleColor.withAlpha(0x7d))
+                holder.body.textSelectHandleLeft?.setTint(R.attr.bubbleColor.withAlpha(0x7d))
+                holder.body.textSelectHandleRight?.setTint(R.attr.bubbleColor.withAlpha(0x7d))
+            }
+        } else {
+            holder.body.highlightColor = theme.theme.withAlpha(0x5d)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                holder.body.textSelectHandle?.setTint(theme.theme.withAlpha(0xad))
+                holder.body.textSelectHandleLeft?.setTint(theme.theme.withAlpha(0xad))
+                holder.body.textSelectHandleRight?.setTint(theme.theme.withAlpha(0xad))
+            }
         }
 
         // Bind the body text


### PR DESCRIPTION
change text selection handles and background colors in compose screen bubbles to use dynamic color values to ensure they always have a high contrast to bubble colours and to match with theme colors

note: selection handles can only have color changed in api 29+ / version_codes.q+. selected text background should always have color changed

closes https://github.com/octoshrimpy/quik/issues/248  which was experiencing some hot teal on teal action

examples. dark theme - teal;
![image](https://github.com/user-attachments/assets/6370c3c7-0c58-4cf0-adf5-b3eb30c79056)    ![image](https://github.com/user-attachments/assets/1d1d6e27-b18d-485d-88f8-4df563adc527)

dark theme - blue;
![image](https://github.com/user-attachments/assets/f4b5b51d-dbe0-4441-ac3d-a599937acc88)     ![image](https://github.com/user-attachments/assets/9365050e-d0a1-4e6e-a0d6-d234cad77356)

light theme - teal;
![image](https://github.com/user-attachments/assets/b755315f-072c-4512-b7fe-6177a527d608)    ![image](https://github.com/user-attachments/assets/db9648d9-712c-4c29-a00b-37e641ed8faa)


light theme - purple;
![image](https://github.com/user-attachments/assets/360cfaa3-6fa6-4244-bfab-d5533cb54257)    ![image](https://github.com/user-attachments/assets/cda562ef-5997-4114-a0fa-8f68cdadea0e)



