### PR TITLE
Normalize numbers before comparing.

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/util/PhoneNumberUtils.kt
+++ b/data/src/main/java/com/moez/QKSMS/util/PhoneNumberUtils.kt
@@ -39,12 +39,14 @@ class PhoneNumberUtils @Inject constructor(context: Context) {
      * This method will run successfully stricter checks without compromising much speed
      */
     fun compare(first: String, second: String): Boolean {
-        if (first.equals(second, true)) {
+        val normalizedFirst = normalizeNumber(first)
+        val normalizedSecond = normalizeNumber(second)
+        if (normalizedFirst.equals(normalizedSecond, true)) {
             return true
         }
 
         if (PhoneNumberUtils.compare(first, second)) {
-            val matchType = phoneNumberUtil.isNumberMatch(first, second)
+            val matchType = phoneNumberUtil.isNumberMatch(normalizedFirst, normalizedSecond)
             if (matchType >= PhoneNumberUtil.MatchType.SHORT_NSN_MATCH) {
                 return true
             }


### PR DESCRIPTION
When QUIK receives a message it compares to see if it goes into a new conversation or an existing. However, if the numbers are formatted differently, it will think that they are separate convos. Hopefully, normalizing before comparing will fix that.