### PR TITLE
Upload app apk to github

### DIFF
--- a/.github/workflows/build-on-pull.yml
+++ b/.github/workflows/build-on-pull.yml
@@ -31,8 +31,14 @@ jobs:
     - name: Run Tests
       run: ./gradlew test
 
-    - name: Deploy Artifacts
+    - name: List APK Output Directory 
+      run: ls -R presentation/build/outputs/apk/noAnalytics/debug
+
+    - name: Rename APK
+      run: mv presentation/build/outputs/apk/noAnalytics/debug/QUIK-v*-noAnalytics-debug.apk presentation/build/outputs/apk/noAnalytics/debug/QUIK-noAnalytics-debug.apk
+      
+    - name: Upload App
       uses: actions/upload-artifact@v4
       with:
-        name: build-artifacts
-        path: build/libs/
+        name: apk
+        path: presentation/build/outputs/apk/noAnalytics/debug/QUIK-noAnalytics-debug.apk


### PR DESCRIPTION
This pr sets up the build-on-pull workflow to automatically upload an apk of each pull request. This will allow for easier testing and will help with debugging.
Satisfies [this request](https://github.com/octoshrimpy/quik/issues/269#issuecomment-2648448795) and [this comment](https://github.com/octoshrimpy/quik/pull/239#issuecomment-2691867028). 