### PR TITLE
Various improvements to the widget

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -201,6 +201,7 @@
         </receiver>
         <receiver
             android:name=".feature.widget.WidgetProvider"
+            android:label="@string/all_conversations_widget_title"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetAdapter.kt
@@ -94,7 +94,7 @@ class WidgetAdapter(intent: Intent) : RemoteViewsService.RemoteViewsFactory {
      * we'll return the max count + 1, where the last row just shows "View more conversations"
      */
     override fun getCount(): Int {
-        val count = Math.min(conversations.size, MAX_CONVERSATIONS_COUNT)
+        val count = conversations.size.coerceAtMost(MAX_CONVERSATIONS_COUNT)
         val shouldShowViewMore = count < conversations.size
         return count + if (shouldShowViewMore) 1 else 0
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetProvider.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetProvider.kt
@@ -25,6 +25,7 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.widget.RemoteViews
@@ -109,8 +110,11 @@ class WidgetProvider : AppWidgetProvider() {
         Timber.v("updateWidget appWidgetId: $appWidgetId")
         val remoteViews = RemoteViews(context.packageName, R.layout.widget)
 
+        val nightModeFlags = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val isNightMode = nightModeFlags == Configuration.UI_MODE_NIGHT_YES
+
         // Apply colors from theme
-        val night = prefs.night.get()
+        val night = prefs.night.get() || isNightMode
         val black = prefs.black.get()
 
         remoteViews.setInt(R.id.background, "setColorFilter", context.getColorCompat(when {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetProvider.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/widget/WidgetProvider.kt
@@ -26,7 +26,6 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
-import android.net.Uri
 import android.os.Bundle
 import android.widget.RemoteViews
 import dagger.android.AndroidInjection
@@ -40,6 +39,7 @@ import dev.octoshrimpy.quik.receiver.StartActivityFromWidgetReceiver
 import dev.octoshrimpy.quik.util.Preferences
 import timber.log.Timber
 import javax.inject.Inject
+import androidx.core.net.toUri
 
 class WidgetProvider : AppWidgetProvider() {
 
@@ -138,7 +138,7 @@ class WidgetProvider : AppWidgetProvider() {
         val intent = Intent(context, WidgetService::class.java)
                 .putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
                 .putExtra("small_widget", smallWidget)
-        intent.data = Uri.parse(intent.toUri(Intent.URI_INTENT_SCHEME))
+        intent.data = intent.toUri(Intent.URI_INTENT_SCHEME).toUri()
         remoteViews.setRemoteAdapter(R.id.conversations, intent)
 
         // compose new message image color and on click intent

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -433,6 +433,7 @@
 
     <string name="widget_loading">Loading…</string>
     <string name="widget_more">View more conversations</string>
+    <string name="all_conversations_widget_title">All Conversations</string>
 
     <string name="qkreply_menu_read">Mark read</string>
     <string name="qkreply_menu_call">Call</string>


### PR DESCRIPTION
This fixes an issue where system theme was not respected in the widget, upgrades some deprecated sections, and renames the widget title to `All Conversations` rather than `QUIK`.
Closes #34 