### PR TITLE
Added a setting to disable screenshots.

### DIFF
--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -132,6 +132,7 @@ class Preferences @Inject constructor(
     val longAsMms = rxPrefs.getBoolean("longAsMms", false)
     val mmsSize = rxPrefs.getInteger("mmsSize", 300)
     val messageLinkHandling = rxPrefs.getInteger("messageLinkHandling", MESSAGE_LINK_HANDLING_ASK)
+    val disableScreenshots = rxPrefs.getBoolean("disableScreenshots", false)
     val logging = rxPrefs.getBoolean("logging", false)
     val unreadAtTop = rxPrefs.getBoolean("unreadAtTop", false)
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkActivity.kt
@@ -22,12 +22,16 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
+import dev.octoshrimpy.quik.util.Preferences
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
 import kotlinx.android.synthetic.main.toolbar.*
+import javax.inject.Inject
 
 abstract class QkActivity : AppCompatActivity() {
+    @Inject lateinit var prefs: Preferences
 
     protected val menu: Subject<Menu> = BehaviorSubject.create()
 
@@ -35,6 +39,12 @@ abstract class QkActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         onNewIntent(intent)
+        disableScreenshots(prefs.disableScreenshots.get())
+    }
+
+    override fun onResume() {
+        super.onResume()
+        disableScreenshots(prefs.disableScreenshots.get())
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -72,6 +82,14 @@ abstract class QkActivity : AppCompatActivity() {
 
     protected open fun showBackButton(show: Boolean) {
         supportActionBar?.setDisplayHomeAsUpEnabled(show)
+    }
+
+    private fun disableScreenshots(disableScreenshots: Boolean) {
+        if (disableScreenshots) {
+            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkThemedActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkThemedActivity.kt
@@ -36,7 +36,6 @@ import dev.octoshrimpy.quik.extensions.mapNotNull
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.repository.MessageRepository
 import dev.octoshrimpy.quik.util.PhoneNumberUtils
-import dev.octoshrimpy.quik.util.Preferences
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import io.reactivex.Observable
@@ -60,7 +59,6 @@ abstract class QkThemedActivity : QkActivity() {
     @Inject lateinit var conversationRepo: ConversationRepository
     @Inject lateinit var messageRepo: MessageRepository
     @Inject lateinit var phoneNumberUtils: PhoneNumberUtils
-    @Inject lateinit var prefs: Preferences
 
     /**
      * In case the activity should be themed for a specific conversation, the selected conversation

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsController.kt
@@ -203,6 +203,8 @@ class SettingsController : QkController<SettingsView, SettingsState, SettingsPre
         messsageLinkHandling.summary = state.messageLinkHandlingSummary
         messageLinkHandlingDialog.adapter.selectedItem = state.messageLinkHandlingId
 
+        disableScreenshots.checkbox.isChecked = state.disableScreenshotsEnabled
+
         when (state.syncProgress) {
             is SyncRepository.SyncProgress.Idle -> syncingProgress.isVisible = false
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -153,6 +153,8 @@ class SettingsPresenter @Inject constructor(
                     )
                 }
             }
+        disposables += prefs.disableScreenshots.asObservable()
+            .subscribe { enabled -> newState { copy(disableScreenshotsEnabled = enabled) } }
 
         disposables += syncRepo.syncProgress
                 .sample(16, TimeUnit.MILLISECONDS)
@@ -227,6 +229,8 @@ class SettingsPresenter @Inject constructor(
                         R.id.mmsSize -> view.showMmsSizePicker()
 
                         R.id.messsageLinkHandling -> view.showMessageLinkHandlingDialogPicker()
+
+                        R.id.disableScreenshots -> prefs.disableScreenshots.set(!prefs.disableScreenshots.get())
 
                         R.id.sync -> syncMessages.execute(Unit)
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsState.kt
@@ -51,5 +51,6 @@ data class SettingsState(
     val maxMmsSizeId: Int = 100,
     val messageLinkHandlingSummary: String = "Ask before opening",
     val messageLinkHandlingId: Int = 2,
+    val disableScreenshotsEnabled: Boolean = false,
     val syncProgress: SyncRepository.SyncProgress = SyncRepository.SyncProgress.Idle
 )

--- a/presentation/src/main/res/drawable/ic_screenshot.xml
+++ b/presentation/src/main/res/drawable/ic_screenshot.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M480,680L480,620L580,620L580,520L640,520L640,680L480,680ZM320,440L320,280L480,280L480,340L380,340L380,440L320,440ZM280,920Q247,920 223.5,896.5Q200,873 200,840L200,120Q200,87 223.5,63.5Q247,40 280,40L680,40Q713,40 736.5,63.5Q760,87 760,120L760,840Q760,873 736.5,896.5Q713,920 680,920L280,920ZM280,720L680,720L680,240L280,240L280,720Z"/>
+</vector>

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -229,6 +229,15 @@
             app:title="@string/settings_mms_weblink_title"
             tools:summary="100KB" />
 
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/disableScreenshots"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_screenshot"
+            app:summary="@string/settings_diable_screenshots_summary"
+            app:title="@string/settings_disable_screenshots_title"
+            app:widget="@layout/settings_switch_widget" />
+
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -324,6 +324,8 @@
     <string name="settings_long_as_mms_summary">If your longer text messages are failing to send, or sending in the wrong order, you can send them as MMS messages instead. Additional charges may apply</string>
     <string name="settings_mms_size_title">Auto-compress MMS image attachments</string>
     <string name="settings_mms_weblink_title">Link handling in messages</string>
+    <string name="settings_disable_screenshots_title">Disable Screenshots</string>
+    <string name="settings_diable_screenshots_summary">Prevent your OS and other apps from taking screenshots of the app.</string>
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>


### PR DESCRIPTION
I added a setting to enable `SECURE_FLAG` for the app. This doesn't hide the app's contents immediately when in the app switcher but does disable screenshots. I am leaving it off by default as the conversation in #136 seemed to be leaning that way.
Closes #136
Closes #355 