### PR TITLE
Moved draft indicator to text snippet

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
@@ -109,16 +109,17 @@ class ConversationsAdapter @Inject constructor(
         holder.title.collapseEnabled = conversation.recipients.size > 1
         holder.title.text = buildSpannedString {
             append(conversation.getTitle())
-            if (conversation.draft.isNotEmpty()) {
-                color(theme) { append(" " + context.getString(R.string.main_draft)) }
-            }
         }
         holder.date.text = conversation.date.takeIf { it > 0 }?.let(dateFormatter::getConversationTimestamp)
         holder.snippet.text = when {
-            conversation.draft.isNotEmpty() -> conversation.draft
+            conversation.draft.isNotEmpty() -> context.getString(R.string.main_sender_draft, conversation.draft)
             conversation.me -> context.getString(R.string.main_sender_you, conversation.snippet)
             else -> conversation.snippet
         }
+
+        // Make the preview in italics if draft
+        if (conversation.draft.isNotEmpty()) holder.snippet.setTypeface(null, Typeface.ITALIC)
+
         holder.pinned.isVisible = conversation.pinned
         holder.unread.setTint(theme)
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
@@ -28,6 +28,7 @@ import android.widget.RemoteViewsService
 import androidx.core.text.bold
 import androidx.core.text.buildSpannedString
 import androidx.core.text.color
+import androidx.core.text.italic
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.DateFormatter
@@ -142,9 +143,6 @@ class WidgetAdapter(intent: Intent) : RemoteViewsService.RemoteViewsFactory {
         remoteViews.setTextColor(R.id.name, textPrimary)
         remoteViews.setTextViewText(R.id.name, boldText(buildSpannedString {
             append(conversation.getTitle())
-            if (conversation.draft.isNotEmpty()) {
-                color(theme.theme) { append(" " + context.getString(R.string.main_draft)) }
-            }
         }, conversation.unread))
 
         // Date
@@ -154,12 +152,17 @@ class WidgetAdapter(intent: Intent) : RemoteViewsService.RemoteViewsFactory {
 
         // Snippet
         val snippet = when {
-            conversation.draft.isNotEmpty() -> conversation.draft
+            conversation.draft.isNotEmpty() -> context.getString(
+                R.string.main_sender_draft,
+                conversation.draft
+            )
+
             conversation.me -> context.getString(R.string.main_sender_you, conversation.snippet)
             else -> conversation.snippet
         }
         remoteViews.setTextColor(R.id.snippet, if (conversation.unread) textPrimary else textTertiary)
         remoteViews.setTextViewText(R.id.snippet, boldText(snippet, conversation.unread))
+        remoteViews.setTextViewText(R.id.snippet, italicText(snippet, conversation.draft.isNotEmpty()))
 
         // set fill-in intent to be used for current item
         remoteViews.setOnClickFillInIntent(
@@ -187,6 +190,12 @@ class WidgetAdapter(intent: Intent) : RemoteViewsService.RemoteViewsFactory {
     private fun boldText(text: CharSequence?, shouldBold: Boolean): CharSequence? = when {
         shouldBold -> SpannableStringBuilder()
                 .bold { append(text) }
+        else -> text
+    }
+
+    private fun italicText(text: CharSequence?, shouldBold: Boolean): CharSequence? = when {
+        shouldBold -> SpannableStringBuilder()
+        .italic { append(text) }
         else -> text
     }
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -63,7 +63,6 @@
     <string name="main_syncing">Syncing messages…</string>
     <string name="main_sender_you">You: %s</string>
     <string name="main_sender_draft">Draft: %s</string>
-    <string name="main_draft">Draft</string>
     <string name="main_message_results_title">Results in messages</string>
     <string name="main_message_results">%d messages</string>
     <string name="inbox_empty_text">Your conversations will appear here</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="main_menu_rename_conversation">Rename conversation</string>
     <string name="main_syncing">Syncing messages…</string>
     <string name="main_sender_you">You: %s</string>
+    <string name="main_sender_draft">Draft: %s</string>
     <string name="main_draft">Draft</string>
     <string name="main_message_results_title">Results in messages</string>
     <string name="main_message_results">%d messages</string>


### PR DESCRIPTION
Fixes #457. Took a page out of Signal's book here and moved the draft indicator to the text snippet preview. This makes the previous groupchat issue irrelevant, but I also believe it's more consistent with how Quik indicates the user's outgoing messages. Currently they're indicated with `You: ...` while drafts have no prefix, which make it seem like an incoming message (especially when combined with the previously mentioned bug).

![Screenshot From 2025-05-18 01-41-46](https://github.com/user-attachments/assets/3db8c4d8-a3a5-47cf-8fd9-b6bb6896cadf)


This is my first time taking a stab at android development, so would love to hear any feedback! Kotlin is a liiiiitle unfamiliar to me, along with this codebase. Cheers!