### PR TITLE
Fix Filter Logic to search by group conversation title.

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/filter/ConversationFilter.kt
+++ b/data/src/main/java/com/moez/QKSMS/filter/ConversationFilter.kt
@@ -24,7 +24,9 @@ import javax.inject.Inject
 class ConversationFilter @Inject constructor(private val recipientFilter: RecipientFilter) : Filter<Conversation>() {
 
     override fun filter(item: Conversation, query: CharSequence): Boolean {
+        if (item.name.contains(query, ignoreCase = true)) {
+            return true
+        }
         return item.recipients.any { recipient -> recipientFilter.filter(recipient, query) }
     }
-
 }


### PR DESCRIPTION
This fixes a bug where renamed conversations were not included in conversation search.
Closes #63 