### PR TITLE
Fix closed Realm instance during send

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/ConversationRepositoryImpl.kt
@@ -314,7 +314,7 @@ class ConversationRepositoryImpl @Inject constructor(
         getConversation(listOf(recipient))
 
     override fun getConversation(recipients: Collection<String>) =
-        Realm.getDefaultInstance().use { realm ->
+        Realm.getDefaultInstance().let { realm ->
             realm.refresh()
             realm.where(Conversation::class.java)
                 .findAll()


### PR DESCRIPTION
I found a bug where sending messages doesn't work:

1. Quit the app (swipe it away in the Recent Apps view)
2. Open QUIK
3. Send a message
4. The message disappears
5. This is logged:

```
2025-09-29 10:30:29.806  3110-3110  Interactor$execute      dev.octoshrimpy.quik.debug           W  java.lang.IllegalStateException: This Realm instance has already been closed, making it unusable.
	at io.realm.BaseRealm.checkIfValid(BaseRealm.java:525)
	at io.realm.dev_octoshrimpy_quik_model_ConversationRealmProxy.realmGet$id(dev_octoshrimpy_quik_model_ConversationRealmProxy.java:130)
	at dev.octoshrimpy.quik.model.Conversation.getId(Conversation.kt:27)
	at dev.octoshrimpy.quik.interactor.SendMessage$buildObservable$2.invoke(SendMessage.kt:51)
	at dev.octoshrimpy.quik.interactor.SendMessage$buildObservable$2.invoke(SendMessage.kt:48)
	at dev.octoshrimpy.quik.interactor.SendMessage.buildObservable$lambda$1(SendMessage.kt:48)
	at dev.octoshrimpy.quik.interactor.SendMessage.$r8$lambda$hlSlgpBA9ul6H285iTbkv7pF6zA(Unknown Source:0)
	at dev.octoshrimpy.quik.interactor.SendMessage$$ExternalSyntheticLambda1.accept(Unknown Source:2)
	at io.reactivex.internal.operators.flowable.FlowableDoOnEach$DoOnEachSubscriber.onNext(FlowableDoOnEach.java:86)
```

Fix below. Unsure if it's the same issue as #509


Looks like there are a lot of instances of `Realm.getDefaultInstance().use { }` which auto-closes the realm instance. is that ever desirable?