### PR TITLE
Set allowBackup to false

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
 
     <application
         android:name=".common.QKApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:requestLegacyExternalStorage="true"


### PR DESCRIPTION
Patches CVE-2024-3430. Brought up in #443. A big thank you to @MatejKovacic for the report. On critical applications, `allowBackup` should be set to false, to prevent the application from leaking it's data.