### PR TITLE
Build debug build automatically with a debug key.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,43 +41,5 @@ To update the wiki, simply navigate to the [wiki tab](https://github.com/octoshr
 6. Submit a pull request with your change.
 **We have a build action on each pull request, if this build fails, please edit the pull request in order to make the build succeed.**
 ## Helpful Tips
-### [build.gradle](https://github.com/octoshrimpy/quik/blob/master/presentation/build.gradle) configuration for building locally
-```
-
-/*
-    signingConfigs {
-        release {
-            def keystoreProps = new Properties()
-            def keystorePropsFile = rootProject.file('./.gradle/.gradlerc')
-            storeFile file('./my-release-key.keystore')
-            keyAlias 'quik_release'
-            if (keystorePropsFile.exists()) {
-                keystoreProps.load(new FileInputStream(keystorePropsFile))
-            } else if (System.getenv("CI") == "true") {
-//                do nothing
-            } else {
-                throw new GradleException("Keystore properties file not found.")
-            }
-            storePassword keystoreProps['storePassword']
-            keyPassword keystoreProps['keyPassword']
-        }
-    }
-*/
-    buildTypes {
-        release {
-            minifyEnabled true
-            shrinkResources true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-       //     signingConfig signingConfigs.release
-        }
-    }
-
-    productFlavors {
-        withAnalytics { dimension "analytics" }
-        noAnalytics {
-        //    signingConfig signingConfigs.release
-        }
-    }
-```
 ### Set Java Version
 When building QUIK, make sure to download JDK 17 and specify an installation path for it. In Android Studio, you can do that in Settings > Build, Execution, Deployment > Build Tools > Gradle.

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -40,6 +40,7 @@ android {
     }
 
     signingConfigs {
+        debug // Uses the default debug keystore.
         release {
             def keystoreProps = new Properties()
             def keystorePropsFile = rootProject.file('./.gradle/.gradlerc')
@@ -47,16 +48,13 @@ android {
             keyAlias 'quik_release'
             if (keystorePropsFile.exists()) {
                 keystoreProps.load(new FileInputStream(keystorePropsFile))
-            } else if (System.getenv("CI") == "true") {
-//                do nothing
-            } else {
-                throw new GradleException("Keystore properties file not found.")
-            }
+            } else
+            // do nothing    
             storePassword keystoreProps['storePassword']
             keyPassword keystoreProps['keyPassword']
         }
     }
-    
+
     dependenciesInfo {
         // Disables dependency metadata when building APKs.
         includeInApk = false
@@ -75,6 +73,7 @@ android {
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
             resValue("string", "app_name", "QUIK-Debug")
+            signingConfig signingConfigs.debug
         }
     }
 
@@ -87,13 +86,12 @@ android {
         jvmTarget = "1.8"
     }
 
-
     productFlavors {
         withAnalytics { dimension "analytics" }
         noAnalytics {
-            signingConfig signingConfigs.release
         }
     }
+
     lint {
         abortOnError false
     }
@@ -232,4 +230,14 @@ dependencies {
 if (getGradle().getStartParameter().getTaskRequests().toString().contains("WithAnalytics")) {
     apply plugin: 'com.google.gms.google-services'
     apply plugin: 'com.google.firebase.crashlytics'
+}
+
+// Check to make sure that the keystore file is present when building a release
+gradle.taskGraph.whenReady { taskGraph ->
+    if ((taskGraph.hasTask(':assembleRelease') ||
+            taskGraph.allTasks.any { it.name == 'assembleRelease' }) &&
+            !file('./.gradle/.gradlerc').exists() &&
+            System.getenv("CI") != "true") {
+        throw new GradleException("Keystore properties file not found")
+    }
 }


### PR DESCRIPTION
After commenting out that signing configs block 3 times in a row, I got sick of it and changed it to automatically use the debug keys. I basically had to force android studio to generate a debug key, and then move the keystore existence check to another area. If the keystore check is in the signing configs section, it fails every time. So I moved it to the bottom, and now everything works. 

I also removed the section in the contributing guidelines about this.

Can you double check that a release still builds? I am pretty sure it will, but am unable to test that. Thanks!
