### PR TITLE
build(presentation): add NanoHTTPD dependency for local web MVP

### DIFF
--- a/WIP_MESSAGES_FOR_WEB.md
+++ b/WIP_MESSAGES_FOR_WEB.md
@@ -1,6 +1,0 @@
-Work in progress: Messages for Web MVP (read-only).
-
-Purpose:
-- Establish active work
-- Lock scope for M1/M2
-- Read-only access only (no send/receive)


### PR DESCRIPTION
Follow-up to #704.

This PR adds the NanoHTTPD dependency needed for the local HTTP server discussed in the issue thread.

### Scope
- Dependency only (no runtime/server logic yet)

### Verification
- Build passes (Gradle sync / assembleDebug)

### Next steps (in a follow-up PR)
- Add a minimal local HTTP server (thin web layer)
- Expose read-only conversation/message data as JSON
- Add simple verification steps (curl / browser)
