### PR TITLE
Add a description to the worker notification

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -91,9 +91,11 @@ class NotificationManagerImpl @Inject constructor(
         createNotificationChannel()
     }
 
+    // Required for running workers on Android 12 and older
     override fun getForegroundNotificationForWorkersOnOlderAndroids() =
         NotificationCompat.Builder(context, DEFAULT_CHANNEL_ID)
-            .setContentTitle(context.getString(R.string.notification_foreground_worker_text))
+            .setContentTitle(context.getString(R.string.notification_foreground_worker_title))
+            .setContentText(context.getString(R.string.notification_foreground_worker_text))
             .setShowWhen(false)
             .setWhen(System.currentTimeMillis())
             .setSmallIcon(R.drawable.ic_notification)

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -504,7 +504,8 @@
     </plurals>
     <string name="notification_message_failed_title">Message not sent</string>
     <string name="notification_message_failed_text">The message to %s failed to send</string>
-    <string name="notification_foreground_worker_text">Receiving message</string>
+    <string name="notification_foreground_worker_title">Receiving message</string>
+    <string name="notification_foreground_worker_text">On Android 12 and older, a notification is required for the background work that enables receiving messages.</string>
     <string name="notification_message_failed_action">Resend</string>
 
     <string-array name="night_modes">


### PR DESCRIPTION
It wasn't clear why it was there, and was confusing for the end user.