### PR TITLE
speed up convo activity (de)select all

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/ClipboardUtils.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/ClipboardUtils.kt
@@ -21,13 +21,25 @@ package dev.octoshrimpy.quik.common.util
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.widget.Toast
+import dev.octoshrimpy.quik.R
 
 object ClipboardUtils {
 
     fun copy(context: Context, string: String) {
-        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val clip = ClipData.newPlainText("SMS", string)
-        clipboard.setPrimaryClip(clip)
+        try {
+            (context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
+                .setPrimaryClip(ClipData.newPlainText("SMS", string))
+        } catch (e: Exception) {
+            Toast.makeText(
+                context,
+                if ((e is RuntimeException) &&
+                    e.message?.startsWith("android.os.TransactionTooLargeException") == true
+                ) R.string.clipboard_too_large_to_copy
+                else R.string.clipboard_unable_to_copy_to,
+                Toast.LENGTH_LONG
+            ).show()
+        }
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -381,18 +381,18 @@ class ComposeViewModel @Inject constructor(
                 .filter { it == R.id.copy }
                 .withLatestFrom(view.messagesSelectedIntent) { _, messageIds ->
                     val messages = messageIds.mapNotNull(messageRepo::getMessage).sortedBy { it.date }
-                    val text = when (messages.size) {
-                        1 -> messages.first().getText()
-                        else -> messages.foldIndexed("") { index, acc, message ->
+                    ClipboardUtils.copy(
+                        context,
+                        messages.foldIndexed(StringBuilder()) { index, acc, message ->
                             when {
-                                index == 0 -> message.getText()
-                                messages[index - 1].compareSender(message) -> "$acc\n${message.getText()}"
-                                else -> "$acc\n\n${message.getText()}"
+                                index == 0 ->
+                                    acc.append(message.getText())
+                                messages[index - 1].compareSender(message) ->
+                                    acc.appendLine().append(message.getText())
+                                else ->
+                                    acc.appendLine().appendLine().append(message.getText())
                             }
-                        }
-                    }
-
-                    ClipboardUtils.copy(context, text)
+                        }.toString())
                 }
                 .autoDisposable(view.scope())
                 .subscribe { view.clearSelection() }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -237,6 +237,9 @@
     <string name="backup_progress_finished">Finished!</string>
     <string name="backup_notification_channel_name">Backup and restore</string>
 
+    <string name="clipboard_too_large_to_copy">Data size exceeds clipboard limit</string>
+    <string name="clipboard_unable_to_copy_to">Unable to copy to the clipboard</string>
+
     <string name="scheduled_title">Scheduled</string>
     <string name="scheduled_empty_description">Automatically send a message, at the exact moment you\'d like</string>
     <string name="scheduled_empty_message_1">Hey! When was your birthday again?</string>


### PR DESCRIPTION
speed up convo activity toggle (de)select all - particularly for large numbers of messages.
also speed up  copy text menu item on convo screen.

selection time...  before: 80790 msgs in 1m 3s.
after:

https://github.com/user-attachments/assets/cfe81599-af62-4142-9003-641ce7d3936c


