### PR TITLE
fix race condition when using block menu item on main activity

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -423,7 +423,7 @@ class MainViewModel @Inject constructor(
         view.optionsItemIntent
                 .filter { itemId -> itemId == R.id.block }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
-                    view.showBlockingDialog(conversations, true)
+                    view.showBlockingDialog(conversations.toList(), true)
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())


### PR DESCRIPTION
fixes a race condition in the main activity where selection was being cleared before block dialog had the list of selected convos

* stumbled upon this issue whilst testing for https://github.com/octoshrimpy/quik/pull/391