### PR TITLE
Set QUIK as a potential default messaging app.

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -61,6 +61,7 @@
             android:windowSoftInputMode="stateAlwaysHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.APP_MESSAGING" />
             </intent-filter>


### PR DESCRIPTION
Some launchers need this in order to launch the app as default. Otherwise, they assume that this app can't be made the default.
Closes #659