### PR TITLE
Notification improvements

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/receiver/BlockThreadReceiver.kt
+++ b/data/src/main/java/com/moez/QKSMS/receiver/BlockThreadReceiver.kt
@@ -18,6 +18,7 @@
  */
 package dev.octoshrimpy.quik.receiver
 
+import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -27,6 +28,7 @@ import dev.octoshrimpy.quik.interactor.MarkBlocked
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.util.Preferences
 import io.reactivex.schedulers.Schedulers
+import timber.log.Timber
 import javax.inject.Inject
 
 class BlockThreadReceiver : BroadcastReceiver() {
@@ -36,6 +38,7 @@ class BlockThreadReceiver : BroadcastReceiver() {
     @Inject lateinit var markBlocked: MarkBlocked
     @Inject lateinit var prefs: Preferences
 
+    @SuppressLint("CheckResult")
     override fun onReceive(context: Context, intent: Intent) {
         AndroidInjection.inject(this, context)
 
@@ -54,8 +57,14 @@ class BlockThreadReceiver : BroadcastReceiver() {
                     MarkBlocked.Params(listOf(threadId), prefs.blockingManager.get(), null)
                 )
             )
-            .subscribe { goAsync().finish() }
-            .dispose()
+            .subscribe(
+                {
+                    goAsync().finish()
+                },
+                { error ->
+                    Timber.e("BlockThreadReceiver", "blocking failed")
+                    goAsync().finish()
+                }
+            )
     }
-
 }

--- a/domain/src/main/java/com/moez/QKSMS/interactor/RetrySending.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/RetrySending.kt
@@ -19,12 +19,16 @@
 package dev.octoshrimpy.quik.interactor
 
 import dev.octoshrimpy.quik.extensions.mapNotNull
+import dev.octoshrimpy.quik.manager.NotificationManager
 import dev.octoshrimpy.quik.model.Message
 import dev.octoshrimpy.quik.repository.MessageRepository
 import io.reactivex.Flowable
 import javax.inject.Inject
 
-class RetrySending @Inject constructor(private val messageRepo: MessageRepository) : Interactor<Long>() {
+class RetrySending @Inject constructor(
+    private val messageRepo: MessageRepository,
+    private val notificationManager: NotificationManager
+) : Interactor<Long>() {
 
     override fun buildObservable(params: Long): Flowable<Message> {
         return Flowable.just(params)
@@ -35,6 +39,8 @@ class RetrySending @Inject constructor(private val messageRepo: MessageRepositor
                         true -> messageRepo.sendSms(message)
                         false -> messageRepo.resendMms(message)
                     }
+                    val threadId = message.threadId
+                    notificationManager.cancel(threadId.toInt() + 100000)
                 }
     }
 

--- a/domain/src/main/java/com/moez/QKSMS/manager/NotificationManager.kt
+++ b/domain/src/main/java/com/moez/QKSMS/manager/NotificationManager.kt
@@ -32,4 +32,6 @@ interface NotificationManager {
 
     fun getNotificationForBackup(): NotificationCompat.Builder
 
+    fun cancel(i: Int)
+
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -527,4 +527,8 @@ class NotificationManagerImpl @Inject constructor(
                 .setOngoing(true)
     }
 
+    override fun cancel(i: Int) {
+        notificationManager.cancel(i)
+    }
+
 }


### PR DESCRIPTION
This has two changes to the notifications. 
* As a follow up to #475, it cancels the notification after the resend action is completed, that way it doesn't confuse the user, and potentially cause duplicate sending.
* Closes #308. .dispose() was nuking the block process, leading to the number being blocked but the notification remaining. I removed the dispose so that it could complete in peace. (Also added some logging)