### PR TITLE
limit convo bubble text to 5000 chars

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/util/Constants.kt
+++ b/data/src/main/java/com/moez/QKSMS/util/Constants.kt
@@ -1,0 +1,7 @@
+package com.moez.QKSMS.util
+
+class Constants {
+    companion object {
+        const val SAVED_MESSAGE_TEXT_FILE_PREFIX = "QuikSmsText-"
+    }
+}

--- a/data/src/main/java/com/moez/QKSMS/util/FileUtils.kt
+++ b/data/src/main/java/com/moez/QKSMS/util/FileUtils.kt
@@ -1,0 +1,149 @@
+package dev.octoshrimpy.quik.util
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.core.content.contentValuesOf
+import androidx.core.net.toFile
+import dev.octoshrimpy.quik.extensions.isEmpty
+import java.io.File
+
+class FileUtils {
+    companion object {
+        enum class Location {
+            Downloads,
+            ExternalCache,
+            Cache,
+            Files,
+            Obb,
+            CodeCache,
+            NoBackup,
+        }
+
+        fun create(
+            location: Location,
+            context: Context,
+            filename: String,
+            mimeType: String
+        ) =
+            if (location == Location.Downloads) createDownloadsFile(context, filename, mimeType)
+            else createLocation(location, context, filename)
+
+        private fun createDownloadsFile(
+            context: Context,
+            filename: String,
+            mimeType: String
+        ): Pair<Uri, Exception?> =
+            try {
+                val uri = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) { // use media store
+                    context.contentResolver.insert(
+                        MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+                        contentValuesOf(
+                            MediaStore.MediaColumns.MIME_TYPE to mimeType,
+                            MediaStore.MediaColumns.RELATIVE_PATH to
+                                    Environment.DIRECTORY_DOWNLOADS,
+                            MediaStore.MediaColumns.DISPLAY_NAME to filename,
+                        )
+                    ) ?: Uri.EMPTY
+                } else { // use direct access to 'external' dir
+                    File(Environment.getExternalStorageDirectory(), filename).let {
+                        if (tryOrNull { it.createNewFile() } == true) Uri.fromFile(it)
+                        else Uri.EMPTY
+                    }
+                }
+
+                if (uri.isEmpty())
+                    throw Exception("Opening file returned an empty uri")
+
+                Pair(uri, null)
+            } catch (e: Exception) {
+                Pair(Uri.EMPTY, e)
+            }
+
+        private fun createLocation(
+            location: Location,
+            context: Context,
+            filename: String
+        ): Pair<Uri, Exception?> =
+            try {
+                val uri = File(
+                    when (location) {
+                        Location.ExternalCache -> context.externalCacheDir
+                        Location.Files -> context.filesDir
+                        Location.Obb -> context.obbDir
+                        Location.CodeCache -> context.codeCacheDir
+                        Location.NoBackup -> context.noBackupFilesDir
+                        else -> context.cacheDir
+                    },
+                    filename
+                ).let {
+                    if (tryOrNull { it.createNewFile() } == true) Uri.fromFile(it)
+                    else Uri.EMPTY
+                }
+
+                if (uri.isEmpty())
+                    throw Exception("Opening file returned an empty uri")
+
+                Pair(uri, null)
+            } catch (e: Exception) {
+                Pair(Uri.EMPTY, e)
+            }
+
+        private fun writeBytes(
+            context: Context,
+            uri: Uri,
+            bytes: ByteArray,
+            mode: String
+        ): Exception? =
+            try {
+                context.contentResolver.openOutputStream(uri, mode)?.use { it.write(bytes) }
+                null
+            } catch (e: Exception) {
+                e
+            }
+
+        fun append(context: Context, uri: Uri, bytes: ByteArray): Exception? =
+            writeBytes(context, uri, bytes, "wa")
+
+        fun write(context: Context, uri: Uri, bytes: ByteArray): Exception? =
+            writeBytes(context, uri, bytes, "w")
+
+        fun truncateAndWrite(context: Context, uri: Uri, bytes: ByteArray): Exception? =
+            writeBytes(context, uri, bytes, "wt")
+
+        fun createAndWrite(
+            context: Context,
+            location: Location,
+            filename: String,
+            mimeType: String,
+            bytes: ByteArray
+        ): Pair<Uri, Exception?> =
+            create(location, context, filename, mimeType).let { (uri, e) ->
+                if (e is Exception) Pair(Uri.EMPTY, e)
+                else {
+                    val we = writeBytes(context, uri, bytes, "w")
+                    if (we is Exception) {
+                        deleteFile(uri)
+                        Pair(Uri.EMPTY, we)
+                    }
+                    else
+                        Pair(uri, null)
+                }
+            }
+
+        fun deleteFile(uri: Uri): Boolean {
+            return try {
+                if (uri == Uri.EMPTY) false
+                else uri.toFile().delete()
+            }
+            catch (e: Exception) { false }
+        }
+
+        fun renameTo(fromUri: Uri, toUri: Uri) {
+            fromUri.toFile().renameTo(toUri.toFile())
+        }
+    }
+
+}

