### PR TITLE
Display all reacted emojis

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/MessagesAdapter.kt
@@ -402,18 +402,14 @@ class MessagesAdapter @Inject constructor(
             val hasReactions = reactions.isNotEmpty()
 
             if (hasReactions) {
-                val reactionCounts = reactions.groupBy { it.emoji }
-                    .mapValues { it.value.size }
-                    .toList()
-                    .sortedByDescending { it.second } // Sort by count, most reactions first
+                val uniqueEmojis = reactions.map { it.emoji }.distinct()
+                val totalCount = reactions.size
 
-                // For now, show just the first (most popular) reaction
-                val topReaction = reactionCounts.first()
-                val reactionText = if (topReaction.second == 1) {
-                    topReaction.first
+                // Show unique emojis followed by total count
+                val reactionText = if (totalCount == 1) {
+                    uniqueEmojis.first()
                 } else {
-                    // Use a non-breaking space to keep the emoji and count together
-                    "${topReaction.first}\u00A0${topReaction.second}"
+                    "${uniqueEmojis.joinToString("")}\u00A0$totalCount"
                 }
 
                 holder.reactionText?.text = reactionText


### PR DESCRIPTION
Not just the most common one.

Previously, a message that had different emoji reactions, e.g [😄, 😄 , 💯], would show "😄 2",
but this PR fixes it to show "😄💯 3"