### PR TITLE
Fix archived toast's incorrect wording

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -440,10 +440,14 @@ class MainActivity : QkThemedActivity(), MainView {
     override fun showChangelog(changelog: ChangelogManager.CumulativeChangelog) =
         changelogDialog.show(changelog)
 
-    override fun showArchivedSnackbar(countConversationsArchived: Int) =
+    override fun showArchivedSnackbar(countConversationsArchived: Int, isArchiving: Boolean) =
         Snackbar.make(
             drawerLayout,
-            resources.getQuantityString(R.plurals.toast_archived, countConversationsArchived, countConversationsArchived),
+            if (isArchiving) {
+                resources.getQuantityString(R.plurals.toast_archived, countConversationsArchived, countConversationsArchived)
+            } else {
+                resources.getQuantityString(R.plurals.toast_unarchived, countConversationsArchived, countConversationsArchived)
+            },
             if (countConversationsArchived < 10) Snackbar.LENGTH_LONG
             else Snackbar.LENGTH_INDEFINITE
         ).let {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainView.kt
@@ -54,7 +54,7 @@ interface MainView : QkView<MainState> {
     fun showDeleteDialog(conversations: List<Long>)
     fun showRenameDialog(conversationName: String)
     fun showChangelog(changelog: ChangelogManager.CumulativeChangelog)
-    fun showArchivedSnackbar(countConversationsArchived: Int)
+    fun showArchivedSnackbar(countConversationsArchived: Int, isArchiving: Boolean)
     fun drawerToggled(opened: Boolean)
 }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -348,7 +348,7 @@ class MainViewModel @Inject constructor(
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
                     markArchived.execute(conversations)
                     lastArchivedThreadIds = conversations.toList()
-                    view.showArchivedSnackbar(lastArchivedThreadIds.count())
+                    view.showArchivedSnackbar(lastArchivedThreadIds.count(), true)
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -358,7 +358,7 @@ class MainViewModel @Inject constructor(
                 .filter { itemId -> itemId == R.id.unarchive }
                 .withLatestFrom(view.conversationsSelectedIntent) { _, conversations ->
                     markUnarchived.execute(conversations.toList())
-                    view.showArchivedSnackbar(conversations.count())
+                    view.showArchivedSnackbar(conversations.count(), false)
                     view.clearSelection()
                 }
                 .autoDisposable(view.scope())
@@ -523,7 +523,7 @@ class MainViewModel @Inject constructor(
                         Preferences.SWIPE_ACTION_ARCHIVE ->
                             markArchived.execute(listOf(threadId)) {
                                 lastArchivedThreadIds = listOf(threadId)
-                                view.showArchivedSnackbar(1)
+                                view.showArchivedSnackbar(1, true)
                             }
                         Preferences.SWIPE_ACTION_DELETE ->
                             view.showDeleteDialog(listOf(threadId))

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -477,6 +477,10 @@
         <item quantity="one">Archived conversation</item>
         <item quantity="other">Archived %d conversations</item>
     </plurals>
+    <plurals name="toast_unarchived">
+        <item quantity="one">Unarchived conversation</item>
+        <item quantity="other">Unarchived %d conversations</item>
+    </plurals>
 
     <string name="toast_qksms_plus">You must unlock QUIK+ to use this</string>
 


### PR DESCRIPTION
Previously it said that messages were archived when they actually were unarchived. The app no longer engages in this duplicity.