### PR TITLE
Fix draft being sorted at the bottom

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
+++ b/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
@@ -36,7 +36,7 @@ class QkRealmMigration @Inject constructor(
 ) : RealmMigration {
 
     companion object {
-        const val SchemaVersion: Long = 12
+        const val SchemaVersion: Long = 13
     }
 
     @SuppressLint("ApplySharedPref")
@@ -239,10 +239,6 @@ class QkRealmMigration @Inject constructor(
             // Because there was never any property associated with which conversation/recipients a scheduled message was for,
             // we can't update this field on a realm migration. It will be set to a default of 0
 
-            version++
-        }
-
-        if (version == 11L) {
             realm.schema.create("MessageContentFilter")
                 .addField("id", Long::class.java, FieldAttribute.PRIMARY_KEY, FieldAttribute.REQUIRED)
                 .addField("value", String::class.java, FieldAttribute.REQUIRED)
@@ -250,6 +246,12 @@ class QkRealmMigration @Inject constructor(
                 .addField("isRegex", Boolean::class.java, FieldAttribute.REQUIRED)
                 .addField("includeContacts", Boolean::class.java, FieldAttribute.REQUIRED)
 
+            version++
+        }
+
+        if (version == 12L) {
+            realm.schema.get("Conversation")
+                ?.addField("draftDate", Long::class.java, FieldAttribute.REQUIRED)
             version++
         }
 

--- a/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
@@ -353,6 +353,7 @@ class ConversationRepositoryImpl @Inject constructor(
 
             realm.executeTransaction {
                 conversation?.takeIf { it.isValid }?.draft = draft
+                conversation?.takeIf { it.isValid }?.draftDate = System.currentTimeMillis()
             }
         }
 

--- a/domain/src/main/java/com/moez/QKSMS/model/Conversation.kt
+++ b/domain/src/main/java/com/moez/QKSMS/model/Conversation.kt
@@ -31,6 +31,7 @@ open class Conversation(
     var recipients: RealmList<Recipient> = RealmList(),
     var lastMessage: Message? = null,
     var draft: String = "",
+    var draftDate: Long = 0,
 
     var blockingClient: Int? = null,
     var blockReason: String? = null,
@@ -38,7 +39,7 @@ open class Conversation(
     var name: String = "" // For group chats, the user is allowed to set a custom title for the conversation
 ) : RealmObject() {
 
-    val date: Long get() = lastMessage?.date ?: 0
+    val date: Long get() = lastMessage?.date ?: if (draft.isNotEmpty()) draftDate else 0
     val snippet: String? get() = lastMessage?.getSummary()
     val unread: Boolean get() = lastMessage?.read == false
     val me: Boolean get() = lastMessage?.isMe() == true


### PR DESCRIPTION
~~No idea, whether or not this actually fixes the issue, I am just guessing that a missing date was the problem.~~
Seems to have fixed it. Apparently, the date property wasn't getting passed to new conversation's drafts. (Maybe it was an Android 13 or e os thing)
Closes #513
Closes #431