### PR TITLE
Fix duplicated messages

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/MessageRepositoryImpl.kt
@@ -738,12 +738,6 @@ open class MessageRepositoryImpl @Inject constructor(
             var managedMessage: Message? = null
             realm.executeTransaction { managedMessage = realm.copyToRealmOrUpdate(message) }
 
-            context.contentResolver.insert(Sms.Inbox.CONTENT_URI, values)
-                ?.lastPathSegment?.toLong()?.let { id ->
-                    // Update contentId after the message has been inserted to the content provider
-                    realm.executeTransaction { managedMessage?.contentId = id }
-                }
-
             managedMessage?.let { savedMessage ->
                 val parsedReaction = reactions.parseEmojiReaction(body)
                 if (parsedReaction != null) {


### PR DESCRIPTION
The insert into SMS database code was called twice, which caused duplicated messages to be created. This ended up breaking all sorts of functionality, including the delete notification action. 

Closes #649