### PR TITLE
make string parsing for emoji-only faster

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeAttachmentAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeAttachmentAdapter.kt
@@ -23,13 +23,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
-import com.moez.QKSMS.feature.extensions.LoadBestIconIntoImageView
-import com.moez.QKSMS.feature.extensions.loadBestIconIntoImageView
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
 import dev.octoshrimpy.quik.common.base.QkViewHolder
 import dev.octoshrimpy.quik.common.util.extensions.getDisplayName
 import dev.octoshrimpy.quik.extensions.getName
+import dev.octoshrimpy.quik.feature.extensions.LoadBestIconIntoImageView
+import dev.octoshrimpy.quik.feature.extensions.loadBestIconIntoImageView
 import dev.octoshrimpy.quik.model.Attachment
 import ezvcard.Ezvcard
 import io.reactivex.subjects.PublishSubject

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -62,6 +62,7 @@ import dev.octoshrimpy.quik.extensions.truncateWithEllipses
 import dev.octoshrimpy.quik.feature.compose.BubbleUtils.canGroup
 import dev.octoshrimpy.quik.feature.compose.BubbleUtils.getBubble
 import dev.octoshrimpy.quik.feature.compose.part.PartsAdapter
+import dev.octoshrimpy.quik.feature.extensions.isEmojiOnly
 import dev.octoshrimpy.quik.model.Conversation
 import dev.octoshrimpy.quik.model.Message
 import dev.octoshrimpy.quik.model.Recipient
@@ -109,30 +110,6 @@ class MessagesAdapter @Inject constructor(
         private const val VIEW_TYPE_MESSAGE_OUT = 1
 
         private const val MAX_MESSAGE_DISPLAY_LENGTH = 5000
-
-        // Thanks to Cory Kilger for this regex
-        // https://gist.github.com/cmkilger/b8f7dba3e76244a84e7e
-        private val EMOJI_REGEX = Regex(
-            "^[\\s\n\r]*(?:(?:[\u00a9\u00ae\u203c\u2049\u2122\u2139\u2194-\u2199" +
-                    "\u21a9-\u21aa\u231a-\u231b\u2328\u23cf\u23e9-\u23f3\u23f8-\u23fa\u24c2" +
-                    "\u25aa-\u25ab\u25b6\u25c0\u25fb-\u25fe\u2600-\u2604\u260e\u2611\u2614-" +
-                    "\u2615\u2618\u261d\u2620\u2622-\u2623\u2626\u262a\u262e-\u262f\u2638-" +
-                    "\u263a\u2648-\u2653\u2660\u2663\u2665-\u2666\u2668\u267b\u267f\u2692-" +
-                    "\u2694\u2696-\u2697\u2699\u269b-\u269c\u26a0-\u26a1\u26aa-\u26ab\u26b0-" +
-                    "\u26b1\u26bd-\u26be\u26c4-\u26c5\u26c8\u26ce-\u26cf\u26d1\u26d3-\u26d4" +
-                    "\u26e9-\u26ea\u26f0-\u26f5\u26f7-\u26fa\u26fd\u2702\u2705\u2708-\u270d" +
-                    "\u270f\u2712\u2714\u2716\u271d\u2721\u2728\u2733-\u2734\u2744\u2747\u274c" +
-                    "\u274e\u2753-\u2755\u2757\u2763-\u2764\u2795-\u2797\u27a1\u27b0\u27bf" +
-                    "\u2934-\u2935\u2b05-\u2b07\u2b1b-\u2b1c\u2b50\u2b55\u3030\u303d\u3297" +
-                    "\u3299\ud83c\udc04\ud83c\udccf\ud83c\udd70-\ud83c\udd71\ud83c\udd7e-" +
-                    "\ud83c\udd7f\ud83c\udd8e\ud83c\udd91-\ud83c\udd9a\ud83c\ude01-\ud83c" +
-                    "\ude02\ud83c\ude1a\ud83c\ude2f\ud83c\ude32-\ud83c\ude3a\ud83c\ude50-" +
-                    "\ud83c\ude51\u200d\ud83c\udf00-\ud83d\uddff\ud83d\ude00-\ud83d\ude4f" +
-                    "\ud83d\ude80-\ud83d\udeff\ud83e\udd00-\ud83e\uddff\udb40\udc20-\udb40" +
-                    "\udc7f]|\u200d[\u2640\u2642]|[\ud83c\udde6-\ud83c\uddff]" +
-                    "{2}|.[\u20e0\u20e3\ufe0f]+)+[\\s\n\r]*)+$"
-        )
-
     }
 
     // click events passed back to compose view model
@@ -345,8 +322,7 @@ class MessagesAdapter @Inject constructor(
             }
 
         // Bind the body text
-        val emojiOnly = (displayText.isNotBlank()) &&
-                (displayText.matches(EMOJI_REGEX))
+        val emojiOnly = displayText.isEmojiOnly()
         textViewStyler.setTextSize(
             holder.body,
             when (emojiOnly) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/extensions/CharSequenceExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/extensions/CharSequenceExtensions.kt
@@ -1,0 +1,33 @@
+package dev.octoshrimpy.quik.feature.extensions
+
+import android.text.Spannable
+import androidx.emoji.text.EmojiCompat
+import androidx.emoji.text.EmojiCompat.REPLACE_STRATEGY_ALL
+import androidx.emoji.text.EmojiSpan
+
+
+fun CharSequence.isEmojiOnly(considerWhitespace: Boolean = false): Boolean {
+    val cs =
+        if (considerWhitespace) this
+        else this.replace(Regex("[\\s\n\r]"), "")
+
+    if (cs.isEmpty())
+        return false
+
+    return when (val spannable = EmojiCompat.get().process(
+        cs,
+        0,
+        (cs.length - 1),
+        Int.MAX_VALUE,
+        REPLACE_STRATEGY_ALL
+    )) {
+        is Spannable -> {
+            (spannable
+                .getSpans(0, (spannable.length - 1), EmojiSpan::class.java)
+                .fold(0) { acc, emojiSpan ->
+                    acc + (spannable.getSpanEnd(emojiSpan) - spannable.getSpanStart(emojiSpan))
+                } == cs.length)
+        }
+        else -> false
+    }
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/extensions/UriExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/extensions/UriExtensions.kt
@@ -1,4 +1,4 @@
-package com.moez.QKSMS.feature.extensions
+package dev.octoshrimpy.quik.feature.extensions
 
 import android.content.Context
 import android.graphics.drawable.Drawable

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAttachmentAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAttachmentAdapter.kt
@@ -23,12 +23,12 @@ import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.moez.QKSMS.feature.extensions.LoadBestIconIntoImageView
-import com.moez.QKSMS.feature.extensions.loadBestIconIntoImageView
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
 import dev.octoshrimpy.quik.common.base.QkViewHolder
 import dev.octoshrimpy.quik.extensions.getName
+import dev.octoshrimpy.quik.feature.extensions.LoadBestIconIntoImageView
+import dev.octoshrimpy.quik.feature.extensions.loadBestIconIntoImageView
 import kotlinx.android.synthetic.main.scheduled_message_image_list_item.fileName
 import kotlinx.android.synthetic.main.scheduled_message_image_list_item.thumbnail
 import javax.inject.Inject


### PR DESCRIPTION
changes to make emoji-only recognition faster.
old regex method was so slow that os would anr the process.

this change can be tested using the emoji string from issue https://github.com/octoshrimpy/quik/issues/183.

closes https://github.com/octoshrimpy/quik/issues/183