### PR TITLE
Fix realm migration again

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
+++ b/data/src/main/java/com/moez/QKSMS/migration/QkRealmMigration.kt
@@ -296,6 +296,8 @@ class QkRealmMigration @Inject constructor(
                 realm.schema.get("Message")
                     ?.addField("sendAsGroup", Boolean::class.java, FieldAttribute.REQUIRED)
             }
+
+            version ++
         }
 
         check(version >= SCHEMA_VERSION) {


### PR DESCRIPTION
In my haste to fix the realm migration from 4.3.1 to 4.3.2 in 2ab857f20ead96d06f7e73891baec125def29929 I forgot to add `version ++`. This broke the migration yet again. Sorry about that.