### PR TITLE
feat(common): add minimal local HTTP server skeleton

### DIFF
--- a/common/src/main/java/com/moez/QKSMS/common/util/extensions/web/LocalHttpServer.kt
+++ b/common/src/main/java/com/moez/QKSMS/common/util/extensions/web/LocalHttpServer.kt
@@ -1,0 +1,36 @@
+package moez.QKSMS.common.web
+
+import fi.iki.elonen.NanoHTTPD
+import timber.log.Timber
+
+class LocalHttpServer(
+    port: Int = 8080
+) : NanoHTTPD(port) {
+
+    override fun start(timeout: Int, daemon: Boolean) {
+        super.start(timeout, daemon)
+        Timber.i("LocalHttpServer started on port $port")
+    }
+
+    override fun stop() {
+        super.stop()
+        Timber.i("LocalHttpServer stopped")
+    }
+
+    override fun serve(session: IHTTPSession): Response {
+        return when (session.uri) {
+            "/health" -> ok("""{"status":"ok"}""")
+            else -> notFound()
+        }
+    }
+
+    private fun ok(body: String): Response =
+        newFixedLengthResponse(Response.Status.OK, "application/json", body)
+
+    private fun notFound(): Response =
+        newFixedLengthResponse(
+            Response.Status.NOT_FOUND,
+            "application/json",
+            """{"error":"not_found"}"""
+        )
+}


### PR DESCRIPTION
Follow-up to #704.

This PR introduces a minimal local HTTP server skeleton using NanoHTTPD.

Scope:
- Common module (no UI / no presentation)
- Dev-only, not started automatically
- Read-only endpoints
- Intended for future web/MVP tooling

Endpoints:
- GET /health -> { "status": "ok" }

Notes:
- No business logic yet
- No message/conversation exposure yet