--- a/domain/src/main/AndroidManifest.xml
+++ b/domain/src/main/AndroidManifest.xml
@@ -25,6 +25,17 @@
             android:exported="false"
             android:grantUriPermissions="true">
         </provider>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="dev.octoshrimpy.quik.messagesText"
+            android:enabled="true"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/messages_text_file_provider_paths" />
+        </provider>
     </application>
 
     <queries>

--- a/domain/src/main/java/com/moez/QKSMS/extensions/LongExtensions.kt
+++ b/domain/src/main/java/com/moez/QKSMS/extensions/LongExtensions.kt
@@ -1,0 +1,7 @@
+package dev.octoshrimpy.quik.extensions
+
+import java.util.concurrent.TimeUnit
+
+fun Long.millisecondsToMinutes(): Long {
+    return TimeUnit.MILLISECONDS.toMinutes(this)
+}

--- a/domain/src/main/java/com/moez/QKSMS/extensions/StringExtensions.kt
+++ b/domain/src/main/java/com/moez/QKSMS/extensions/StringExtensions.kt
@@ -24,3 +24,16 @@ import java.text.Normalizer
  * Strip the accents from a string
  */
 fun CharSequence.removeAccents(): String = Normalizer.normalize(this, Normalizer.Form.NFKD).replace(Regex("\\p{M}"), "")
+
+fun String.joinTo(rhs:String, separator: String) =
+    when {
+        this.isEmpty() -> rhs
+        rhs.isEmpty() -> this
+        else -> "$this$separator$rhs"
+}
+
+fun String.truncateWithEllipses(maxLengthIncEllipses: Int) =
+    when (this.length) {
+        in 0..maxLengthIncEllipses -> this
+        else -> this.take(maxLengthIncEllipses - 1) + "…"
+    }

--- a/domain/src/main/res/xml/messages_text_file_provider_paths.xml
+++ b/domain/src/main/res/xml/messages_text_file_provider_paths.xml
@@ -1,0 +1,3 @@
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="messages_text" path="." />
+</paths>

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/ClipboardUtils.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/ClipboardUtils.kt
@@ -24,21 +24,22 @@ import android.content.Context
 import android.widget.Toast
 import dev.octoshrimpy.quik.R
 
