### PR TITLE
Improvements to the mark (un)read actions

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
@@ -36,6 +36,7 @@ import dev.octoshrimpy.quik.feature.blocking.BlockingActivity
 import dev.octoshrimpy.quik.feature.compose.ComposeActivity
 import dev.octoshrimpy.quik.feature.conversationinfo.ConversationInfoActivity
 import dev.octoshrimpy.quik.feature.gallery.GalleryActivity
+import dev.octoshrimpy.quik.feature.main.MainActivity
 import dev.octoshrimpy.quik.feature.notificationprefs.NotificationPrefsActivity
 import dev.octoshrimpy.quik.feature.plus.PlusActivity
 import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivity
@@ -90,6 +91,11 @@ class Navigator @Inject constructor(
             intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, context.packageName)
             context.startActivity(intent)
         }
+    }
+
+    fun showMainActivity() {
+        val intent = Intent(context, MainActivity::class.java)
+        startActivity(intent)
     }
 
     fun showCompose(body: String? = null, attachments: List<Uri>? = null, mode: String? = null) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoAdapter.kt
@@ -31,6 +31,7 @@ class ConversationInfoAdapter @Inject constructor(
     val themeClicks: Subject<Long> = PublishSubject.create()
     val nameClicks: Subject<Unit> = PublishSubject.create()
     val notificationClicks: Subject<Unit> = PublishSubject.create()
+    val markUnreadClicks: Subject<Unit> = PublishSubject.create()
     val archiveClicks: Subject<Unit> = PublishSubject.create()
     val blockClicks: Subject<Unit> = PublishSubject.create()
     val deleteClicks: Subject<Unit> = PublishSubject.create()
@@ -60,6 +61,7 @@ class ConversationInfoAdapter @Inject constructor(
             1 -> QkViewHolder(inflater.inflate(R.layout.conversation_info_settings, parent, false)).apply {
                 groupName.clicks().subscribe(nameClicks)
                 notifications.clicks().subscribe(notificationClicks)
+                markUnread.clicks().subscribe(markUnreadClicks)
                 archive.clicks().subscribe(archiveClicks)
                 block.clicks().subscribe(blockClicks)
                 delete.clicks().subscribe(deleteClicks)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoController.kt
@@ -102,6 +102,7 @@ class ConversationInfoController(
     override fun nameClicks(): Observable<*> = adapter.nameClicks
     override fun nameChanges(): Observable<String> = nameChangeSubject
     override fun notificationClicks(): Observable<*> = adapter.notificationClicks
+    override fun markUnreadClicks(): Observable<*> = adapter.markUnreadClicks
     override fun archiveClicks(): Observable<*> = adapter.archiveClicks
     override fun blockClicks(): Observable<*> = adapter.blockClicks
     override fun deleteClicks(): Observable<*> = adapter.deleteClicks
@@ -132,5 +133,4 @@ class ConversationInfoController(
                 .setNegativeButton(R.string.button_cancel, null)
                 .show()
     }
-
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoPresenter.kt
@@ -34,6 +34,7 @@ import dev.octoshrimpy.quik.feature.conversationinfo.ConversationInfoItem.Conver
 import dev.octoshrimpy.quik.interactor.DeleteConversations
 import dev.octoshrimpy.quik.interactor.MarkArchived
 import dev.octoshrimpy.quik.interactor.MarkUnarchived
+import dev.octoshrimpy.quik.interactor.MarkUnread
 import dev.octoshrimpy.quik.manager.PermissionManager
 import dev.octoshrimpy.quik.model.Conversation
 import dev.octoshrimpy.quik.repository.ConversationRepository
@@ -53,6 +54,7 @@ class ConversationInfoPresenter @Inject constructor(
     private val context: Context,
     private val conversationRepo: ConversationRepository,
     private val deleteConversations: DeleteConversations,
+    private val markUnread: MarkUnread,
     private val markArchived: MarkArchived,
     private val markUnarchived: MarkUnarchived,
     private val navigator: Navigator,
@@ -157,6 +159,14 @@ class ConversationInfoPresenter @Inject constructor(
                 .withLatestFrom(conversation) { _, conversation -> conversation }
                 .autoDisposable(view.scope())
                 .subscribe { conversation -> navigator.showNotificationSettings(conversation.id) }
+
+        view.markUnreadClicks()
+                .withLatestFrom(conversation) { _, conversation -> conversation }
+                .autoDisposable(view.scope())
+                .subscribe {conversation ->
+                    markUnread.execute(listOf(conversation.id))
+                    navigator.showMainActivity()
+                }
 
         // Toggle the archived state of the conversation
         view.archiveClicks()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoView.kt
@@ -29,6 +29,7 @@ interface ConversationInfoView : QkViewContract<ConversationInfoState> {
     fun nameClicks(): Observable<*>
     fun nameChanges(): Observable<String>
     fun notificationClicks(): Observable<*>
+    fun markUnreadClicks(): Observable<*>
     fun archiveClicks(): Observable<*>
     fun blockClicks(): Observable<*>
     fun deleteClicks(): Observable<*>

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -255,8 +255,10 @@ class MainActivity : QkThemedActivity(), MainView {
             findItem(R.id.add)?.isVisible = addContact && selectedConversations != 0
             findItem(R.id.pin)?.isVisible = markPinned && selectedConversations != 0
             findItem(R.id.unpin)?.isVisible = !markPinned && selectedConversations != 0
-            findItem(R.id.read)?.isVisible = markRead && selectedConversations != 0
-            findItem(R.id.unread)?.isVisible = !markRead && selectedConversations != 0
+            findItem(R.id.read)?.isVisible = ( markRead && selectedConversations != 0 ) ||
+                    selectedConversations > 1
+            findItem(R.id.unread)?.isVisible = ( !markRead && selectedConversations != 0 ) ||
+                    selectedConversations > 1
             findItem(R.id.block)?.isVisible = selectedConversations != 0
             findItem(R.id.rename)?.isVisible = selectedConversations == 1
         }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -467,7 +467,11 @@ class MainViewModel @Inject constructor(
                             ?.recipients?.first()
                             ?.takeIf { recipient -> recipient.contact == null } != null
                     val pin = conversations.sumBy { if (it.pinned) -1 else 1 } >= 0
-                    val read = conversations.sumBy { if (!it.unread) -1 else 1 } >= 0
+                    val read = when (conversations.size) {
+                        0    -> false
+                        1    -> conversations[0].unread
+                        else -> true
+                    }
                     val selected = selection.size
 
                     when (state.page) {

--- a/presentation/src/main/res/layout/conversation_info_settings.xml
+++ b/presentation/src/main/res/layout/conversation_info_settings.xml
@@ -44,6 +44,13 @@
         app:title="@string/info_notifications" />
 
     <dev.octoshrimpy.quik.common.widget.PreferenceView
+        android:id="@+id/markUnread"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:icon="@drawable/ic_markunread_black_24dp"
+        app:title="@string/main_menu_unread" />
+
+    <dev.octoshrimpy.quik.common.widget.PreferenceView
         android:id="@+id/archive"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
- 3bf1e710225058335b36342ea0adf04cf84443d8: Makes changes so that both mark read and unread are present when multiple messages are selected
- 25f4716572f387b745e5fda31e4b57747a24f5b7: Adds an action to mark unread (and then navigate back to the main activity) from the conversation info

Closes #500