### PR TITLE
Fix cut-off emoji reactions

### DIFF
--- a/presentation/src/main/res/layout/message_list_item_in.xml
+++ b/presentation/src/main/res/layout/message_list_item_in.xml
@@ -23,13 +23,17 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground">
+    android:background="?attr/selectableItemBackground"
+    android:clipChildren="false"
+    android:clipToPadding="false">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginEnd="36dp"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:clipChildren="false"
+        android:clipToPadding="false">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
Before:
<img width="930" height="337" alt="Screenshot_20260112-021651" src="https://github.com/user-attachments/assets/3a0444ad-0c6d-4967-8390-f3c5de321a83" />

After:

<img width="939" height="314" alt="Screenshot_20260112-021716" src="https://github.com/user-attachments/assets/cb39db66-cec4-4df2-9533-76b5378dfca6" />
