### PR TITLE
Fix regex matching for message content filters

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/MessageContentFilterRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageContentFilterRepositoryImpl.kt
@@ -62,10 +62,10 @@ class MessageContentFilterRepositoryImpl @Inject constructor() : MessageContentF
                     } else if (filter.isRegex) {
                         Regex(filter.value).matches(messageBody)
                     } else if (filter.caseSensitive) {
-                        val regexp = ".*\\b" + Regex.escape(filter.value) + "\\b.*"
+                        val regexp = "[\\s\\S]*\\b" + Regex.escape(filter.value) + "\\b[\\s\\S]*"
                         Regex(regexp).matches(messageBody)
                     } else {
-                        val regexp = ".*\\b" + Regex.escape(filter.value.lowercase()) + "\\b.*"
+                        val regexp = "[\\s\\S]*\\b" + Regex.escape(filter.value.lowercase()) + "\\b[\\s\\S]*"
                         Regex(regexp).matches(messageBody.lowercase())
                     }
                 }


### PR DESCRIPTION
Quick fix for message content filter regex matching to take into account e.g. line breaks. See related discussion in https://github.com/octoshrimpy/quik/pull/496.