### PR TITLE
Fix crash on loading conversation

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -178,7 +178,6 @@ class ComposeViewModel @Inject constructor(
                     .filter { conversations -> conversations.isLoaded }
                     .mapNotNull { conversationRepo.getConversation(addresses) }
                     .doOnNext { newState { copy(loading = false) } }
-                    .switchMap { conversation -> conversation.asObservable() }
                 }
 
         // Merges two potential conversation sources (constructor threadId and contact selection)


### PR DESCRIPTION
The switchMap was causing a crash because it was trying to use conversation as an observable, even though it is not. (caused by ca50c4d4ba893c77fb1c81ca1099a030a12b5b4a) There is no need for this code, because the whole function is now an observable.

Closes #602 