### PR TITLE
no keyboard auto-show on compose activity

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -57,7 +57,8 @@
         <activity
             android:name=".feature.main.MainActivity"
             android:exported="true"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="stateAlwaysHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -70,7 +71,8 @@
         <activity
             android:name=".feature.compose.ComposeActivity"
             android:exported="true"
-            android:parentActivityName=".feature.main.MainActivity">
+            android:parentActivityName=".feature.main.MainActivity"
+            android:windowSoftInputMode="stateHidden">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.MAIN" />

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -839,10 +839,6 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override fun onBackPressed() = backPressedIntent.onNext(Unit)
 
     override fun focusMessage() {
-        runOnUiThread {
-            val message = findViewById<QkEditText>(R.id.message)
-            if (message !== null) message.requestFocus()
-        }
+        message.requestFocus()
     }
-
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeView.kt
@@ -113,5 +113,4 @@ interface ComposeView : QkView<ComposeState> {
     fun showClearCurrentMessageDialog()
     fun startSpeechRecognition()
     fun focusMessage()
-
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
@@ -29,7 +29,7 @@ interface MainView : QkView<MainState> {
     val activityResumedIntent: Observable<Boolean>
     val queryChangedIntent: Observable<CharSequence>
     val composeIntent: Observable<Unit>
-    val drawerOpenIntent: Observable<Boolean>
+    val drawerToggledIntent: Observable<Boolean>
     val homeIntent: Observable<*>
     val navigationIntent: Observable<NavItem>
     val optionsItemIntent: Observable<Int>
@@ -55,7 +55,7 @@ interface MainView : QkView<MainState> {
     fun showRenameDialog(conversationName: String)
     fun showChangelog(changelog: ChangelogManager.CumulativeChangelog)
     fun showArchivedSnackbar(countConversationsArchived: Int)
-
+    fun drawerToggled(opened: Boolean)
 }
 
 enum class NavItem { BACK, INBOX, ARCHIVED, BACKUP, SCHEDULED, BLOCKING, SETTINGS, PLUS, HELP, INVITE }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -82,8 +82,10 @@ class MainViewModel @Inject constructor(
     private val ratingManager: RatingManager,
     private val syncContacts: SyncContacts,
     private val syncMessages: SyncMessages
-) : QkViewModel<MainView, MainState>(MainState(page = Inbox(data = conversationRepo.getConversations(prefs.unreadAtTop.get())))) {
-    private val lastArchivedThreadIds = ArrayList<Long>()
+) : QkViewModel<MainView, MainState>(
+    MainState(page = Inbox(data = conversationRepo.getConversations(prefs.unreadAtTop.get())))
+) {
+    private var lastArchivedThreadIds = listOf<Long>(0)
 
     init {
         disposables += deleteConversations
@@ -342,9 +344,8 @@ class MainViewModel @Inject constructor(
                 .filter { itemId -> itemId == R.id.archive }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
                     markArchived.execute(conversations)
-                    lastArchivedThreadIds.clear()
-                    conversations.forEach { conversation -> lastArchivedThreadIds.add(conversation) }
-                    view.showArchivedSnackbar(conversations.count())
+                    lastArchivedThreadIds = conversations.toList()
+                    view.showArchivedSnackbar(lastArchivedThreadIds.count())
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -518,8 +519,7 @@ class MainViewModel @Inject constructor(
                     when (action) {
                         Preferences.SWIPE_ACTION_ARCHIVE ->
                             markArchived.execute(listOf(threadId)) {
-                                lastArchivedThreadIds.clear()
-                                lastArchivedThreadIds.add(threadId)
+                                lastArchivedThreadIds = listOf(threadId)
                                 view.showArchivedSnackbar(1)
                             }
                         Preferences.SWIPE_ACTION_DELETE ->
@@ -543,8 +543,8 @@ class MainViewModel @Inject constructor(
         view.undoArchiveIntent
                 .autoDisposable(view.scope())
                 .subscribe {
-                    markUnarchived.execute(lastArchivedThreadIds)
-                    lastArchivedThreadIds.clear()
+                    markUnarchived.execute(lastArchivedThreadIds.toList())
+                    lastArchivedThreadIds = listOf()
                 }
 
         view.snackbarButtonIntent

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -295,9 +295,13 @@ class MainViewModel @Inject constructor(
                 .autoDisposable(view.scope())
                 .subscribe()
 
-        view.drawerOpenIntent
-                .autoDisposable(view.scope())
-                .subscribe { open -> newState { copy(drawerOpen = open) } }
+        view.drawerToggledIntent
+            .doOnNext {
+                newState { copy(drawerOpen = it) }
+                view.drawerToggled(it)
+            }
+            .autoDisposable(view.scope())
+            .subscribe { open -> newState { copy(drawerOpen = open) } }
 
         view.navigationIntent
                 .withLatestFrom(state) { drawerItem, state ->

--- a/presentation/src/main/res/layout/main_activity.xml
+++ b/presentation/src/main/res/layout/main_activity.xml
@@ -62,9 +62,7 @@
                 app:textSize="primary"
                 tools:textSize="16sp"
                 android:focusable="true"
-                android:focusableInTouchMode="true"
                 android:nextFocusRight="@+id/compose" />
-
         </androidx.appcompat.widget.Toolbar>
 
         <dev.octoshrimpy.quik.common.widget.QkTextView


### PR DESCRIPTION
edit: added some code cleanups and changes from wiggleforlifes testing.

change windowSoftInputMode="stateHidden" and remove some focusing code so keyboard not shown automagically on compose screen entry

edit:
* added requestfocus to search box on main actiivty layout. added  windowSoftInputMode="stateHidden" to stop keyboard being automagically shown on main activity load.
* cleaned up and refoctored some main activity code
* re-implemented setting focus to message box after sending sms on compose activity

this pr needs testing on a pure dpad device and also with touch screens. it is supposed to result in both dpad needing to click middle button to show keyboard (if it has on-screen keyboard), and for touch, to touch the input box to show keyboard.

below is a viddy of how this pr performs on my emulator using dpad emulation and, after dpad demo, using touch (mouse clicks). it also starts with my 'work-around' for moving from the search box to the convo list on the main activity that requires touches to select multiple convos first - which i presume needs fixing for better dpad control in a future pr;

https://github.com/user-attachments/assets/f2e5468a-0491-4724-af34-1d1f6896fdad
