### PR TITLE
Bump kotlin version to 1.7.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext.exoplayer_version = "r2.9.0"
     ext.glide_version = "4.16.0"
     ext.junit_version = '4.12'
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.7.21'
     ext.lifecycle_version = '2.1.0'
     ext.material_version = '1.0.0'
     ext.mockito_version = '2.18.3'


### PR DESCRIPTION
I'm unable to compile the app on 1.7.20 due to:

java.lang.IllegalAccessError: superclass access check failed: class org.jetbrains.kotlin.kapt3.base.javac.KaptJavaCompiler (in unnamed module @0x47dc37ed) cannot access class com.sun.tools.javac.main.JavaCompiler (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.main to unnamed module @0x47dc37ed'

This is mentioned in #100 