### PR TITLE
upgrades to appcompat and emoji libraries. fix pr 399 for non-playstore/gsm os

### DIFF
--- a/android-smsmms/build.gradle
+++ b/android-smsmms/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 23

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     ext.androidx_constraintlayout_version = '1.1.3'
     ext.androidx_core_version = '1.1.0'
     ext.androidx_documentfile_version = '1.0.1'
-    ext.androidx_emoji_version = '1.0.0'
     ext.androidx_exifinterface_version = '1.0.0'
     ext.androidx_testrunner_version = '1.1.0-alpha3'
     ext.androidx_viewpager_version = '1.0.0-beta05'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.androidx_appcompat_version = '1.3.1'
+    ext.androidx_appcompat_version = '1.6.1'
     ext.androidx_constraintlayout_version = '1.1.3'
     ext.androidx_core_version = '1.1.0'
     ext.androidx_documentfile_version = '1.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext.androidx_appcompat_version = '1.6.1'
+    ext.androidx_emoji2_version = '1.4.0'
     ext.androidx_constraintlayout_version = '1.1.3'
     ext.androidx_core_version = '1.1.0'
     ext.androidx_documentfile_version = '1.0.1'

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdk 33
+    compileSdk 34
     publishNonDefault true
     flavorDimensions "analytics"
 

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     compileOptions {
         sourceCompatibility 1.8

--- a/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
+++ b/domain/src/main/java/com/moez/QKSMS/util/Preferences.kt
@@ -156,7 +156,8 @@ class Preferences @Inject constructor(
     val keyChanges: Observable<String> = Observable.create<String> { emitter ->
         // Making this a lambda would cause it to be GCd
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-            emitter.onNext(key)
+            if (key != null)
+                emitter.onNext(key)
         }
 
         emitter.setCancellable {

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdk 33
+    compileSdk 34
     flavorDimensions "analytics"
 
     defaultConfig {
@@ -123,6 +123,7 @@ dependencies {
 
     // androidx
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
+    implementation "androidx.emoji2:emoji2-bundled:$androidx_emoji2_version"
     implementation "androidx.constraintlayout:constraintlayout:$androidx_constraintlayout_version"
     implementation "androidx.core:core-ktx:$androidx_core_version"
     implementation "androidx.viewpager2:viewpager2:$androidx_viewpager_version"

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -125,7 +125,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidx_appcompat_version"
     implementation "androidx.constraintlayout:constraintlayout:$androidx_constraintlayout_version"
     implementation "androidx.core:core-ktx:$androidx_core_version"
-    implementation "androidx.emoji:emoji-appcompat:$androidx_emoji_version"
     implementation "androidx.viewpager2:viewpager2:$androidx_viewpager_version"
     implementation "com.google.android.material:material:$material_version"
     implementation("androidx.work:work-runtime-ktx:$androidx_work_version")

--- a/presentation/src/main/java/com/moez/QKSMS/common/QKApplication.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/QKApplication.kt
@@ -23,8 +23,6 @@ import android.app.Application
 import android.app.Service
 import android.content.BroadcastReceiver
 import androidx.core.provider.FontRequest
-import androidx.emoji.text.EmojiCompat
-import androidx.emoji.text.FontRequestEmojiCompatConfig
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import androidx.work.WorkerFactory
@@ -105,14 +103,6 @@ class QKApplication : Application(), HasActivityInjector, HasBroadcastReceiverIn
         }
 
         nightModeManager.updateCurrentTheme()
-
-        val fontRequest = FontRequest(
-                "com.google.android.gms.fonts",
-                "com.google.android.gms",
-                "Noto Color Emoji Compat",
-                R.array.com_google_android_gms_fonts_certs)
-
-        EmojiCompat.init(FontRequestEmojiCompatConfig(this, fontRequest))
 
         Timber.plant(Timber.DebugTree(), CrashlyticsTree(), fileLoggingTree)
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/QKApplication.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/QKApplication.kt
@@ -22,7 +22,8 @@ import android.app.Activity
 import android.app.Application
 import android.app.Service
 import android.content.BroadcastReceiver
-import androidx.core.provider.FontRequest
+import androidx.emoji2.bundled.BundledEmojiCompatConfig
+import androidx.emoji2.text.EmojiCompat
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import androidx.work.WorkerFactory
@@ -104,8 +105,26 @@ class QKApplication : Application(), HasActivityInjector, HasBroadcastReceiverIn
 
         nightModeManager.updateCurrentTheme()
 
+        // configure timber logging
         Timber.plant(Timber.DebugTree(), CrashlyticsTree(), fileLoggingTree)
 
+        // configure emoji compatibility with bundled package
+        // (bundled library works with no play-services/gsm os versions)
+        EmojiCompat.init(BundledEmojiCompatConfig(this)
+            .registerInitCallback(object: EmojiCompat.InitCallback() {
+                override fun onInitialized() {
+                    super.onInitialized()
+                    Timber.v("bundled emojicompat initialized")
+                }
+
+                override fun onFailed(throwable: Throwable?) {
+                    super.onFailed(throwable)
+                    Timber.e("bundled emojicompat initialization failed")
+                }
+            })
+        )
+
+        // rxdogtag provides 'look-back' for exceptions in rxjava2 'chains'
         RxDogTag.builder()
                 .configureWith(AutoDisposeConfigurer::configure)
                 .install()

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/QkActivityResultContracts.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/QkActivityResultContracts.kt
@@ -28,12 +28,11 @@ class QkActivityResultContracts {
             return intent
         }
 
-        override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
-            if (intent == null || resultCode != Activity.RESULT_OK) {
-                return null
-            }
+        override fun parseResult(resultCode: Int, intent: Intent?): Uri {
+            if (resultCode != Activity.RESULT_OK)
+                return Uri.EMPTY
 
-            return intent.data
+            return intent?.data ?: Uri.EMPTY
         }
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/QkEditText.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/QkEditText.kt
@@ -25,7 +25,7 @@ import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputConnectionWrapper
-import android.widget.EditText
+import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.inputmethod.InputConnectionCompat
 import androidx.core.view.inputmethod.InputContentInfoCompat
@@ -44,7 +44,8 @@ import javax.inject.Inject
  * Beware of updating to extend AppCompatTextView, as this inexplicably breaks the view in
  * the contacts chip view
  */
-class QkEditText @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) : EditText(context, attrs) {
+class QkEditText @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null)
+    : AppCompatEditText(context, attrs) {
 
     @Inject lateinit var textViewStyler: TextViewStyler
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/QkTextView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/QkTextView.kt
@@ -20,14 +20,14 @@ package dev.octoshrimpy.quik.common.widget
 
 import android.content.Context
 import android.util.AttributeSet
-import androidx.emoji.widget.EmojiAppCompatTextView
+import androidx.appcompat.widget.AppCompatTextView
 import dev.octoshrimpy.quik.common.util.TextViewStyler
 import dev.octoshrimpy.quik.injection.appComponent
 import javax.inject.Inject
 
 open class QkTextView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
-) : EmojiAppCompatTextView(context, attrs) {
+) : AppCompatTextView(context, attrs) {
 
     @Inject lateinit var textViewStyler: TextViewStyler
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/backup/BackupController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/backup/BackupController.kt
@@ -104,7 +104,7 @@ class BackupController : QkController<BackupView, BackupState, BackupPresenter>(
                 .create()
     }
 
-    private lateinit var openDirectory: ActivityResultLauncher<Uri>
+    private lateinit var openDirectory: ActivityResultLauncher<Uri?>
     private lateinit var openDocument: ActivityResultLauncher<QkActivityResultContracts.OpenDocumentParams>
 
     init {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -824,7 +824,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
                     if (messageEditBox !== null) {
                         // populate message box with data returned by STT, set cursor to end, and focus
                         messageEditBox.append(match[0])
-                        messageEditBox.setSelection(messageEditBox.text.length)
+                        messageEditBox.setSelection(messageEditBox.text?.length ?: 0)
                         messageEditBox.requestFocus()
                     }
                 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/extensions/CharSequenceExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/extensions/CharSequenceExtensions.kt
@@ -1,9 +1,9 @@
 package dev.octoshrimpy.quik.feature.extensions
 
 import android.text.Spannable
-import androidx.emoji.text.EmojiCompat
-import androidx.emoji.text.EmojiCompat.REPLACE_STRATEGY_ALL
-import androidx.emoji.text.EmojiSpan
+import androidx.emoji2.text.EmojiCompat
+import androidx.emoji2.text.EmojiCompat.REPLACE_STRATEGY_ALL
+import androidx.emoji2.text.EmojiSpan
 
 
 fun CharSequence.isEmojiOnly(considerWhitespace: Boolean = false): Boolean {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/qkreply/QkReplyActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/qkreply/QkReplyActivity.kt
@@ -80,7 +80,7 @@ class QkReplyActivity : QkThemedActivity(), QkReplyView {
 
         // populate message box with data returned by STT, set cursor to end, and focus
         message.setText(match[0])
-        message.setSelection(message.text.length)
+        message.setSelection(message.text?.length ?: 0)
         message.requestFocus()
     }
 


### PR DESCRIPTION
appcompat library to 1.6.1
remove deprecated androidx.emoji-appcompat - see https://developer.android.com/develop/ui/views/text-and-emoji/emoji-compat
use androidx.emoji2-bundled library (bundled for compatibility with non playstore/gsm os)
emoji2 compat library to 1.4.0 (required compilesdk upgrade to 34)
make qkedittext use appcompatedittext for emoji compatibility
fix small incompatibilities introduced by new library versions

* this pr overwrites and fixes previous pr https://github.com/octoshrimpy/quik/pull/399 which broke the app for non-playstore/gsm os's