### PR TITLE
do not save draft text when adding new recipients to group convo

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
@@ -48,4 +48,5 @@ data class ComposeState(
     val canSend: Boolean = false,
     val validRecipientNumbers: Int = 1,
     val audioMsgRecording: Boolean = false,
+    val saveDraft: Boolean = true,
 )

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -328,6 +328,7 @@ class ComposeViewModel @Inject constructor(
         view.optionsItemIntent
                 .filter { it == R.id.add }
                 .withLatestFrom(selectedChips) { _, chips ->
+                    newState { copy(saveDraft = false) }  // do not save draft on next activity invisibility
                     view.showContacts(sharing, chips)
                 }
                 .autoDisposable(view.scope())
@@ -641,8 +642,10 @@ class ComposeViewModel @Inject constructor(
                 .withLatestFrom(conversation) { _, conversation -> conversation }
                 .mapNotNull { conversation -> conversation.takeIf { it.isValid }?.id }
                 .observeOn(Schedulers.io())
-                .withLatestFrom(view.textChangedIntent) { threadId, draft ->
-                    conversationRepo.saveDraft(threadId, draft.toString())
+                .withLatestFrom(view.textChangedIntent, state) { threadId, draftText, state ->
+                    if (state.saveDraft)
+                        conversationRepo.saveDraft(threadId, draftText.toString())
+                    newState { copy(saveDraft = true) }
                 }
                 .autoDisposable(view.scope())
                 .subscribe()


### PR DESCRIPTION
change to not save sms body input text as draft between adding new recipients to sms on compose screen.

solves issue below, but also in the following scenario;

1. click floating + button on main activity (new sms)
2. select a contact/existing convo
3. start typing text into sms body input box
4. add a new contact/existing convo
5. previously, the text entered before the second recipient was added was saved as draft in first added contact's convo, now it isn't

closes https://github.com/octoshrimpy/quik/issues/187