### PR TITLE
Rename error toast string

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -683,7 +683,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
             try {
                 startActivityForResult(intent, ComposeView.SpeechRecognitionRequestCode)
             } catch (e: ActivityNotFoundException) {
-                Toast.makeText(this, getString(R.string.stt_toast_no_provider), Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.error_stt_toast), Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/presentation/src/main/res/values-pl/strings.xml
+++ b/presentation/src/main/res/values-pl/strings.xml
@@ -548,6 +548,6 @@
     <string name="messageLinkHandling_dialog_body">Niektóre linki mogą być niebezpieczne lub nieoczekiwanie przekierowywać użytkownika. Sprawdź poniższy link przed kontynuowaniem:\n\n%1$s\n\nCzy chcesz kontynuować?</string>
     <string name="messageLinkHandling_dialog_positive">Tak, otwórz link</string>
     <string name="messageLinkHandling_dialog_negative">Nie</string>
-    <string name="stt_toast_no_provider">Brak dostępnej usługi zamiany mowy na tekst</string>
+    <string name="error_stt_toast">Brak dostępnej usługi zamiany mowy na tekst</string>
     <string name="stt_toast_extra_prompt">Wypowiedz swoją wiadomość</string>
 </resources>

--- a/presentation/src/main/res/values-ro/strings.xml
+++ b/presentation/src/main/res/values-ro/strings.xml
@@ -476,6 +476,6 @@
     <string name="messageLinkHandling_dialog_body">Unele link-uri pot fi nesigure sau te pot redirecționa în mod neașteptat. Examinează link-ul de mai jos înainte de a continua:\n\n%1$s\n\nDorești să continui?</string>
     <string name="messageLinkHandling_dialog_positive">Da, deschide link-ul</string>
     <string name="messageLinkHandling_dialog_negative">Nu</string>
-    <string name="stt_toast_no_provider">Nici un serviciu vorbire-în-text disponibil</string>
+    <string name="error_stt_toast">Nici un serviciu vorbire-în-text disponibil</string>
     <string name="stt_toast_extra_prompt">Vorbește mesajul</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -570,7 +570,7 @@
     <string name="messageLinkHandling_dialog_body">Some links may be unsafe or redirect you unexpectedly. Review the link below before proceeding:\n\n%1$s\n\nDo you want to continue?</string>
     <string name="messageLinkHandling_dialog_positive">Yes, open the link</string>
     <string name="messageLinkHandling_dialog_negative">No</string>
-    <string name="stt_toast_no_provider">No speech-to-text service available</string>
+    <string name="error_stt_toast">Sorry, there was an error loading the Speech-To-Text provider.</string>
     <string name="stt_toast_extra_prompt">Speak your message</string>
 
     <string name="messages_text_share_file_error">Oops! Something went wrong while sharing</string>


### PR DESCRIPTION
Fixes something brought up in #401. This makes the message on an STT error more clear.