### PR TITLE
maintain setting messages seen and read congruence with native provider db

### DIFF
--- a/domain/src/main/java/com/moez/QKSMS/interactor/CancelDelayedMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/CancelDelayedMessage.kt
@@ -32,9 +32,9 @@ class CancelDelayedMessage @Inject constructor(
 
     override fun buildObservable(params: Params): Flowable<*> {
         return Flowable.just(Unit)
-                .doOnNext { messageRepo.cancelDelayedSms(params.messageId) }
-                .doOnNext { messageRepo.deleteMessages(params.messageId) }
-                .doOnNext { conversationRepo.updateConversations(params.threadId) } // Update the conversation
+            .doOnNext { messageRepo.cancelDelayedSms(params.messageId) }
+            .doOnNext { messageRepo.deleteMessages(listOf(params.messageId)) }
+            .doOnNext { conversationRepo.updateConversations(params.threadId) } // Update the conversation
     }
 
 }

--- a/domain/src/main/java/com/moez/QKSMS/interactor/DeleteMessages.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/DeleteMessages.kt
@@ -34,11 +34,11 @@ class DeleteMessages @Inject constructor(
     data class Params(val messageIds: List<Long>, val threadId: Long)
 
     override fun buildObservable(params: Params): Flowable<*> {
-        return Flowable.just(params.messageIds.toLongArray())
-                .doOnNext { messageIds -> messageRepo.deleteMessages(*messageIds) } // Delete the messages
-                .doOnNext { conversationRepo.updateConversations(params.threadId) } // Update the conversation
-                .doOnNext { notificationManager.update(params.threadId) }
-                .flatMap { updateBadge.buildObservable(Unit) } // Update the badge
+        return Flowable.just(params.messageIds)
+            .doOnNext { messageIds -> messageRepo.deleteMessages(messageIds) } // Delete the messages
+            .doOnNext { conversationRepo.updateConversations(params.threadId) } // Update the conversation
+            .doOnNext { notificationManager.update(params.threadId) }
+            .flatMap { updateBadge.buildObservable(Unit) } // Update the badge
     }
 
 }

--- a/domain/src/main/java/com/moez/QKSMS/interactor/MarkRead.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/MarkRead.kt
@@ -30,10 +30,10 @@ class MarkRead @Inject constructor(
 ) : Interactor<List<Long>>() {
 
     override fun buildObservable(params: List<Long>): Flowable<*> {
-        return Flowable.just(params.toLongArray())
-                .doOnNext { threadIds -> messageRepo.markRead(*threadIds) }
-                .doOnNext { threadIds -> threadIds.forEach(notificationManager::update) }
-                .flatMap { updateBadge.buildObservable(Unit) } // Update the badge
+        return Flowable.just(params)
+            .doOnNext { threadIds -> messageRepo.markRead(threadIds) }
+            .doOnNext { threadIds -> threadIds.forEach(notificationManager::update) }
+            .flatMap { updateBadge.buildObservable(Unit) } // Update the badge
     }
 
 }

--- a/domain/src/main/java/com/moez/QKSMS/interactor/MarkUnread.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/MarkUnread.kt
@@ -28,9 +28,9 @@ class MarkUnread @Inject constructor(
 ) : Interactor<List<Long>>() {
 
     override fun buildObservable(params: List<Long>): Flowable<*> {
-        return Flowable.just(params.toLongArray())
-                .doOnNext { threadId -> messageRepo.markUnread(*threadId) }
-                .flatMap { updateBadge.buildObservable(Unit) } // Update the badge
+        return Flowable.just(params)
+            .doOnNext { threadIds -> messageRepo.markUnread(threadIds) }
+            .flatMap { updateBadge.buildObservable(Unit) } // Update the badge
     }
 
 }

--- a/domain/src/main/java/com/moez/QKSMS/interactor/ReceiveMms.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/ReceiveMms.kt
@@ -49,7 +49,7 @@ class ReceiveMms @Inject constructor(
                     // TODO: Ideally this is done when we're saving the MMS to ContentResolver
                     // This change can be made once we move the MMS storing code to the Data module
                     if (activeConversationManager.getActiveConversation() == message.threadId) {
-                        messageRepo.markRead(message.threadId)
+                        messageRepo.markRead(listOf(message.threadId))
                     }
                 }
                 .mapNotNull { message ->
@@ -62,13 +62,13 @@ class ReceiveMms @Inject constructor(
                     Timber.v("block=$action, drop=$shouldDrop")
 
                     if (action is BlockingClient.Action.Block && shouldDrop) {
-                        messageRepo.deleteMessages(message.id)
+                        messageRepo.deleteMessages(listOf(message.id))
                         return@mapNotNull null
                     }
 
                     when (action) {
                         is BlockingClient.Action.Block -> {
-                            messageRepo.markRead(message.threadId)
+                            messageRepo.markRead(listOf(message.threadId))
                             conversationRepo.markBlocked(listOf(message.threadId), prefs.blockingManager.get(), action.reason)
                         }
                         is BlockingClient.Action.Unblock -> conversationRepo.markUnblocked(message.threadId)

--- a/domain/src/main/java/com/moez/QKSMS/interactor/ReceiveSms.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/ReceiveSms.kt
@@ -49,13 +49,13 @@ class ReceiveSms @Inject constructor(
                     ((action is BlockingClient.Action.Block) && prefs.drop.get()) ->  {
                         // blocked and 'drop blocked.' remove from db and don't continue
                         Timber.v("address is blocked and drop blocked is on. dropped")
-                        messageRepo.deleteMessages(it.id)
+                        messageRepo.deleteMessages(listOf(it.id))
                         return@mapNotNull null
                     }
                     action is BlockingClient.Action.Block -> {
                         // blocked
                         Timber.v("address is blocked")
-                        messageRepo.markRead(it.threadId)
+                        messageRepo.markRead(listOf(it.threadId))
                         conversationRepo.markBlocked(
                             listOf(it.threadId),
                             prefs.blockingManager.get(),

--- a/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
+++ b/domain/src/main/java/com/moez/QKSMS/repository/MessageRepository.kt
@@ -57,20 +57,20 @@ interface MessageRepository {
      */
     fun getUnreadMessages(threadId: Long): RealmResults<Message>
 
-    fun markAllSeen()
+    fun markAllSeen(): Int
 
-    fun markSeen(threadId: Long)
+    fun markSeen(threadId: Long): Int
 
-    fun markRead(vararg threadIds: Long)
+    fun markRead(threadIds: Collection<Long>): Int
 
-    fun markUnread(vararg threadIds: Long)
+    fun markUnread(threadIds: Collection<Long>): Int
 
     fun sendMessage(
         subId: Int,
         threadId: Long,
-        addresses: List<String>,
+        addresses: Collection<String>,
         body: String,
-        attachments: List<Attachment>,
+        attachments: Collection<Attachment>,
         delay: Int = 0
     )
 
@@ -103,7 +103,7 @@ interface MessageRepository {
 
     fun markDeliveryFailed(id: Long, resultCode: Int)
 
-    fun deleteMessages(vararg messageIds: Long)
+    fun deleteMessages(messageIds: Collection<Long>)
 
     /**
      * Returns the number of messages older than [maxAgeDays] per conversation


### PR DESCRIPTION
update messagerepo to keep congruence between app db messages and native provider when marking messages seen and read. previous code always threw an exception that was swallowed and didn't set anything in the native provider.

reformatting and small refactorings on mesasgerepo code.

* i saw somewhere - but don't recall where - someone mentioning that quik (or maybe qksms at the time) didn't set messages 'seen' properly and this was interacting badly with other sms apps. this pr should fix that.