### PR TITLE
Start migration to view bindings

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -89,6 +89,7 @@ android {
     namespace 'dev.octoshrimpy.quik'
     buildFeatures {
         buildConfig true
+        viewBinding true
     }
     if (System.getenv("CI") == "true") {
         signingConfigs.release.storePassword = System.getenv("keystore_password")

--- a/presentation/src/main/java/com/moez/QKSMS/common/MenuItemAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/MenuItemAdapter.kt
@@ -24,22 +24,20 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.ArrayRes
 import androidx.recyclerview.widget.RecyclerView
-import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
 import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColor
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
+import dev.octoshrimpy.quik.databinding.MenuListItemBinding
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.menu_list_item.*
-import kotlinx.android.synthetic.main.menu_list_item.view.*
 import javax.inject.Inject
 
 data class MenuItem(val title: String, val actionId: Int)
 
-class MenuItemAdapter @Inject constructor(private val context: Context, private val colors: Colors) : QkAdapter<MenuItem, QkViewHolder>() {
+class MenuItemAdapter @Inject constructor(private val context: Context, private val colors: Colors) : QkAdapter<MenuItem, QkBindingViewHolder<MenuListItemBinding>>() {
 
     val menuItemClicks: Subject<Int> = PublishSubject.create()
 
@@ -63,31 +61,30 @@ class MenuItemAdapter @Inject constructor(private val context: Context, private 
                 .mapIndexed { index, title -> MenuItem(title, valueInts?.getOrNull(index) ?: index) }
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        val layoutInflater = LayoutInflater.from(parent.context)
-        val view = layoutInflater.inflate(R.layout.menu_list_item, parent, false)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<MenuListItemBinding> {
+        val binding = MenuListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 
         val states = arrayOf(
                 intArrayOf(android.R.attr.state_activated),
                 intArrayOf(-android.R.attr.state_activated))
 
         val text = parent.context.resolveThemeColor(android.R.attr.textColorTertiary)
-        view.check.imageTintList = ColorStateList(states, intArrayOf(colors.theme().theme, text))
+        binding.check.imageTintList = ColorStateList(states, intArrayOf(colors.theme().theme, text))
 
-        return QkViewHolder(view).apply {
-            view.setOnClickListener {
+        return QkBindingViewHolder(binding).apply {
+            binding.root.setOnClickListener {
                 val menuItem = getItem(adapterPosition)
                 menuItemClicks.onNext(menuItem.actionId)
             }
         }
     }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<MenuListItemBinding>, position: Int) {
         val menuItem = getItem(position)
 
-        holder.title.text = menuItem.title
-        holder.check.isActivated = (menuItem.actionId == selectedItem)
-        holder.check.setVisible(selectedItem != null)
+        holder.binding.title.text = menuItem.title
+        holder.binding.check.isActivated = (menuItem.actionId == selectedItem)
+        holder.binding.check.setVisible(selectedItem != null)
     }
 
     override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkActivity.kt
@@ -22,6 +22,7 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import dev.octoshrimpy.quik.util.Preferences
@@ -59,6 +60,12 @@ abstract class QkActivity : AppCompatActivity() {
 
     override fun setContentView(layoutResID: Int) {
         super.setContentView(layoutResID)
+        setSupportActionBar(toolbar)
+        title = title // The title may have been set before layout inflation
+    }
+
+    override fun setContentView(view: View?) {
+        super.setContentView(view)
         setSupportActionBar(toolbar)
         title = title // The title may have been set before layout inflation
     }

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkRealmAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkRealmAdapter.kt
@@ -30,7 +30,7 @@ import io.realm.RealmRecyclerViewAdapter
 import io.realm.RealmResults
 import timber.log.Timber
 
-abstract class QkRealmAdapter<T : RealmModel> : RealmRecyclerViewAdapter<T, QkViewHolder>(null, true) {
+abstract class QkRealmAdapter<T : RealmModel, VH : QkViewHolder> : RealmRecyclerViewAdapter<T, VH>(null, true) {
 
     /**
      * This view can be set, and the adapter will automatically control the visibility of this view

--- a/presentation/src/main/java/com/moez/QKSMS/common/base/QkViewHolder.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/base/QkViewHolder.kt
@@ -20,8 +20,11 @@ package dev.octoshrimpy.quik.common.base
 
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
 import kotlinx.android.extensions.LayoutContainer
 
 open class QkViewHolder(view: View) : RecyclerView.ViewHolder(view), LayoutContainer {
     override val containerView: View = view
 }
+
+open class QkBindingViewHolder<T : ViewBinding>(val binding: T) : QkViewHolder(binding.root)

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/AvatarView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/AvatarView.kt
@@ -21,7 +21,6 @@ package dev.octoshrimpy.quik.common.widget
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import android.view.View
 import android.widget.FrameLayout
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.Navigator

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/AvatarView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/AvatarView.kt
@@ -20,6 +20,7 @@ package dev.octoshrimpy.quik.common.widget
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import dev.octoshrimpy.quik.R
@@ -27,10 +28,10 @@ import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.extensions.setBackgroundTint
 import dev.octoshrimpy.quik.common.util.extensions.setTint
+import dev.octoshrimpy.quik.databinding.AvatarViewBinding
 import dev.octoshrimpy.quik.injection.appComponent
 import dev.octoshrimpy.quik.model.Recipient
 import dev.octoshrimpy.quik.util.GlideApp
-import kotlinx.android.synthetic.main.avatar_view.view.*
 import javax.inject.Inject
 
 class AvatarView @JvmOverloads constructor(
@@ -45,6 +46,7 @@ class AvatarView @JvmOverloads constructor(
     private var photoUri: String? = null
     private var lastUpdated: Long? = null
     private var theme: Colors.Theme
+    private var layout: AvatarViewBinding
 
     init {
         if (!isInEditMode) {
@@ -53,7 +55,7 @@ class AvatarView @JvmOverloads constructor(
 
         theme = colors.theme()
 
-        View.inflate(context, R.layout.avatar_view, this)
+        layout = AvatarViewBinding.inflate(LayoutInflater.from(context), this)
         setBackgroundResource(R.drawable.circle)
         clipToOutline = true
     }
@@ -81,8 +83,8 @@ class AvatarView @JvmOverloads constructor(
     private fun updateView() {
         // Apply theme
         setBackgroundTint(theme.theme)
-        initial.setTextColor(theme.textPrimary)
-        icon.setTint(theme.textPrimary)
+        layout.initial.setTextColor(theme.textPrimary)
+        layout.icon.setTint(theme.textPrimary)
 
         val initials = fullName
                 ?.substringBefore(',')
@@ -93,18 +95,18 @@ class AvatarView @JvmOverloads constructor(
                 .map { initial -> initial.toString() }
 
         if (initials.isNotEmpty()) {
-            initial.text = if (initials.size > 1) initials.first() + initials.last() else initials.first()
-            icon.visibility = GONE
+            layout.initial.text = if (initials.size > 1) initials.first() + initials.last() else initials.first()
+            layout.icon.visibility = GONE
         } else {
-            initial.text = null
-            icon.visibility = VISIBLE
+            layout.initial.text = null
+            layout.icon.visibility = VISIBLE
         }
 
-        photo.setImageDrawable(null)
+        layout.photo.setImageDrawable(null)
         photoUri?.let { photoUri ->
-            GlideApp.with(photo)
+            GlideApp.with(layout.photo)
                     .load(photoUri)
-                    .into(photo)
+                    .into(layout.photo)
         }
     }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/GroupAvatarView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/GroupAvatarView.kt
@@ -20,30 +20,28 @@ package dev.octoshrimpy.quik.common.widget
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
-import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.util.extensions.getColorCompat
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColor
 import dev.octoshrimpy.quik.common.util.extensions.setBackgroundTint
+import dev.octoshrimpy.quik.databinding.GroupAvatarViewBinding
 import dev.octoshrimpy.quik.model.Recipient
-import kotlinx.android.synthetic.main.group_avatar_view.view.*
 
 class GroupAvatarView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : ConstraintLayout(context, attrs) {
+
+    private var layout: GroupAvatarViewBinding =
+        GroupAvatarViewBinding.inflate(LayoutInflater.from(context), this)
 
     var recipients: List<Recipient> = ArrayList()
         set(value) {
             field = value.sortedWith(compareByDescending { contact -> contact.contact?.lookupKey })
             updateView()
         }
-
-    init {
-        View.inflate(context, R.layout.group_avatar_view, this)
-    }
 
     override fun onFinishInflate() {
         super.onFinishInflate()
@@ -54,18 +52,18 @@ class GroupAvatarView @JvmOverloads constructor(
     }
 
     private fun updateView() {
-        avatar1Frame.setBackgroundTint(when (recipients.size > 1) {
+        layout.avatar1Frame.setBackgroundTint(when (recipients.size > 1) {
             true -> context.resolveThemeColor(android.R.attr.windowBackground)
             false -> context.getColorCompat(android.R.color.transparent)
         })
-        avatar1Frame.updateLayoutParams<LayoutParams> {
+        layout.avatar1Frame.updateLayoutParams<LayoutParams> {
             matchConstraintPercentWidth = if (recipients.size > 1) 0.75f else 1.0f
         }
-        avatar2.isVisible = recipients.size > 1
+        layout.avatar2.isVisible = recipients.size > 1
 
 
-        recipients.getOrNull(0).run(avatar1::setRecipient)
-        recipients.getOrNull(1).run(avatar2::setRecipient)
+        recipients.getOrNull(0).run(layout.avatar1::setRecipient)
+        recipients.getOrNull(1).run(layout.avatar2::setRecipient)
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/PagerTitleView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/PagerTitleView.kt
@@ -27,7 +27,6 @@ import android.widget.TextView
 import androidx.viewpager.widget.ViewPager
 import com.uber.autodispose.android.ViewScopeProvider
 import com.uber.autodispose.autoDisposable
-import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.extensions.forEach
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColor

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/PagerTitleView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/PagerTitleView.kt
@@ -31,12 +31,12 @@ import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.extensions.forEach
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColor
+import dev.octoshrimpy.quik.databinding.TabViewBinding
 import dev.octoshrimpy.quik.extensions.Optional
 import dev.octoshrimpy.quik.injection.appComponent
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.tab_view.view.*
 import javax.inject.Inject
 
 class PagerTitleView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) : LinearLayout(context, attrs) {
@@ -66,11 +66,11 @@ class PagerTitleView @JvmOverloads constructor(context: Context, attrs: Attribut
         removeAllViews()
 
         pager?.adapter?.count?.forEach { position ->
-            val view = LayoutInflater.from(context).inflate(R.layout.tab_view, this, false)
+            val view = TabViewBinding.inflate(LayoutInflater.from(context), this, false)
             view.label.text = pager?.adapter?.getPageTitle(position)
-            view.setOnClickListener { pager?.currentItem = position }
+            view.root.setOnClickListener { pager?.currentItem = position }
 
-            addView(view)
+            addView(view.root)
         }
 
         childCount.forEach { index ->

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/PreferenceView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/PreferenceView.kt
@@ -36,7 +36,7 @@ class PreferenceView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : LinearLayoutCompat(context, attrs) {
 
-    private lateinit var layout: PreferenceViewBinding
+    private var layout: PreferenceViewBinding
 
     var title: String? = null
         set(value) {

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/PreferenceView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/PreferenceView.kt
@@ -21,6 +21,7 @@ package dev.octoshrimpy.quik.common.widget
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.widget.LinearLayoutCompat
@@ -28,12 +29,14 @@ import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeAttribute
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColorStateList
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
+import dev.octoshrimpy.quik.databinding.PreferenceViewBinding
 import dev.octoshrimpy.quik.injection.appComponent
-import kotlinx.android.synthetic.main.preference_view.view.*
 
 class PreferenceView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : LinearLayoutCompat(context, attrs) {
+
+    private lateinit var layout: PreferenceViewBinding
 
     var title: String? = null
         set(value) {
@@ -42,7 +45,7 @@ class PreferenceView @JvmOverloads constructor(
             if (isInEditMode) {
                 findViewById<TextView>(R.id.titleView).text = value
             } else {
-                titleView.text = value
+                layout.titleView.text = value
             }
         }
 
@@ -57,8 +60,8 @@ class PreferenceView @JvmOverloads constructor(
                     setVisible(value?.isNotEmpty() == true)
                 }
             } else {
-                summaryView.text = value
-                summaryView.setVisible(value?.isNotEmpty() == true)
+                layout.summaryView.text = value
+                layout.summaryView.setVisible(value?.isNotEmpty() == true)
             }
         }
 
@@ -67,12 +70,12 @@ class PreferenceView @JvmOverloads constructor(
             appComponent.inject(this)
         }
 
-        View.inflate(context, R.layout.preference_view, this)
+        layout = PreferenceViewBinding.inflate(LayoutInflater.from(context), this)
         setBackgroundResource(context.resolveThemeAttribute(R.attr.selectableItemBackground))
         orientation = HORIZONTAL
         gravity = Gravity.CENTER_VERTICAL
 
-        icon.imageTintList = context.resolveThemeColorStateList(android.R.attr.textColorSecondary)
+        layout.icon.imageTintList = context.resolveThemeColorStateList(android.R.attr.textColorSecondary)
 
         context.obtainStyledAttributes(attrs, R.styleable.PreferenceView).run {
             title = getString(R.styleable.PreferenceView_title)
@@ -80,13 +83,13 @@ class PreferenceView @JvmOverloads constructor(
 
             // If there's a custom view used for the preference's widget, inflate it
             getResourceId(R.styleable.PreferenceView_widget, -1).takeIf { it != -1 }?.let { id ->
-                View.inflate(context, id, widgetFrame)
+                View.inflate(context, id, layout.widgetFrame)
             }
 
             // If an icon is being used, set up the icon view
             getResourceId(R.styleable.PreferenceView_icon, -1).takeIf { it != -1 }?.let { id ->
-                icon.setVisible(true)
-                icon.setImageResource(id)
+                layout.icon.setVisible(true)
+                layout.icon.setImageResource(id)
             }
 
             recycle()

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/PreferenceView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/PreferenceView.kt
@@ -38,6 +38,8 @@ class PreferenceView @JvmOverloads constructor(
 
     private var layout: PreferenceViewBinding
 
+    val titleTextView: TextView get() = layout.titleView
+
     var title: String? = null
         set(value) {
             field = value

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/QkDialog.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/QkDialog.kt
@@ -23,7 +23,6 @@ import android.view.LayoutInflater
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
-import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
 import dev.octoshrimpy.quik.databinding.QkDialogBinding
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/QkDialog.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/QkDialog.kt
@@ -25,11 +25,11 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
-import kotlinx.android.synthetic.main.qk_dialog.view.*
+import dev.octoshrimpy.quik.databinding.QkDialogBinding
 
 class QkDialog(private val context: Activity) : AlertDialog(context) {
 
-    private val view = LayoutInflater.from(context).inflate(R.layout.qk_dialog, null)
+    private val view = QkDialogBinding.inflate(LayoutInflater.from(context))
 
     @StringRes
     var titleRes: Int? = null
@@ -99,7 +99,7 @@ class QkDialog(private val context: Activity) : AlertDialog(context) {
         }
 
     init {
-        setView(view)
+        setView(view.root)
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/RadioPreferenceView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/RadioPreferenceView.kt
@@ -40,7 +40,7 @@ class RadioPreferenceView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs) {
 
     @Inject lateinit var colors: Colors
-    private lateinit var layout: RadioPreferenceViewBinding
+    private var layout: RadioPreferenceViewBinding
 
     var title: String? = null
         set(value) {

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/RadioPreferenceView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/RadioPreferenceView.kt
@@ -21,6 +21,7 @@ package dev.octoshrimpy.quik.common.widget
 import android.content.Context
 import android.content.res.ColorStateList
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -30,8 +31,8 @@ import dev.octoshrimpy.quik.common.util.extensions.forwardTouches
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeAttribute
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColor
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
+import dev.octoshrimpy.quik.databinding.RadioPreferenceViewBinding
 import dev.octoshrimpy.quik.injection.appComponent
-import kotlinx.android.synthetic.main.radio_preference_view.view.*
 import javax.inject.Inject
 
 class RadioPreferenceView @JvmOverloads constructor(
@@ -39,6 +40,7 @@ class RadioPreferenceView @JvmOverloads constructor(
 ) : ConstraintLayout(context, attrs) {
 
     @Inject lateinit var colors: Colors
+    private lateinit var layout: RadioPreferenceViewBinding
 
     var title: String? = null
         set(value) {
@@ -47,7 +49,7 @@ class RadioPreferenceView @JvmOverloads constructor(
             if (isInEditMode) {
                 findViewById<TextView>(R.id.titleView).text = value
             } else {
-                titleView.text = value
+                layout.titleView.text = value
             }
         }
 
@@ -62,8 +64,8 @@ class RadioPreferenceView @JvmOverloads constructor(
                     setVisible(value?.isNotEmpty() == true)
                 }
             } else {
-                summaryView.text = value
-                summaryView.setVisible(value?.isNotEmpty() == true)
+                layout.summaryView.text = value
+                layout.summaryView.setVisible(value?.isNotEmpty() == true)
             }
         }
 
@@ -72,7 +74,7 @@ class RadioPreferenceView @JvmOverloads constructor(
             appComponent.inject(this)
         }
 
-        View.inflate(context, R.layout.radio_preference_view, this)
+        layout = RadioPreferenceViewBinding.inflate(LayoutInflater.from(context), this)
         setBackgroundResource(context.resolveThemeAttribute(R.attr.selectableItemBackground))
 
         val states = arrayOf(
@@ -84,8 +86,8 @@ class RadioPreferenceView @JvmOverloads constructor(
             false -> colors.theme().theme
         }
         val textSecondary = context.resolveThemeColor(android.R.attr.textColorTertiary)
-        radioButton.buttonTintList = ColorStateList(states, intArrayOf(themeColor, textSecondary))
-        radioButton.forwardTouches(this)
+        layout.radioButton.buttonTintList = ColorStateList(states, intArrayOf(themeColor, textSecondary))
+        layout.radioButton.forwardTouches(this)
 
         context.obtainStyledAttributes(attrs, R.styleable.RadioPreferenceView)?.run {
             title = getString(R.styleable.RadioPreferenceView_title)
@@ -93,7 +95,7 @@ class RadioPreferenceView @JvmOverloads constructor(
 
             // If there's a custom view used for the preference's widget, inflate it
             getResourceId(R.styleable.RadioPreferenceView_widget, -1).takeIf { it != -1 }?.let { id ->
-                View.inflate(context, id, widgetFrame)
+                View.inflate(context, id, layout.widgetFrame)
             }
 
             recycle()

--- a/presentation/src/main/java/com/moez/QKSMS/common/widget/TextInputDialog.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/widget/TextInputDialog.kt
@@ -23,16 +23,16 @@ import android.content.DialogInterface
 import android.view.LayoutInflater
 import androidx.appcompat.app.AlertDialog
 import dev.octoshrimpy.quik.R
-import kotlinx.android.synthetic.main.text_input_dialog.view.*
+import dev.octoshrimpy.quik.databinding.TextInputDialogBinding
 
 class TextInputDialog(context: Activity, hint: String, listener: (String) -> Unit) : AlertDialog(context) {
 
-    private val layout = LayoutInflater.from(context).inflate(R.layout.text_input_dialog, null)
+    private val layout = TextInputDialogBinding.inflate(LayoutInflater.from(context))
 
     init {
         layout.field.hint = hint
 
-        setView(layout)
+        setView(layout.root)
         setButton(DialogInterface.BUTTON_NEUTRAL, context.getString(R.string.button_cancel)) { _, _ -> }
         setButton(DialogInterface.BUTTON_NEGATIVE, context.getString(R.string.button_delete)) { _, _ -> listener("") }
         setButton(DialogInterface.BUTTON_POSITIVE, context.getString(R.string.button_save)) { _, _ ->

--- a/presentation/src/main/java/com/moez/QKSMS/feature/backup/BackupActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/backup/BackupActivity.kt
@@ -25,19 +25,21 @@ import com.bluelinelabs.conductor.RouterTransaction
 import dagger.android.AndroidInjection
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkThemedActivity
-import kotlinx.android.synthetic.main.container_activity.*
+import dev.octoshrimpy.quik.databinding.ContainerActivityBinding
 
 
 class BackupActivity : QkThemedActivity() {
 
     private lateinit var router: Router
+    private lateinit var binding: ContainerActivityBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.container_activity)
+        binding = ContainerActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        router = Conductor.attachRouter(this, container, savedInstanceState)
+        router = Conductor.attachRouter(this, binding.container, savedInstanceState)
         if (!router.hasRootController()) {
             router.setRoot(RouterTransaction.with(BackupController()))
         }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/BlockingActivity.kt
@@ -25,18 +25,20 @@ import com.bluelinelabs.conductor.RouterTransaction
 import dagger.android.AndroidInjection
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkThemedActivity
-import kotlinx.android.synthetic.main.container_activity.*
+import dev.octoshrimpy.quik.databinding.ContainerActivityBinding
 
 class BlockingActivity : QkThemedActivity() {
 
     private lateinit var router: Router
+    private lateinit var binding: ContainerActivityBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.container_activity)
+        binding = ContainerActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        router = Conductor.attachRouter(this, container, savedInstanceState)
+        router = Conductor.attachRouter(this, binding.container, savedInstanceState)
         if (!router.hasRootController()) {
             router.setRoot(RouterTransaction.with(BlockingController()))
         }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersAdapter.kt
@@ -30,7 +30,7 @@ import io.reactivex.subjects.Subject
 import kotlinx.android.synthetic.main.message_content_filter_list_item.*
 import kotlinx.android.synthetic.main.message_content_filter_list_item.view.*
 
-class MessageContentFiltersAdapter : QkRealmAdapter<MessageContentFilter>() {
+class MessageContentFiltersAdapter : QkRealmAdapter<MessageContentFilter, QkViewHolder>() {
 
     val removeMessageContentFilter: Subject<Long> = PublishSubject.create()
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/filters/MessageContentFiltersAdapter.kt
@@ -23,33 +23,32 @@ import android.view.View
 import android.view.ViewGroup
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkRealmAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
 import dev.octoshrimpy.quik.model.MessageContentFilter
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.message_content_filter_list_item.*
-import kotlinx.android.synthetic.main.message_content_filter_list_item.view.*
+import dev.octoshrimpy.quik.databinding.MessageContentFilterListItemBinding
 
-class MessageContentFiltersAdapter : QkRealmAdapter<MessageContentFilter, QkViewHolder>() {
+class MessageContentFiltersAdapter : QkRealmAdapter<MessageContentFilter, QkBindingViewHolder<MessageContentFilterListItemBinding>>() {
 
     val removeMessageContentFilter: Subject<Long> = PublishSubject.create()
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.message_content_filter_list_item, parent, false)
-        return QkViewHolder(view).apply {
-            containerView.removeFilter.setOnClickListener {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<MessageContentFilterListItemBinding> {
+        val binding = MessageContentFilterListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return QkBindingViewHolder(binding).apply {
+            binding.removeFilter.setOnClickListener {
                 val filter = getItem(adapterPosition) ?: return@setOnClickListener
                 removeMessageContentFilter.onNext(filter.id)
             }
         }
     }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<MessageContentFilterListItemBinding>, position: Int) {
         val item = getItem(position)!!
-        holder.caseIcon.visibility = if (item.caseSensitive) View.VISIBLE else View.GONE
-        holder.regexIcon.visibility = if (item.isRegex) View.VISIBLE else View.GONE
-        holder.contactsIcon.visibility = if (item.includeContacts) View.VISIBLE else View.GONE
-        holder.filter.text = item.value
+        holder.binding.caseIcon.visibility = if (item.caseSensitive) View.VISIBLE else View.GONE
+        holder.binding.regexIcon.visibility = if (item.isRegex) View.VISIBLE else View.GONE
+        holder.binding.contactsIcon.visibility = if (item.includeContacts) View.VISIBLE else View.GONE
+        holder.binding.filter.text = item.value
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/manager/BlockingManagerPreferenceView.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/manager/BlockingManagerPreferenceView.kt
@@ -22,6 +22,7 @@ package dev.octoshrimpy.quik.feature.blocking.manager
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -29,11 +30,14 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.util.extensions.resolveThemeAttribute
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
-import kotlinx.android.synthetic.main.blocking_manager_preference_view.view.*
+import dev.octoshrimpy.quik.databinding.BlockingManagerPreferenceViewBinding
 
 class BlockingManagerPreferenceView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : ConstraintLayout(context, attrs) {
+
+    private val binding: BlockingManagerPreferenceViewBinding =
+        BlockingManagerPreferenceViewBinding.inflate(LayoutInflater.from(context), this)
 
     var icon: Drawable? = null
         set(value) {
@@ -42,7 +46,7 @@ class BlockingManagerPreferenceView @JvmOverloads constructor(
             if (isInEditMode) {
                 findViewById<ImageView>(R.id.iconView).setImageDrawable(value)
             } else {
-                iconView.setImageDrawable(value)
+                binding.iconView.setImageDrawable(value)
             }
         }
 
@@ -53,7 +57,7 @@ class BlockingManagerPreferenceView @JvmOverloads constructor(
             if (isInEditMode) {
                 findViewById<TextView>(R.id.titleView).text = value
             } else {
-                titleView.text = value
+                binding.titleView.text = value
             }
         }
 
@@ -67,13 +71,12 @@ class BlockingManagerPreferenceView @JvmOverloads constructor(
                     setVisible(value?.isNotEmpty() == true)
                 }
             } else {
-                summaryView.text = value
-                summaryView.setVisible(value?.isNotEmpty() == true)
+                binding.summaryView.text = value
+                binding.summaryView.setVisible(value?.isNotEmpty() == true)
             }
         }
 
     init {
-        View.inflate(context, R.layout.blocking_manager_preference_view, this)
         setBackgroundResource(context.resolveThemeAttribute(R.attr.selectableItemBackground))
 
         context.obtainStyledAttributes(attrs, R.styleable.BlockingManagerPreferenceView).run {
@@ -83,7 +86,7 @@ class BlockingManagerPreferenceView @JvmOverloads constructor(
 
             // If there's a custom view used for the preference's widget, inflate it
             getResourceId(R.styleable.BlockingManagerPreferenceView_widget, -1).takeIf { it != -1 }?.let { id ->
-                View.inflate(context, id, widgetFrame)
+                View.inflate(context, id, binding.widgetFrame)
             }
 
             recycle()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/messages/BlockedMessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/messages/BlockedMessagesAdapter.kt
@@ -38,7 +38,7 @@ import javax.inject.Inject
 class BlockedMessagesAdapter @Inject constructor(
     private val context: Context,
     private val dateFormatter: DateFormatter
-) : QkRealmAdapter<Conversation>() {
+) : QkRealmAdapter<Conversation, QkViewHolder>() {
 
     val clicks: PublishSubject<Long> = PublishSubject.create()
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/numbers/BlockedNumbersAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/numbers/BlockedNumbersAdapter.kt
@@ -22,31 +22,30 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkRealmAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
 import dev.octoshrimpy.quik.model.BlockedNumber
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.blocked_number_list_item.*
-import kotlinx.android.synthetic.main.blocked_number_list_item.view.*
+import dev.octoshrimpy.quik.databinding.BlockedNumberListItemBinding
 
-class BlockedNumbersAdapter : QkRealmAdapter<BlockedNumber, QkViewHolder>() {
+class BlockedNumbersAdapter : QkRealmAdapter<BlockedNumber, QkBindingViewHolder<BlockedNumberListItemBinding>>() {
 
     val unblockAddress: Subject<Long> = PublishSubject.create()
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.blocked_number_list_item, parent, false)
-        return QkViewHolder(view).apply {
-            containerView.unblock.setOnClickListener {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<BlockedNumberListItemBinding> {
+        val binding = BlockedNumberListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return QkBindingViewHolder(binding).apply {
+            binding.unblock.setOnClickListener {
                 val number = getItem(adapterPosition) ?: return@setOnClickListener
                 unblockAddress.onNext(number.id)
             }
         }
     }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<BlockedNumberListItemBinding>, position: Int) {
         val item = getItem(position)!!
 
-        holder.number.text = item.address
+        holder.binding.number.text = item.address
     }
 
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/numbers/BlockedNumbersAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/numbers/BlockedNumbersAdapter.kt
@@ -29,7 +29,7 @@ import io.reactivex.subjects.Subject
 import kotlinx.android.synthetic.main.blocked_number_list_item.*
 import kotlinx.android.synthetic.main.blocked_number_list_item.view.*
 
-class BlockedNumbersAdapter : QkRealmAdapter<BlockedNumber>() {
+class BlockedNumbersAdapter : QkRealmAdapter<BlockedNumber, QkViewHolder>() {
 
     val unblockAddress: Subject<Long> = PublishSubject.create()
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/changelog/ChangelogAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/changelog/ChangelogAdapter.kt
@@ -24,11 +24,11 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
+import dev.octoshrimpy.quik.databinding.ChangelogListItemBinding
 import dev.octoshrimpy.quik.manager.ChangelogManager
-import kotlinx.android.synthetic.main.changelog_list_item.*
 
-class ChangelogAdapter(private val context: Context) : QkAdapter<ChangelogAdapter.ChangelogItem, QkViewHolder>() {
+class ChangelogAdapter(private val context: Context) : QkAdapter<ChangelogAdapter.ChangelogItem, QkBindingViewHolder<ChangelogListItemBinding>>() {
 
     data class ChangelogItem(val type: Int, val label: String)
 
@@ -57,19 +57,18 @@ class ChangelogAdapter(private val context: Context) : QkAdapter<ChangelogAdapte
         data = changes
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.changelog_list_item, parent, false)
-        return QkViewHolder(view).apply {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<ChangelogListItemBinding> {
+        val binding = ChangelogListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return QkBindingViewHolder(binding).apply {
             if (viewType == 0) {
-                changelogItem.setTypeface(changelogItem.typeface, Typeface.BOLD)
+                binding.changelogItem.setTypeface(binding.changelogItem.typeface, Typeface.BOLD)
             }
         }
     }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<ChangelogListItemBinding>, position: Int) {
         val item = getItem(position)
-
-        holder.changelogItem.text = item.label
+        holder.binding.changelogItem.text = item.label
     }
 
     override fun getItemViewType(position: Int): Int {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/changelog/ChangelogDialog.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/changelog/ChangelogDialog.kt
@@ -22,11 +22,11 @@ import android.view.LayoutInflater
 import androidx.appcompat.app.AlertDialog
 import dev.octoshrimpy.quik.BuildConfig
 import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.databinding.ChangelogDialogBinding
 import dev.octoshrimpy.quik.feature.main.MainActivity
 import dev.octoshrimpy.quik.manager.ChangelogManager
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.changelog_dialog.view.*
 
 class ChangelogDialog(activity: MainActivity) {
 
@@ -36,11 +36,11 @@ class ChangelogDialog(activity: MainActivity) {
     private val adapter = ChangelogAdapter(activity)
 
     init {
-        val layout = LayoutInflater.from(activity).inflate(R.layout.changelog_dialog, null)
+        val layout = ChangelogDialogBinding.inflate(LayoutInflater.from(activity))
 
         dialog = AlertDialog.Builder(activity)
                 .setCancelable(true)
-                .setView(layout)
+                .setView(layout.root)
                 .create()
 
         layout.version.text = activity.getString(R.string.changelog_version, BuildConfig.VERSION_NAME)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -97,7 +97,7 @@ class MessagesAdapter @Inject constructor(
     private val prefs: Preferences,
     private val textViewStyler: TextViewStyler,
     private val navigator: Navigator,
-) : QkRealmAdapter<Message>() {
+) : QkRealmAdapter<Message, QkViewHolder>() {
     class AudioState(
         var partId: Long = -1,
         var state: QkMediaPlayer.PlayingState = QkMediaPlayer.PlayingState.Stopped,

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/ChipsAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/ChipsAdapter.kt
@@ -23,36 +23,34 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.RelativeLayout
 import androidx.recyclerview.widget.RecyclerView
-import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
 import dev.octoshrimpy.quik.common.util.extensions.dpToPx
+import dev.octoshrimpy.quik.databinding.ContactChipBinding
 import dev.octoshrimpy.quik.model.Recipient
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.contact_chip.*
 import javax.inject.Inject
 
-class ChipsAdapter @Inject constructor() : QkAdapter<Recipient, QkViewHolder>() {
+class ChipsAdapter @Inject constructor() : QkAdapter<Recipient, QkBindingViewHolder<ContactChipBinding>>() {
 
     var view: RecyclerView? = null
     val chipDeleted: PublishSubject<Recipient> = PublishSubject.create<Recipient>()
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        val inflater = LayoutInflater.from(parent.context)
-        val view = inflater.inflate(R.layout.contact_chip, parent, false)
-        return QkViewHolder(view).apply {
-            view.setOnClickListener {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<ContactChipBinding> {
+        val binding = ContactChipBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return QkBindingViewHolder(binding).apply {
+            binding.root.setOnClickListener {
                 val chip = getItem(adapterPosition)
-                showDetailedChip(view.context, chip)
+                showDetailedChip(binding.root.context, chip)
             }
         }
     }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<ContactChipBinding>, position: Int) {
         val recipient = getItem(position)
 
-        holder.avatar.setRecipient(recipient)
-        holder.name.text = recipient.contact?.name?.takeIf { it.isNotBlank() } ?: recipient.address
+        holder.binding.avatar.setRecipient(recipient)
+        holder.binding.name.text = recipient.contact?.name?.takeIf { it.isNotBlank() } ?: recipient.address
     }
 
     /**

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/PhoneNumberAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/editing/PhoneNumberAdapter.kt
@@ -22,23 +22,22 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
+import dev.octoshrimpy.quik.databinding.ContactNumberListItemBinding
 import dev.octoshrimpy.quik.model.PhoneNumber
-import kotlinx.android.synthetic.main.contact_number_list_item.*
 
-class PhoneNumberAdapter : QkAdapter<PhoneNumber, QkViewHolder>() {
+class PhoneNumberAdapter : QkAdapter<PhoneNumber, QkBindingViewHolder<ContactNumberListItemBinding>>() {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        val inflater = LayoutInflater.from(parent.context)
-        val view = inflater.inflate(R.layout.contact_number_list_item, parent, false)
-        return QkViewHolder(view)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<ContactNumberListItemBinding> {
+        val binding = ContactNumberListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return QkBindingViewHolder(binding)
     }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<ContactNumberListItemBinding>, position: Int) {
         val number = getItem(position)
 
-        holder.address.text = number.address
-        holder.type.text = number.type
+        holder.binding.address.text = number.address
+        holder.binding.type.text = number.type
     }
 
     override fun areItemsTheSame(old: PhoneNumber, new: PhoneNumber): Boolean {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
@@ -48,7 +48,7 @@ class ConversationsAdapter @Inject constructor(
     private val scheduledMessageRepo: ScheduledMessageRepository,
     private val navigator: Navigator,
     private val phoneNumberUtils: PhoneNumberUtils
-) : QkRealmAdapter<Conversation>() {
+) : QkRealmAdapter<Conversation, QkViewHolder>() {
     private val disposables = CompositeDisposable()
 
     init {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryPagerAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryPagerAdapter.kt
@@ -45,7 +45,7 @@ import kotlinx.android.synthetic.main.gallery_video_page.*
 import java.util.*
 import javax.inject.Inject
 
-class GalleryPagerAdapter @Inject constructor(private val context: Context) : QkRealmAdapter<MmsPart>() {
+class GalleryPagerAdapter @Inject constructor(private val context: Context) : QkRealmAdapter<MmsPart, QkViewHolder>() {
 
     companion object {
         private const val VIEW_TYPE_INVALID = 0

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/SearchAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/SearchAdapter.kt
@@ -27,14 +27,13 @@ import android.view.ViewGroup
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
 import dev.octoshrimpy.quik.common.util.Colors
 import dev.octoshrimpy.quik.common.util.DateFormatter
 import dev.octoshrimpy.quik.common.util.extensions.setVisible
 import dev.octoshrimpy.quik.extensions.removeAccents
 import dev.octoshrimpy.quik.model.SearchResult
-import kotlinx.android.synthetic.main.search_list_item.*
-import kotlinx.android.synthetic.main.search_list_item.view.*
+import dev.octoshrimpy.quik.databinding.SearchListItemBinding
 import javax.inject.Inject
 
 class SearchAdapter @Inject constructor(
@@ -42,26 +41,25 @@ class SearchAdapter @Inject constructor(
     private val context: Context,
     private val dateFormatter: DateFormatter,
     private val navigator: Navigator
-) : QkAdapter<SearchResult, QkViewHolder>() {
+) : QkAdapter<SearchResult, QkBindingViewHolder<SearchListItemBinding>>() {
 
     private val highlightColor: Int by lazy { colors.theme().highlight }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        val layoutInflater = LayoutInflater.from(parent.context)
-        val view = layoutInflater.inflate(R.layout.search_list_item, parent, false)
-        return QkViewHolder(view).apply {
-            view.setOnClickListener {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<SearchListItemBinding> {
+        val binding = SearchListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return QkBindingViewHolder(binding).apply {
+            itemView.setOnClickListener {
                 val result = getItem(adapterPosition)
                 navigator.showConversation(result.conversation.id, result.query.takeIf { result.messages > 0 })
             }
         }
     }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<SearchListItemBinding>, position: Int) {
         val previous = data.getOrNull(position - 1)
         val result = getItem(position)
 
-        holder.resultsHeader.setVisible(result.messages > 0 && previous?.messages == 0)
+        holder.binding.resultsHeader.setVisible(result.messages > 0 && previous?.messages == 0)
 
         val query = result.query
         val title = SpannableString(result.conversation.getTitle())
@@ -71,23 +69,23 @@ class SearchAdapter @Inject constructor(
             title.setSpan(BackgroundColorSpan(highlightColor), index, index + query.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             index = title.indexOf(query, index + query.length, true)
         }
-        holder.title.text = title
+        holder.binding.title.text = title
 
-        holder.avatars.recipients = result.conversation.recipients
+        holder.binding.avatars.recipients = result.conversation.recipients
 
         when (result.messages == 0) {
             true -> {
-                holder.date.setVisible(true)
-                holder.date.text = dateFormatter.getConversationTimestamp(result.conversation.date)
-                holder.snippet.text = when (result.conversation.me) {
+                holder.binding.date.setVisible(true)
+                holder.binding.date.text = dateFormatter.getConversationTimestamp(result.conversation.date)
+                holder.binding.snippet.text = when (result.conversation.me) {
                     true -> context.getString(R.string.main_sender_you, result.conversation.snippet)
                     false -> result.conversation.snippet
                 }
             }
 
             false -> {
-                holder.date.setVisible(false)
-                holder.snippet.text = context.getString(R.string.main_message_results, result.messages)
+                holder.binding.date.setVisible(false)
+                holder.binding.snippet.text = context.getString(R.string.main_message_results, result.messages)
             }
         }
     }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/plus/PlusActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/plus/PlusActivity.kt
@@ -36,9 +36,7 @@ import dev.octoshrimpy.quik.common.util.extensions.setVisible
 import dev.octoshrimpy.quik.common.widget.PreferenceView
 import dev.octoshrimpy.quik.feature.plus.experiment.UpgradeButtonExperiment
 import dev.octoshrimpy.quik.manager.BillingManager
-import kotlinx.android.synthetic.main.collapsing_toolbar.*
-import kotlinx.android.synthetic.main.preference_view.view.*
-import kotlinx.android.synthetic.main.qksms_plus_activity.*
+import dev.octoshrimpy.quik.databinding.QksmsPlusActivityBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -52,66 +50,68 @@ class PlusActivity : QkThemedActivity(), PlusView {
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     private val viewModel by lazy { ViewModelProviders.of(this, viewModelFactory)[PlusViewModel::class.java] }
+    private lateinit var binding: QksmsPlusActivityBinding
 
-    override val upgradeIntent by lazy { upgrade.clicks() }
-    override val upgradeDonateIntent by lazy { upgradeDonate.clicks() }
-    override val donateIntent by lazy { donate.clicks() }
-    override val themeClicks by lazy { themes.clicks() }
-    override val scheduleClicks by lazy { schedule.clicks() }
-    override val backupClicks by lazy { backup.clicks() }
-    override val delayedClicks by lazy { delayed.clicks() }
-    override val nightClicks by lazy { night.clicks() }
+    override val upgradeIntent get() = binding.upgrade.clicks()
+    override val upgradeDonateIntent get() = binding.upgradeDonate.clicks()
+    override val donateIntent get() = binding.donate.clicks()
+    override val themeClicks get() = binding.themes.clicks()
+    override val scheduleClicks get() = binding.schedule.clicks()
+    override val backupClicks get() = binding.backup.clicks()
+    override val delayedClicks get() = binding.delayed.clicks()
+    override val nightClicks get() = binding.night.clicks()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.qksms_plus_activity)
+        binding = QksmsPlusActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setTitle(R.string.title_qksms_plus)
         showBackButton(true)
         viewModel.bindView(this)
 
-        free.setVisible(false)
+        binding.free.setVisible(false)
 
         if (!prefs.systemFont.get()) {
             fontProvider.getLato { lato ->
                 val typeface = Typeface.create(lato, Typeface.BOLD)
-                collapsingToolbar.setCollapsedTitleTypeface(typeface)
-                collapsingToolbar.setExpandedTitleTypeface(typeface)
+                binding.toolbarLayout.collapsingToolbar.setCollapsedTitleTypeface(typeface)
+                binding.toolbarLayout.collapsingToolbar.setExpandedTitleTypeface(typeface)
             }
         }
 
         // Make the list titles bold
-        linearLayout.children
-                .mapNotNull { it as? PreferenceView }
-                .map { it.titleView }
-                .forEach { it.setTypeface(it.typeface, Typeface.BOLD) }
+        binding.linearLayout.children
+            .mapNotNull { it as? PreferenceView }
+            .map { it.titleTextView }
+            .forEach { it.setTypeface(it.typeface, Typeface.BOLD) }
 
         val textPrimary = resolveThemeColor(android.R.attr.textColorPrimary)
-        collapsingToolbar.setCollapsedTitleTextColor(textPrimary)
-        collapsingToolbar.setExpandedTitleColor(textPrimary)
+        binding.toolbarLayout.collapsingToolbar.setCollapsedTitleTextColor(textPrimary)
+        binding.toolbarLayout.collapsingToolbar.setExpandedTitleColor(textPrimary)
 
         val theme = colors.theme().theme
-        donate.setBackgroundTint(theme)
-        upgrade.setBackgroundTint(theme)
-        thanksIcon.setTint(theme)
+        binding.donate.setBackgroundTint(theme)
+        binding.upgrade.setBackgroundTint(theme)
+        binding.thanksIcon.setTint(theme)
     }
 
     override fun render(state: PlusState) {
-        description.text = getString(R.string.qksms_plus_description_summary, state.upgradePrice)
-        upgrade.text = getString(upgradeButtonExperiment.variant, state.upgradePrice, state.currency)
-        upgradeDonate.text = getString(R.string.qksms_plus_upgrade_donate, state.upgradeDonatePrice, state.currency)
+        binding.description.text = getString(R.string.qksms_plus_description_summary, state.upgradePrice)
+        binding.upgrade.text = getString(upgradeButtonExperiment.variant, state.upgradePrice, state.currency)
+        binding.upgradeDonate.text = getString(R.string.qksms_plus_upgrade_donate, state.upgradeDonatePrice, state.currency)
 
         val fdroid = true
 
-        free.setVisible(fdroid)
-        toUpgrade.setVisible(!fdroid && !state.upgraded)
-        upgraded.setVisible(!fdroid && state.upgraded)
+        binding.free.setVisible(fdroid)
+        binding.toUpgrade.setVisible(!fdroid && !state.upgraded)
+        binding.upgraded.setVisible(!fdroid && state.upgraded)
 
-        themes.isEnabled = state.upgraded
-        schedule.isEnabled = state.upgraded
-        backup.isEnabled = state.upgraded
-        delayed.isEnabled = state.upgraded
-        night.isEnabled = state.upgraded
+        binding.themes.isEnabled = state.upgraded
+        binding.schedule.isEnabled = state.upgraded
+        binding.backup.isEnabled = state.upgraded
+        binding.delayed.isEnabled = state.upgraded
+        binding.night.isEnabled = state.upgraded
     }
 
     override fun initiatePurchaseFlow(billingManager: BillingManager, sku: String) {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAttachmentAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/scheduled/ScheduledMessageAttachmentAdapter.kt
@@ -25,44 +25,40 @@ import android.view.View
 import android.view.ViewGroup
 import dev.octoshrimpy.quik.R
 import dev.octoshrimpy.quik.common.base.QkAdapter
-import dev.octoshrimpy.quik.common.base.QkViewHolder
+import dev.octoshrimpy.quik.common.base.QkBindingViewHolder
 import dev.octoshrimpy.quik.extensions.getName
 import dev.octoshrimpy.quik.feature.extensions.LoadBestIconIntoImageView
 import dev.octoshrimpy.quik.feature.extensions.loadBestIconIntoImageView
-import kotlinx.android.synthetic.main.scheduled_message_image_list_item.fileName
-import kotlinx.android.synthetic.main.scheduled_message_image_list_item.thumbnail
+import dev.octoshrimpy.quik.databinding.ScheduledMessageImageListItemBinding
 import javax.inject.Inject
 
 
 class ScheduledMessageAttachmentAdapter @Inject constructor(
     private val context: Context
-) : QkAdapter<Uri, QkViewHolder>() {
+) : QkAdapter<Uri, QkBindingViewHolder<ScheduledMessageImageListItemBinding>>() {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkViewHolder {
-        return QkViewHolder(
-            LayoutInflater
-                .from(parent.context)
-                .inflate(R.layout.scheduled_message_image_list_item, parent, false)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QkBindingViewHolder<ScheduledMessageImageListItemBinding> =
+        QkBindingViewHolder(
+            ScheduledMessageImageListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         )
-    }
 
-    override fun onBindViewHolder(holder: QkViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: QkBindingViewHolder<ScheduledMessageImageListItemBinding>, position: Int) {
         val uri = getItem(position)
 
         // set best image and text to use for icon
-        when (getItem(position).loadBestIconIntoImageView(context, holder.thumbnail)) {
+        when (getItem(position).loadBestIconIntoImageView(context, holder.binding.thumbnail)) {
             LoadBestIconIntoImageView.Missing -> {
-                holder.fileName.text = context.getString(R.string.attachment_missing)
-                holder.fileName.visibility = View.VISIBLE
+                holder.binding.fileName.text = context.getString(R.string.attachment_missing)
+                holder.binding.fileName.visibility = View.VISIBLE
             }
             LoadBestIconIntoImageView.ActivityIcon,
             LoadBestIconIntoImageView.DefaultAudioIcon,
             LoadBestIconIntoImageView.GenericIcon -> {
                 // generic style icon used, also show name
-                holder.fileName.text = uri.getName(context)
-                holder.fileName.visibility = View.VISIBLE
+                holder.binding.fileName.text = uri.getName(context)
+                holder.binding.fileName.visibility = View.VISIBLE
             }
-            else -> holder.fileName.visibility = View.GONE
+            else -> holder.binding.fileName.visibility = View.GONE
         }
     }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/autodelete/AutoDeleteDialog.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/autodelete/AutoDeleteDialog.kt
@@ -23,14 +23,14 @@ import android.content.DialogInterface
 import android.view.LayoutInflater
 import androidx.appcompat.app.AlertDialog
 import dev.octoshrimpy.quik.R
-import kotlinx.android.synthetic.main.settings_auto_delete_dialog.view.*
+import dev.octoshrimpy.quik.databinding.SettingsAutoDeleteDialogBinding
 
 class AutoDeleteDialog(context: Activity, listener: (Int) -> Unit) : AlertDialog(context) {
 
-    private val layout = LayoutInflater.from(context).inflate(R.layout.settings_auto_delete_dialog, null)
+    private val layout = SettingsAutoDeleteDialogBinding.inflate(LayoutInflater.from(context))
 
     init {
-        setView(layout)
+        setView(layout.root)
         setTitle(R.string.settings_auto_delete)
         setMessage(context.getString(R.string.settings_auto_delete_dialog_message))
         setButton(DialogInterface.BUTTON_NEUTRAL, context.getString(R.string.button_cancel)) { _, _ -> }

--- a/presentation/src/main/res/layout/qksms_plus_activity.xml
+++ b/presentation/src/main/res/layout/qksms_plus_activity.xml
@@ -23,7 +23,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include layout="@layout/collapsing_toolbar" />
+    <include
+        android:id="@+id/toolbarLayout"
+        layout="@layout/collapsing_toolbar" />
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"


### PR DESCRIPTION
The codebase currently relies on kotlin synthetics to bind views, which is deprecated. This blocks future upgrades like moving to Kotlin 2.x

https://developer.android.com/topic/libraries/view-binding/migration

let me know how this looks, and i can do a bunch more