-object ClipboardUtils {
-
-    fun copy(context: Context, string: String) {
-        try {
-            (context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
-                .setPrimaryClip(ClipData.newPlainText("SMS", string))
-        } catch (e: Exception) {
-            Toast.makeText(
-                context,
-                if ((e is RuntimeException) &&
-                    e.message?.startsWith("android.os.TransactionTooLargeException") == true
-                ) R.string.clipboard_too_large_to_copy
-                else R.string.clipboard_unable_to_copy_to,
-                Toast.LENGTH_LONG
-            ).show()
+class ClipboardUtils {
+    companion object {
+        fun copy(context: Context, string: String) {
+            try {
+                (context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
+                    .setPrimaryClip(ClipData.newPlainText("SMS", string))
+            } catch (e: Exception) {
+                Toast.makeText(
+                    context,
+                    if ((e is RuntimeException) &&
+                        e.message?.startsWith("android.os.TransactionTooLargeException") == true
+                    ) R.string.clipboard_too_large_to_copy
+                    else R.string.clipboard_unable_to_copy_to,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
         }
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeState.kt
@@ -39,6 +39,7 @@ data class ComposeState(
     val searchResults: Int = 0,
     val messages: Pair<Conversation, RealmResults<Message>>? = null,
     val selectedMessages: Int = 0,
+    val selectedMessagesHaveText: Boolean = false,
     val scheduled: Long = 0,
     val attachments: List<Attachment> = listOf(),
     val attaching: Boolean = false,

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -89,12 +89,14 @@ interface ComposeView : QkView<ComposeState> {
     val recordAudioMsgRecordVisible: Subject<Boolean>
     val recordAudioRecord: Subject<MicInputCloudView.ViewState>
     val recordAudioChronometer: Subject<Boolean>
+//    val saveMessagesTextIntent: Subject<String>
 
     fun clearSelection()
     fun toggleSelectAll()
     fun expandMessages(messageIds: List<Long>, expand: Boolean)
     fun showDetails(details: String)
     fun showMessageLinkAskDialog(uri: Uri)
+//    fun showSaveMessagesFilenameDialog(filename: String)
     fun requestDefaultSms()
     fun requestStoragePermission()
     fun requestRecordAudioPermission()

--- a/presentation/src/main/res/menu/compose.xml
+++ b/presentation/src/main/res/menu/compose.xml
@@ -68,6 +68,13 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/share"
+        android:icon="@android:drawable/ic_menu_share"
+        android:title="@string/compose_menu_share"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+
+    <item
         android:id="@+id/forward"
         android:icon="@drawable/ic_forward_black_24dp"
         android:title="@string/compose_menu_forward"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="compose_hint">Write a message…</string>
     <string name="compose_no_valid_recipients">Can\'t send to other participants</string>
     <string name="compose_menu_copy">Copy text</string>
+    <string name="compose_menu_share">Share text</string>
     <string name="compose_menu_forward">Forward</string>
     <string name="compose_menu_show_status">Show status</string>
     <string name="compose_menu_delete">Delete</string>
@@ -189,6 +190,7 @@
     <string name="message_status_sending">Sending…</string>
     <string name="message_status_delivered">Delivered %s</string>
     <string name="message_status_failed">Failed to send. Tap to try again</string>
+    <string name="message_body_too_long_to_display">⚠ Message is long. Copy or Save for the full text</string>
 
     <string name="info_title">Details</string>
     <string name="info_copied_address">Address copied</string>
@@ -570,4 +572,6 @@
     <string name="messageLinkHandling_dialog_negative">No</string>
     <string name="stt_toast_no_provider">No speech-to-text service available</string>
     <string name="stt_toast_extra_prompt">Speak your message</string>
+
+    <string name="messages_text_share_file_error">Oops! Something went wrong while sharing</string>
 </resources>


### PR DESCRIPTION
lots of point changes that flowed from limiting and sharing text feature;

limit bubble display of text to 5000 chars with ellipses.
add instruction status message when bubble char limit exceeded. add share text feature.
make copy and share text menu options only available when there is text in selected messages.
new FileProvider to share messages text files out of app's cache dir.
add message subject to copy messages text feature.
a lot of refactoring of MessagesAdapter class.
add new FileUtils class.
convert file logging to use new FileUtils class.
convert MediaRecorder to use new FileUtils class.
housekeeping worker now cleans messages text cache files.
housekeeping worker now checks cache files older than 2 hours before deleting.

https://github.com/user-attachments/assets/c9f33f68-5884-44f7-b2cb-58e807372188

closes https://github.com/octoshrimpy/quik/issues/236
