### PR TITLE
Enable Android conversation features

### DIFF
--- a/domain/src/main/java/com/moez/QKSMS/interactor/ReceiveSms.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/ReceiveSms.kt
@@ -93,6 +93,7 @@ class ReceiveSms @Inject constructor(
                 // update shortcuts
                 Timber.v("update shortcuts")
                 shortcutManager.updateShortcuts()
+                shortcutManager.reportShortcutUsed(it.id)
 
                 // update the badge and widget
                 Timber.v("update badge and widget")

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendMessage.kt
@@ -19,6 +19,7 @@
 package dev.octoshrimpy.quik.interactor
 
 import android.content.Context
+import dev.octoshrimpy.quik.manager.ShortcutManager
 import dev.octoshrimpy.quik.model.Attachment
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.repository.MessageRepository
@@ -29,7 +30,8 @@ class SendMessage @Inject constructor(
     private val context: Context,
     private val conversationRepo: ConversationRepository,
     private val messageRepo: MessageRepository,
-    private val updateBadge: UpdateBadge
+    private val updateBadge: UpdateBadge,
+    private val shortcutManager: ShortcutManager
 ) : Interactor<SendMessage.Params>() {
 
     data class Params(
@@ -61,6 +63,8 @@ class SendMessage @Inject constructor(
             conversationRepo.updateConversations(threadId)
 
             conversationRepo.markUnarchived(threadId)
+
+            shortcutManager.reportShortcutUsed(threadId)
 
             // delete attachment local files, if any, because they're saved to mms db by now
             params.attachments.forEach { it.removeCacheFile() }

--- a/domain/src/main/java/com/moez/QKSMS/manager/ShortcutManager.kt
+++ b/domain/src/main/java/com/moez/QKSMS/manager/ShortcutManager.kt
@@ -18,10 +18,17 @@
  */
 package dev.octoshrimpy.quik.manager
 
+import android.content.pm.ShortcutInfo
+import androidx.core.content.pm.ShortcutInfoCompat
+
 interface ShortcutManager {
 
     fun updateBadge()
 
     fun updateShortcuts()
+
+    fun getShortcut(threadId: Long): ShortcutInfoCompat?
+
+    fun reportShortcutUsed(threadId: Long)
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
@@ -21,24 +21,26 @@ package dev.octoshrimpy.quik.common.util
 import android.annotation.TargetApi
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ShortcutInfo
-import android.content.pm.ShortcutManager
-import android.graphics.drawable.Icon
 import android.os.Build
-import dev.octoshrimpy.quik.R
+import android.content.pm.ShortcutManager
+import androidx.core.app.Person
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import dev.octoshrimpy.quik.common.util.extensions.getThemedIcon
+import dev.octoshrimpy.quik.common.util.extensions.toPerson
 import dev.octoshrimpy.quik.feature.compose.ComposeActivity
 import dev.octoshrimpy.quik.model.Conversation
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.repository.MessageRepository
-import dev.octoshrimpy.quik.util.GlideApp
-import dev.octoshrimpy.quik.util.tryOrNull
 import me.leolin.shortcutbadger.ShortcutBadger
+import timber.log.Timber
 import javax.inject.Inject
 
 class ShortcutManagerImpl @Inject constructor(
     private val context: Context,
     private val conversationRepo: ConversationRepository,
-    private val messageRepo: MessageRepository
+    private val messageRepo: MessageRepository,
+    private val colors: Colors
 ) : dev.octoshrimpy.quik.manager.ShortcutManager {
 
     override fun updateBadge() {
@@ -51,41 +53,109 @@ class ShortcutManagerImpl @Inject constructor(
             val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
             if (shortcutManager.isRateLimitingActive) return
 
-            shortcutManager.dynamicShortcuts = conversationRepo.getTopConversations()
+            val shortcuts: List<ShortcutInfoCompat> = conversationRepo.getTopConversations()
                     .take(shortcutManager.maxShortcutCountPerActivity - shortcutManager.manifestShortcuts.size)
-                    .map { conversation -> createShortcutForConversation(conversation, shortcutManager) }
+                    .map { conversation -> createShortcutForConversation(conversation) }
+
+            ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
         }
     }
 
-    @TargetApi(25)
-    private fun createShortcutForConversation(conversation: Conversation, shortcutManager: ShortcutManager): ShortcutInfo {
+    /**
+     * Get the shortcut for a threadId. Will create it if it doesn't exist.
+     */
+    override fun getShortcut(threadId: Long): ShortcutInfoCompat? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            var sc = getShortcuts().find { it.id == threadId.toString() }
+            if(sc != null)
+                sc = updateShortcut(sc)
+            if (sc == null)  {
+                val conv = conversationRepo.getConversation(threadId)
+                if (conv == null)
+                    return null
+                else
+                    sc =  createShortcutForConversation(conv)
+            }
+            return sc
+        } else {
+            return null
+        }
+    }
+
+    /**
+     * Report thread usage. Will create the shortcut if it doesn't exist.
+     */
+    override fun reportShortcutUsed(threadId: Long) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
+            if(getShortcut(threadId ) == null) {
+                val conversation = conversationRepo.getOrCreateConversation(threadId)
+                if (conversation == null)
+                    return
+                val shortcut = createShortcutForConversation(conversation)
+                ShortcutManagerCompat.setDynamicShortcuts(context, listOf(shortcut))
+            }
+            shortcutManager.reportShortcutUsed(threadId.toString())
+        }
+    }
+
+    @TargetApi(29)
+    private fun createShortcutForConversation(conversation: Conversation): ShortcutInfoCompat {
+        Timber.v("creating shortcut for conversation ${conversation.id} : ${conversation.getTitle()}")
         val icon = when {
             conversation.recipients.size == 1 -> {
-                val address = conversation.recipients.first()!!.address
-                val request = GlideApp.with(context)
-                        .asBitmap()
-                        .circleCrop()
-                        .load("tel:$address")
-                        .submit(shortcutManager.iconMaxWidth, shortcutManager.iconMaxHeight)
-                val bitmap = tryOrNull(false) { request.get() }
-
-                if (bitmap != null) Icon.createWithBitmap(bitmap)
-                else Icon.createWithResource(context, R.mipmap.ic_shortcut_person)
+                val recipient = conversation.recipients.first()!!
+                recipient.getThemedIcon(context,
+                    colors.theme(recipient),
+                    ShortcutManagerCompat.getIconMaxWidth(context),
+                    ShortcutManagerCompat.getIconMaxHeight(context)
+                )
             }
 
-            else -> Icon.createWithResource(context, R.mipmap.ic_shortcut_people)
+            else -> {
+                conversation.getThemedIcon(context,
+                    ShortcutManagerCompat.getIconMaxWidth(context),
+                    ShortcutManagerCompat.getIconMaxHeight(context)
+                )
+            }
         }
+
+        val persons: Array<Person> = conversation.recipients.map { it -> it.toPerson(context, colors) }.toTypedArray();
 
         val intent = Intent(context, ComposeActivity::class.java)
                 .setAction(Intent.ACTION_VIEW)
                 .putExtra("threadId", conversation.id)
+                .putExtra("fromShortcut", true)
 
-        return ShortcutInfo.Builder(context, "${conversation.id}")
+        val sc = ShortcutInfoCompat.Builder(context, "${conversation.id}")
                 .setShortLabel(conversation.getTitle())
                 .setLongLabel(conversation.getTitle())
                 .setIcon(icon)
                 .setIntent(intent)
+                .setPersons(persons)
+                .setLongLived(true)
                 .build()
+
+        ShortcutManagerCompat.pushDynamicShortcut(context, sc)
+        return sc
     }
 
+    private fun updateShortcut(shortcut: ShortcutInfoCompat): ShortcutInfoCompat {
+        val conversation = conversationRepo.getConversation(shortcut.id.toLong())
+        if (conversation == null)
+            return shortcut
+        else {
+            val sc = createShortcutForConversation(conversation)
+            ShortcutManagerCompat.pushDynamicShortcut(context, sc)
+            return sc
+        }
+    }
+
+    private fun getShortcuts() : List<ShortcutInfoCompat> {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            return ShortcutManagerCompat.getDynamicShortcuts(context)
+        } else {
+            return emptyList()
+        }
+    }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ConversationExtension.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/ConversationExtension.kt
@@ -1,0 +1,73 @@
+package dev.octoshrimpy.quik.common.util.extensions
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Path
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View.GONE
+import android.view.View.MeasureSpec
+import android.view.View.VISIBLE
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.IconCompat
+import androidx.core.view.drawToBitmap
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.widget.TextViewCompat
+import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.util.Colors
+import dev.octoshrimpy.quik.common.widget.AvatarView
+import dev.octoshrimpy.quik.common.widget.QkTextView
+import dev.octoshrimpy.quik.model.Conversation
+import dev.octoshrimpy.quik.model.Recipient
+import dev.octoshrimpy.quik.util.GlideApp
+import dev.octoshrimpy.quik.util.tryOrNull
+import timber.log.Timber
+
+fun Conversation.getThemedIcon(context: Context, width: Int, height: Int): IconCompat {
+
+    var icon : IconCompat? = null
+    Timber.v("Photo not found, creating default icon")
+    val inflater = LayoutInflater.from(context)
+    val layout = FrameLayout(context)
+    layout.layout(0, 0, width, height)
+    layout.layoutParams = FrameLayout.LayoutParams(width, height)
+    val view = inflater.inflate(R.layout.group_avatar_view, layout)
+    view.layoutParams = FrameLayout.LayoutParams(width, height)
+    val avatar1 = view.findViewById<AvatarView>(R.id.avatar1)
+    val avatar2 = view.findViewById<AvatarView>(R.id.avatar2)
+    val avatar1Frame = view.findViewById<FrameLayout>(R.id.avatar1Frame)
+
+    avatar1Frame.setBackgroundTint(when (recipients.size > 1) {
+        true -> context.resolveThemeColor(android.R.attr.windowBackground)
+        false -> context.getColorCompat(android.R.color.transparent)
+    })
+    avatar1Frame.updateLayoutParams<LayoutParams> {
+        matchConstraintPercentWidth = if (recipients.size > 1) 0.75f else 1.0f
+    }
+    avatar2.isVisible = recipients.size > 1
+
+
+    recipients.getOrNull(0).run(avatar1::setRecipient)
+    recipients.getOrNull(1).run(avatar2::setRecipient)
+
+    view.apply {
+        measure(
+            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+        )
+        layout(0, 0, measuredWidth, measuredHeight)
+    }
+
+    Timber.v("w: ${view.measuredWidth}; h: ${view.measuredHeight}")
+    val bitmap = createBitmap(view.measuredWidth, view.measuredHeight, Bitmap.Config.ARGB_8888)
+    val canvas = android.graphics.Canvas(bitmap)
+    view.draw(canvas)
+
+    icon = IconCompat.createWithBitmap(bitmap)
+    return icon
+}

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/RecipientExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/RecipientExtensions.kt
@@ -1,0 +1,141 @@
+package dev.octoshrimpy.quik.common.util.extensions
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Path
+import android.provider.ContactsContract
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View.*
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.app.Person
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.IconCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.drawToBitmap
+import androidx.core.widget.TextViewCompat
+import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.util.Colors
+import dev.octoshrimpy.quik.common.widget.QkTextView
+import dev.octoshrimpy.quik.model.Recipient
+import dev.octoshrimpy.quik.util.GlideApp
+import dev.octoshrimpy.quik.util.tryOrNull
+import timber.log.Timber
+
+
+fun Recipient.getThemedIcon(context: Context, theme: Colors.Theme, width: Int, height: Int): IconCompat {
+    var icon : IconCompat? = null
+    if(contact != null) {
+        val req = GlideApp.with(context)
+            .asBitmap()
+            .circleCrop()
+            .load(contact!!.photoUri)
+            .submit(width, height)
+
+        val bitmap = tryOrNull { req.get() }
+        if (bitmap == null)
+            icon = null
+        else
+            icon = IconCompat.createWithBitmap(bitmap)
+    }
+    if(icon == null) { // If there is no contact or no photo, create the default icon
+        Timber.v("Photo not found, creating default icon")
+        val inflater = LayoutInflater.from(context)
+        val layout = FrameLayout(context)
+        layout.layout(0, 0, width, height)
+        layout.layoutParams = FrameLayout.LayoutParams(width, height)
+        val view = inflater.inflate(R.layout.avatar_view, layout)
+        view.layoutParams = FrameLayout.LayoutParams(width, height)
+        val textView = view.findViewById<QkTextView>(R.id.initial)
+        val iconView = view.findViewById<ImageView>(R.id.icon)
+        val photoView = view.findViewById<ImageView>(R.id.photo)
+
+        photoView.visibility = GONE
+        view.setBackgroundColor(theme.theme)
+        view.setBackgroundTint(theme.theme)
+        textView.setTextColor(theme.textPrimary)
+        TextViewCompat.setAutoSizeTextTypeWithDefaults(textView, TextViewCompat.AUTO_SIZE_TEXT_TYPE_NONE)
+        textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, height * 0.5f)
+        iconView.layoutParams = FrameLayout.LayoutParams((width * 0.5).toInt(), (height * 0.5).toInt(),
+            Gravity.CENTER)
+
+        if(contact != null) {
+            val initials = contact!!.name
+                .substringBefore(',')
+                .split(" ")
+                .filter { name -> name.isNotEmpty() }
+                .map { name -> name[0] }
+                .filter { initial -> initial.isLetterOrDigit() }
+                .map { initial -> initial.toString() }
+            if (initials.isNotEmpty()) {
+                textView.text =
+                    if (initials.size > 1) initials.first() + initials.last() else initials.first()
+                iconView.visibility = GONE
+            } else {
+                textView.text = null
+                iconView.visibility = VISIBLE
+            }
+        }
+        else {
+            textView.visibility = GONE
+            iconView.visibility = VISIBLE
+            iconView.setTint(theme.textPrimary)
+        }
+
+        view.apply {
+            measure(
+                MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+            )
+            layout(0, 0, measuredWidth, measuredHeight)
+        }
+
+        Timber.v("w: ${view.measuredWidth}; h: ${view.measuredHeight}")
+        val bitmap = createBitmap(view.measuredWidth, view.measuredHeight, Bitmap.Config.ARGB_8888)
+        val canvas = android.graphics.Canvas(bitmap)
+        canvas.clipPath(Path().apply {
+            addCircle(
+                (width / 2).toFloat(),
+                (height / 2).toFloat(),
+                (width / 2).toFloat(),
+                Path.Direction.CW
+            )
+        })
+        view.draw(canvas)
+
+        icon = IconCompat.createWithBitmap(bitmap)
+    }
+    return icon
+}
+
+@TargetApi(29)
+fun Person.Builder.fromRecipient(
+    recipient: Recipient,
+    context: Context,
+    colors: Colors
+): Person.Builder {
+    setName(recipient.getDisplayName())
+    setIcon(recipient.getThemedIcon(context, colors.theme(recipient), 512, 512))
+
+    recipient.contact
+        ?.let { contact -> "${ContactsContract.Contacts.CONTENT_LOOKUP_URI}/${contact.lookupKey}" }
+        ?.let(this::setUri)
+
+    setKey(recipient.address)
+
+    return this
+}
+
+/**
+ * Return a Person object corresponding to this recipient
+ */
+@TargetApi(29)
+fun Recipient.toPerson(context : Context, colors: Colors): Person {
+    val person = Person.Builder().fromRecipient(this, context, colors)
+    return person.build()
+}

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/RecipientExtensions.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/extensions/RecipientExtensions.kt
@@ -5,19 +5,15 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Path
 import android.provider.ContactsContract
-import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View.*
 import android.widget.FrameLayout
 import android.widget.ImageView
-import android.widget.TextView
 import androidx.core.app.Person
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.IconCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.drawToBitmap
 import androidx.core.widget.TextViewCompat
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.util.Colors
@@ -43,14 +39,12 @@ fun Recipient.getThemedIcon(context: Context, theme: Colors.Theme, width: Int, h
         else
             icon = IconCompat.createWithBitmap(bitmap)
     }
-    if(icon == null) { // If there is no contact or no photo, create the default icon
-        Timber.v("Photo not found, creating default icon")
+    if(icon == null) {
+        // If there is no contact or no photo, create the default icon using the avatar_view layout
         val inflater = LayoutInflater.from(context)
-        val layout = FrameLayout(context)
-        layout.layout(0, 0, width, height)
-        layout.layoutParams = FrameLayout.LayoutParams(width, height)
-        val view = inflater.inflate(R.layout.avatar_view, layout)
-        view.layoutParams = FrameLayout.LayoutParams(width, height)
+        val container = FrameLayout(context)
+        container.layoutParams = FrameLayout.LayoutParams(width, height)
+        val view = inflater.inflate(R.layout.avatar_view, container)
         val textView = view.findViewById<QkTextView>(R.id.initial)
         val iconView = view.findViewById<ImageView>(R.id.icon)
         val photoView = view.findViewById<ImageView>(R.id.photo)
@@ -87,7 +81,7 @@ fun Recipient.getThemedIcon(context: Context, theme: Colors.Theme, width: Int, h
             iconView.setTint(theme.textPrimary)
         }
 
-        view.apply {
+        container.apply {
             measure(
                 MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
                 MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
@@ -95,8 +89,8 @@ fun Recipient.getThemedIcon(context: Context, theme: Colors.Theme, width: Int, h
             layout(0, 0, measuredWidth, measuredHeight)
         }
 
-        Timber.v("w: ${view.measuredWidth}; h: ${view.measuredHeight}")
-        val bitmap = createBitmap(view.measuredWidth, view.measuredHeight, Bitmap.Config.ARGB_8888)
+        Timber.v("w: ${container.measuredWidth}; h: ${container.measuredHeight}")
+        val bitmap = createBitmap(container.measuredWidth, container.measuredHeight, Bitmap.Config.ARGB_8888)
         val canvas = android.graphics.Canvas(bitmap)
         canvas.clipPath(Path().apply {
             addCircle(
@@ -106,7 +100,7 @@ fun Recipient.getThemedIcon(context: Context, theme: Colors.Theme, width: Int, h
                 Path.Direction.CW
             )
         })
-        view.draw(canvas)
+        container.draw(canvas)
 
         icon = IconCompat.createWithBitmap(bitmap)
     }


### PR DESCRIPTION
Hi, this is for #423

This PR add the necessary shortcuts to the system and to notifications so Android can enable it's conversation features for QUIK : notifications will be displayed on top, you can define priority convs and you can uses and android's default conversations widget.

I also added a Recipient.getThemedIcon function to get unified icons between notifications, launcher shortcuts and in app view.

This is also a first step for bubbles support, but some more work is needed.

![Screenshot_20250421-002905_Trebuchet](https://github.com/user-attachments/assets/4056ee04-9741-4858-bf11-c48fd9108a06)
![Screenshot_20250421-003116_QUIK-Debug](https://github.com/user-attachments/assets/f2d00da7-3b0c-4956-a258-dcdd9cabb8a7)
![Screenshot_20250421-005756_Trebuchet](https://github.com/user-attachments/assets/162531cf-0e77-4776-b50e-40fe21c69f50)
![Screenshot_20250421-005010_Trebuchet](https://github.com/user-attachments/assets/14be9efa-596d-4452-aee0-3746a84dd368)
