### PR TITLE
Refactor sync code to use an async transaction/separate looper thread

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/SyncRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/SyncRepositoryImpl.kt
@@ -21,6 +21,8 @@ package dev.octoshrimpy.quik.repository
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.net.Uri
+import android.os.Handler
+import android.os.HandlerThread
 import android.provider.Telephony
 import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dev.octoshrimpy.quik.extensions.forEach
@@ -49,6 +51,7 @@ import io.reactivex.subjects.Subject
 import io.realm.Realm
 import io.realm.RealmList
 import io.realm.Sort
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -73,146 +76,171 @@ class SyncRepositoryImpl @Inject constructor(
 
     override fun syncMessages() {
 
+        val oldBlockedSenders = rxPrefs.getStringSet("pref_key_blocked_senders")
+
         // If the sync is already running, don't try to do another one
         if (syncProgress.blockingFirst() is SyncRepository.SyncProgress.Running) return
         syncProgress.onNext(SyncRepository.SyncProgress.Running(0, 0, true))
 
-        val realm = Realm.getDefaultInstance()
-        realm.beginTransaction()
+        val handlerThread = HandlerThread("RealmSyncThread")
+        handlerThread.start()
+        Handler(handlerThread.looper).post {
+            Realm.getDefaultInstance().executeTransactionAsync(
+                { realm ->
+                // Prepare existing conversation data
+                val persistedData = realm.copyFromRealm(
+                    realm.where(Conversation::class.java)
+                        .beginGroup()
+                        .equalTo("archived", true)
+                        .or()
+                        .equalTo("blocked", true)
+                        .or()
+                        .equalTo("pinned", true)
+                        .or()
+                        .isNotEmpty("name")
+                        .or()
+                        .isNotNull("blockingClient")
+                        .or()
+                        .isNotEmpty("blockReason")
+                        .endGroup()
+                        .findAll()
+                ).associateBy { conversation -> conversation.id }.toMutableMap()
 
-        val persistedData = realm.copyFromRealm(realm.where(Conversation::class.java)
-                .beginGroup()
-                .equalTo("archived", true)
-                .or()
-                .equalTo("blocked", true)
-                .or()
-                .equalTo("pinned", true)
-                .or()
-                .isNotEmpty("name")
-                .or()
-                .isNotNull("blockingClient")
-                .or()
-                .isNotEmpty("blockReason")
-                .endGroup()
-                .findAll())
-                .associateBy { conversation -> conversation.id }
-                .toMutableMap()
+                removeOldMessages(realm)
 
-        realm.delete(Contact::class.java)
-        realm.delete(ContactGroup::class.java)
-        realm.delete(Conversation::class.java)
-        realm.delete(Message::class.java)
-        realm.delete(MmsPart::class.java)
-        realm.delete(Recipient::class.java)
+                keys.reset()
 
-        keys.reset()
+                val partsCursor = cursorToPart.getPartsCursor()
+                val messageCursor = cursorToMessage.getMessagesCursor()
+                val conversationCursor = cursorToConversation.getConversationsCursor()
+                val recipientCursor = cursorToRecipient.getRecipientCursor()
 
-        val partsCursor = cursorToPart.getPartsCursor()
-        val messageCursor = cursorToMessage.getMessagesCursor()
-        val conversationCursor = cursorToConversation.getConversationsCursor()
-        val recipientCursor = cursorToRecipient.getRecipientCursor()
+                val max = (partsCursor?.count ?: 0) +
+                        (messageCursor?.count ?: 0) +
+                        (conversationCursor?.count ?: 0) +
+                        (recipientCursor?.count ?: 0)
 
-        val max = (partsCursor?.count ?: 0) +
-                (messageCursor?.count ?: 0) +
-                (conversationCursor?.count ?: 0) +
-                (recipientCursor?.count ?: 0)
+                var progress = 0
 
-        var progress = 0
-
-        // Sync message parts
-        partsCursor?.use {
-            partsCursor.forEach {
-                tryOrNull {
-                    progress++
-                    val part = cursorToPart.map(partsCursor)
-                    realm.insertOrUpdate(part)
+                // Sync message parts
+                partsCursor?.use {
+                    partsCursor.forEach { cursor ->
+                        tryOrNull {
+                            val part = cursorToPart.map(partsCursor)
+                            realm.insertOrUpdate(part)
+                            progress++
+                        }
+                    }
                 }
-            }
-        }
 
-        // Sync messages
-        messageCursor?.use {
-            val messageColumns = CursorToMessage.MessageColumns(messageCursor)
-            messageCursor.forEach { cursor ->
-                tryOrNull {
-                    progress++
-                    syncProgress.onNext(SyncRepository.SyncProgress.Running(max, progress, false))
-                    val message = cursorToMessage.map(Pair(cursor, messageColumns)).apply {
-                        if (isMms()) {
-                            parts = RealmList<MmsPart>().apply {
-                                addAll(realm.where(MmsPart::class.java)
-                                        .equalTo("messageId", contentId)
-                                        .findAll())
+                // Sync messages
+                messageCursor?.use {
+                    val messageColumns = CursorToMessage.MessageColumns(messageCursor)
+                    messageCursor.forEach { cursor ->
+                        tryOrNull {
+                            syncProgress.onNext(
+                                SyncRepository.SyncProgress.Running(
+                                    max,
+                                    ++progress,
+                                    false
+                                )
+                            )
+                            val message = cursorToMessage.map(Pair(cursor, messageColumns)).apply {
+                                if (isMms()) {
+                                    parts = RealmList<MmsPart>().apply {
+                                        addAll(
+                                            realm.where(MmsPart::class.java)
+                                                .equalTo("messageId", contentId)
+                                                .findAll()
+                                        )
+                                    }
+                                }
                             }
+                            realm.insertOrUpdate(message)
                         }
                     }
-                    realm.insertOrUpdate(message)
                 }
-            }
-        }
 
-        // Migrate blocked conversations from 2.7.3
-        val oldBlockedSenders = rxPrefs.getStringSet("pref_key_blocked_senders")
-        oldBlockedSenders.get()
-                .map { threadIdString -> threadIdString.toLong() }
-                .filter { threadId -> !persistedData.contains(threadId) }
-                .forEach { threadId -> persistedData[threadId] = Conversation(id = threadId, blocked = true) }
-
-        // Sync conversations
-        conversationCursor?.use {
-            conversationCursor.forEach { cursor ->
-                tryOrNull {
-                    progress++
-                    syncProgress.onNext(SyncRepository.SyncProgress.Running(max, progress, false))
-                    val conversation = cursorToConversation.map(cursor).apply {
-                        persistedData[id]?.let { persistedConversation ->
-                            archived = persistedConversation.archived
-                            blocked = persistedConversation.blocked
-                            pinned = persistedConversation.pinned
-                            name = persistedConversation.name
-                            blockingClient = persistedConversation.blockingClient
-                            blockReason = persistedConversation.blockReason
-                        }
-                        lastMessage = realm.where(Message::class.java)
-                                .sort("date", Sort.DESCENDING)
-                                .equalTo("threadId", id)
-                                .findFirst()
+                // Migrate blocked conversations from 2.7.3
+                oldBlockedSenders.get()
+                    .map { threadIdString -> threadIdString.toLong() }
+                    .filter { threadId -> !persistedData.contains(threadId) }
+                    .forEach { threadId ->
+                        persistedData[threadId] = Conversation(id = threadId, blocked = true)
                     }
-                    realm.insertOrUpdate(conversation)
-                }
-            }
-        }
 
-        // Sync recipients
-        recipientCursor?.use {
-            val contacts = realm.copyToRealmOrUpdate(getContacts())
-            recipientCursor.forEach { cursor ->
-                tryOrNull {
-                    progress++
-                    syncProgress.onNext(SyncRepository.SyncProgress.Running(max, progress, false))
-                    val recipient = cursorToRecipient.map(cursor).apply {
-                        contact = contacts.firstOrNull { contact ->
-                            contact.numbers.any { phoneNumberUtils.compare(address, it.address) }
+                // Sync conversations
+                conversationCursor?.use {
+                    conversationCursor.forEach { cursor ->
+                        tryOrNull {
+                            syncProgress.onNext(
+                                SyncRepository.SyncProgress.Running(
+                                    max,
+                                    ++progress,
+                                    false
+                                )
+                            )
+                            val conversation = cursorToConversation.map(cursor).apply {
+                                persistedData[id]?.let { persistedConversation ->
+                                    archived = persistedConversation.archived
+                                    blocked = persistedConversation.blocked
+                                    pinned = persistedConversation.pinned
+                                    name = persistedConversation.name
+                                    blockingClient = persistedConversation.blockingClient
+                                    blockReason = persistedConversation.blockReason
+                                }
+                                lastMessage = realm.where(Message::class.java)
+                                    .sort("date", Sort.DESCENDING)
+                                    .equalTo("threadId", id)
+                                    .findFirst()
+                            }
+                            realm.insertOrUpdate(conversation)
                         }
                     }
-                    realm.insertOrUpdate(recipient)
                 }
-            }
+
+                // Sync recipients
+                val contacts = realm.copyToRealmOrUpdate(getContacts())
+                recipientCursor?.use {
+                    recipientCursor.forEach { cursor ->
+                        tryOrNull {
+                            syncProgress.onNext(
+                                SyncRepository.SyncProgress.Running(
+                                    max,
+                                    ++progress,
+                                    false
+                                )
+                            )
+                            val rec = cursorToRecipient.map(cursor).apply {
+                                contact = contacts.firstOrNull { c ->
+                                    c.numbers.any { num ->
+                                        phoneNumberUtils.compare(
+                                            address,
+                                            num.address
+                                        )
+                                    }
+                                }
+                            }
+                            realm.insertOrUpdate(rec)
+                        }
+                    }
+                }
+
+                syncProgress.onNext(SyncRepository.SyncProgress.Running(0, 0, true))
+
+                realm.insert(SyncLog())
+            }, {
+                handlerThread.quitSafely()
+                oldBlockedSenders.delete()
+                syncProgress.onNext(SyncRepository.SyncProgress.Idle)
+            },
+                { error ->
+                    handlerThread.quitSafely()
+                    Timber.e(error, "syncMessages Failed")
+                    syncProgress.onNext(SyncRepository.SyncProgress.Idle)
+                })
         }
-
-        syncProgress.onNext(SyncRepository.SyncProgress.Running(0, 0, true))
-
-
-        realm.insert(SyncLog())
-        realm.commitTransaction()
-        realm.close()
-
-        // Only delete this after the sync has successfully completed
-        oldBlockedSenders.delete()
-
-        syncProgress.onNext(SyncRepository.SyncProgress.Idle)
     }
-
     override fun syncMessage(uri: Uri): Message? {
 
         // If we don't have a valid type, return null
@@ -343,6 +371,15 @@ class SyncRepositoryImpl @Inject constructor(
         }
 
         return groups
+    }
+
+    private fun removeOldMessages(realm: Realm) {
+        realm.delete(Contact::class.java)
+        realm.delete(ContactGroup::class.java)
+        realm.delete(Conversation::class.java)
+        realm.delete(Message::class.java)
+        realm.delete(MmsPart::class.java)
+        realm.delete(Recipient::class.java)
     }
 
 }


### PR DESCRIPTION
I am guessing that on large message db, sync could be unreliable hence the issue in #520. This speeds up the sync process, and makes it more robust
Closes #520