### PR TITLE
fix possible race conditions in main and compose activities

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -1205,7 +1205,7 @@ class ComposeViewModel @Inject constructor(
         // Delete the message
         view.confirmDeleteIntent
                 .withLatestFrom(view.messagesSelectedIntent, conversation) { _, messages, conversation ->
-                    deleteMessages.execute(DeleteMessages.Params(messages, conversation.id))
+                    deleteMessages.execute(DeleteMessages.Params(messages.toList(), conversation.id))
                 }
                 .autoDisposable(view.scope())
                 .subscribe { view.clearSelection() }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -353,7 +353,7 @@ class MainViewModel @Inject constructor(
         view.optionsItemIntent
                 .filter { itemId -> itemId == R.id.unarchive }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
-                    markUnarchived.execute(conversations)
+                    markUnarchived.execute(conversations.toList())
                     view.showArchivedSnackbar(conversations.count())
                     view.clearSelection()
                 }
@@ -385,7 +385,7 @@ class MainViewModel @Inject constructor(
         view.optionsItemIntent
                 .filter { itemId -> itemId == R.id.pin }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
-                    markPinned.execute(conversations)
+                    markPinned.execute(conversations.toList())
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -394,7 +394,7 @@ class MainViewModel @Inject constructor(
         view.optionsItemIntent
                 .filter { itemId -> itemId == R.id.unpin }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
-                    markUnpinned.execute(conversations)
+                    markUnpinned.execute(conversations.toList())
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -404,7 +404,7 @@ class MainViewModel @Inject constructor(
                 .filter { itemId -> itemId == R.id.read }
                 .filter { permissionManager.isDefaultSms().also { if (!it) view.requestDefaultSms() } }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
-                    markRead.execute(conversations)
+                    markRead.execute(conversations.toList())
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -414,7 +414,7 @@ class MainViewModel @Inject constructor(
                 .filter { itemId -> itemId == R.id.unread }
                 .filter { permissionManager.isDefaultSms().also { if (!it) view.requestDefaultSms() } }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
-                    markUnread.execute(conversations)
+                    markUnread.execute(conversations.toList())
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -488,7 +488,7 @@ class MainViewModel @Inject constructor(
         view.confirmDeleteIntent
                 .autoDisposable(view.scope())
                 .subscribe { conversations ->
-                    deleteConversations.execute(conversations)
+                    deleteConversations.execute(conversations.toList())
                     view.clearSelection()
                 }
 


### PR DESCRIPTION
use copied lists for non-main-thread tasks when followed by a clearSelections() call