### PR TITLE
Add a GH action to validate fastlane metadata

### DIFF
--- a/.github/workflows/validate-fastlane.yml
+++ b/.github/workflows/validate-fastlane.yml
@@ -1,0 +1,13 @@
+name: Validate fastlane
+
+on:
+  pull_request:
+    paths: 'metadata/**'
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ashutoshgngwr/validate-fastlane-supply-metadata@v2
+        with:
+          fastlaneDir: ./metadata


### PR DESCRIPTION
As we are now translating the app descriptions we should have a validation check instead of blindly merging. As of right now, we have some failures that will need to be corrected if we want it published on Google Play.