### PR TITLE
Add pending intent to foreground worker notification

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -1,3 +1,4 @@
+```kotlin
 /*
  * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
  *
@@ -103,8 +104,14 @@ class NotificationManagerImpl @Inject constructor(
     }
 
     // Required for running workers on Android 12 and older
-    override fun getForegroundNotificationForWorkersOnOlderAndroids() =
-        NotificationCompat.Builder(context, RECEIVING_WORKER_CHANNEL_ID)
+    override fun getForegroundNotificationForWorkersOnOlderAndroids(): Notification {
+        val contentIntent = Intent(context, ComposeActivity::class.java)
+        val taskStackBuilder = TaskStackBuilder.create(context)
+            .addParentStack(ComposeActivity::class.java)
+            .addNextIntent(contentIntent)
+        val contentPI = taskStackBuilder.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+        return NotificationCompat.Builder(context, DEFAULT_CHANNEL_ID)
             .setContentTitle(context.getString(R.string.notification_foreground_worker_title))
             .setContentText(context.getString(R.string.notification_foreground_worker_text))
             .setShowWhen(false)
@@ -115,7 +122,9 @@ class NotificationManagerImpl @Inject constructor(
             .setPriority(NotificationCompat.PRIORITY_MIN)
             .setOngoing(true)
             .setSilent(true)
+            .setContentIntent(contentPI)
             .build()
+    }
 
     /**
      * Updates the notification for a particular conversation
@@ -174,419 +183,38 @@ class NotificationManagerImpl @Inject constructor(
         val notification = NotificationCompat.Builder(context, getChannelIdForNotification(threadId))
                 .setCategory(NotificationCompat.CATEGORY_MESSAGE)
                 .setColor(colors.theme(lastRecipient).theme)
-                .setPriority(NotificationCompat.PRIORITY_MAX)
-                .setSmallIcon(R.drawable.ic_notification)
-                .setNumber(messages.size)
-                .setAutoCancel(true)
-                .setOnlyAlertOnce(true)
-                .setContentIntent(contentPI)
-                .setDeleteIntent(seenPI)
-                .setLights(Color.WHITE, 500, 2000)
-                .setWhen(conversation.lastMessage?.date ?: System.currentTimeMillis())
-                .setVibrate(if (prefs.vibration(threadId).get()) VIBRATE_PATTERN else longArrayOf(0))
-
-        // if preference set to silence notifications if no recipients in contacts
-        if (prefs.silentNotContact.get() && run {
-            val msgRecipientNumbers = conversation.recipients.map { it.address }
-
-            // true if any message recipients are in device's contacts
-            !contactRepo
-                .getUnmanagedAllContacts()
-                .flatMap { it.numbers }
-                .map { it.address }
-                .any { contactNumber ->
-                    msgRecipientNumbers.any { phoneNumberUtils.compare(contactNumber, it) }
-                }
-        })
-            notification.setSilent(true)
-        else
-            notification.setSound(ringtone)
-
-    // Tell the notification if it's a group message
-        val messagingStyle = NotificationCompat.MessagingStyle("Me")
-        if (conversation.recipients.size >= 2) {
-            messagingStyle.isGroupConversation = true
-            messagingStyle.conversationTitle = conversation.getTitle()
-        }
-
-        // Add the messages to the notification
-        messages.forEach { message ->
-            val person = Person.Builder()
-
-            if (!message.isMe()) {
-                val recipient = conversation.recipients.find { recipient ->
-                    phoneNumberUtils.compare(recipient.address, message.address)
-                }
-
-                if(recipient != null)
-                    person.fromRecipient(recipient, context, colors)
-            }
-
-            NotificationCompat.MessagingStyle.Message(message.getSummary(), message.date, person.build()).apply {
-                message.parts.firstOrNull { it.isImage() }?.let { part ->
-                    setData(part.type, ContentUris.withAppendedId(CursorToPartImpl.CONTENT_URI, part.id))
-                }
-                messagingStyle.addMessage(this)
-            }
-        }
-
-        // remove system generated contextual actions (they're generated from message links) unless
-        // the user has explicitly set to allow message links
-        notification.setAllowSystemGeneratedContextualActions(
-            (prefs.messageLinkHandling.get() == Preferences.MESSAGE_LINK_HANDLING_ALLOW)
-        )
-
-        // Set the large icon
-        val avatar = conversation.recipients.takeIf { it.size == 1 }
-                ?.first()?.contact?.photoUri
-                ?.let { photoUri ->
-                    GlideApp.with(context)
-                            .asBitmap()
-                            .circleCrop()
-                            .load(photoUri)
-                            .submit(64.dpToPx(context), 64.dpToPx(context))
-                }
-                ?.let { futureGet -> tryOrNull(false) { futureGet.get() } }
-
-        // Bind the notification contents based on the notification preview mode
-        when (prefs.notificationPreviews(threadId).get()) {
-            Preferences.NOTIFICATION_PREVIEWS_ALL -> {
-                notification
-                        .setLargeIcon(avatar)
-                        .setStyle(messagingStyle)
-            }
-
-            Preferences.NOTIFICATION_PREVIEWS_NAME -> {
-                notification
-                        .setLargeIcon(avatar)
-                        .setContentTitle(conversation.getTitle())
-                        .setContentText(context.resources.getQuantityString(
-                                R.plurals.notification_new_messages, messages.size, messages.size))
-            }
-
-            Preferences.NOTIFICATION_PREVIEWS_NONE -> {
-                notification
-                        .setContentTitle(context.getString(R.string.app_name))
-                        .setContentText(context.resources.getQuantityString(
-                                R.plurals.notification_new_messages, messages.size, messages.size))
-            }
-        }
-
-        // Add all of the people from this conversation to the notification, so that the system can
-        // appropriately bypass DND mode
-        conversation.recipients.forEach { recipient ->
-            notification.addPerson(recipient.toPerson(context, colors))
-        }
-
-        // Add the action buttons
-        val actionLabels = context.resources.getStringArray(R.array.notification_actions)
-        listOf(prefs.notifAction1, prefs.notifAction2, prefs.notifAction3)
-                .map { preference -> preference.get() }
-                .distinct()
-                .mapNotNull { action ->
-                    when (action) {
-                        Preferences.NOTIFICATION_ACTION_ARCHIVE -> {
-                            val intent = Intent(context, MessageMarkReceiver::class.java)
-                                .putExtra("threadId", threadId)
-                                .putExtra("type", MessageMarkReceiver.MarkType.Archived.ordinal)
-                            val pi = PendingIntent.getBroadcast(
-                                context,
-                                MessageMarkReceiver.MarkType.Archived.getRequestCode(threadId),
-                                intent,
-                                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                            NotificationCompat.Action.Builder(R.drawable.ic_archive_white_24dp, actionLabels[action], pi)
-                                    .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_ARCHIVE).build()
-                        }
-
-                        Preferences.NOTIFICATION_ACTION_DELETE -> {
-                            val messageIds = messages.map { it.id }.toLongArray()
-                            val intent = Intent(context, DeleteMessagesReceiver::class.java)
-                                    .putExtra("threadId", threadId)
-                                    .putExtra("messageIds", messageIds)
-                            val pi = PendingIntent.getBroadcast(context, threadId.toInt(), intent,
-                                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                            NotificationCompat.Action.Builder(R.drawable.ic_delete_white_24dp, actionLabels[action], pi)
-                                    .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_DELETE).build()
-                        }
-
-                        Preferences.NOTIFICATION_ACTION_BLOCK -> {
-                            val intent = Intent(context, BlockThreadReceiver::class.java).putExtra("threadId", threadId)
-                            val pi = PendingIntent.getBroadcast(context, threadId.toInt(), intent,
-                                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                            NotificationCompat.Action.Builder(R.drawable.ic_block_white_24dp, actionLabels[action], pi)
-                                    .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_MUTE).build()
-                        }
-
-                        Preferences.NOTIFICATION_ACTION_READ -> {
-                            val intent = Intent(context, MessageMarkReceiver::class.java)
-                                .putExtra("threadId", threadId)
-                                .putExtra("type", MessageMarkReceiver.MarkType.Read.ordinal)
-                            val pi = PendingIntent.getBroadcast(
-                                context,
-                                MessageMarkReceiver.MarkType.Read.getRequestCode(threadId),
-                                intent,
-                                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                            NotificationCompat.Action.Builder(R.drawable.ic_check_white_24dp, actionLabels[action], pi)
-                                    .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_MARK_AS_READ).build()
-                        }
-
-                        Preferences.NOTIFICATION_ACTION_REPLY -> {
-                            if (Build.VERSION.SDK_INT >= 24) {
-                                getReplyAction(threadId)
-                            } else {
-                                val intent = Intent(context, QkReplyActivity::class.java).putExtra("threadId", threadId)
-                                val pi = PendingIntent.getActivity(context, threadId.toInt(), intent,
-                                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                                NotificationCompat.Action
-                                        .Builder(R.drawable.ic_reply_white_24dp, actionLabels[action], pi)
-                                        .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY).build()
-                            }
-                        }
-
-                        Preferences.NOTIFICATION_ACTION_CALL -> {
-                            val address = conversation.recipients[0]?.address
-                            val intentAction = if (permissions.hasCalling()) Intent.ACTION_CALL else Intent.ACTION_DIAL
-                            val intent = Intent(intentAction, "tel:$address".toUri())
-                            val pi = PendingIntent.getActivity(context, threadId.toInt(), intent,
-                                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                            NotificationCompat.Action.Builder(R.drawable.ic_call_white_24dp, actionLabels[action], pi)
-                                    .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_CALL).build()
-                        }
-
-                        Preferences.NOTIFICATION_ACTION_SPEAK -> {
-                            val intent = Intent(context, SpeakThreadsReceiver::class.java).putExtra("threadId", threadId)
-                            val pi = PendingIntent.getBroadcast(context, 0, intent,
-                                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-                            NotificationCompat.Action.Builder(R.drawable.ic_speaker_black_24dp, actionLabels[action], pi)
-                                .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_NONE).build()
-                        }
-
-                        else -> null
-                    }
-                }
-                .forEach { notification.addAction(it) }
-
-        if (prefs.qkreply.get()) {
-            notification.priority = NotificationCompat.PRIORITY_DEFAULT
-
-            val intent = Intent(context, QkReplyActivity::class.java)
-                    .putExtra("threadId", threadId)
-                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-
-            context.startActivity(intent)
-        }
-        val sc = shortcutManager.getOrCreateShortcut(threadId)
-        notification.setShortcutInfo(sc)
-        notificationManager.notify(threadId.toInt(), notification.build())
-
-        // Wake screen
-        if (prefs.wakeScreen(threadId).get()) {
-            context.getSystemService<PowerManager>()?.let { powerManager ->
-                if (!powerManager.isInteractive) {
-                    val flags = PowerManager.SCREEN_DIM_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP
-                    val wakeLock = powerManager.newWakeLock(flags, context.packageName)
-                    wakeLock.acquire(5000)
-                }
-            }
-        }
-    }
-
-    override fun notifyFailed(msgId: Long) {
-        val message = messageRepo.getMessage(msgId)
-
-        if (message == null || !message.isFailedMessage()) {
-            return
-        }
-
-        val conversation = conversationRepo.getConversation(message.threadId) ?: return
-        val lastRecipient = conversation.lastMessage?.let { lastMessage ->
-            conversation.recipients.find { recipient ->
-                phoneNumberUtils.compare(recipient.address, lastMessage.address)
-            }
-        } ?: conversation.recipients.firstOrNull()
-
-        val threadId = conversation.id
-
-        val contentIntent = Intent(context, ComposeActivity::class.java).putExtra("threadId", threadId)
-        val taskStackBuilder = TaskStackBuilder.create(context)
-            .addParentStack(ComposeActivity::class.java)
-            .addNextIntent(contentIntent)
-        val contentPI = taskStackBuilder.getPendingIntent(threadId.toInt(), PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
-
-        //Action for resending a failed message
-        val resendIntent = Intent(context, ResendMessageReceiver::class.java).apply {
-            putExtra("id", message.id)
-        }
-        val resendPendingIntent = PendingIntent.getBroadcast(
-            context,
-            message.id.toInt(),
-            resendIntent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val resendAction = NotificationCompat.Action.Builder(
-            R.drawable.ic_send_black_24dp,
-            context.getString(R.string.notification_message_failed_action),
-            resendPendingIntent
-        )
-            .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_NONE)
-            .build()
-
-        val notification = NotificationCompat.Builder(context, getChannelIdForNotification(threadId))
-                .setContentTitle(context.getString(R.string.notification_message_failed_title))
-                .setContentText(context.getString(R.string.notification_message_failed_text, conversation.getTitle()))
-                .addAction(resendAction)
-                .setColor(colors.theme(lastRecipient).theme)
-                .setPriority(NotificationManagerCompat.IMPORTANCE_MAX)
-                .setSmallIcon(R.drawable.ic_notification_failed)
-                .setAutoCancel(true)
-                .setContentIntent(contentPI)
-                .setSound(Uri.parse(prefs.ringtone(threadId).get()))
-                .setLights(Color.WHITE, 500, 2000)
-                .setVibrate(if (prefs.vibration(threadId).get()) VIBRATE_PATTERN else longArrayOf(0))
-
-        notificationManager.notify(threadId.toInt() + 100000, notification.build())
-    }
-
-    private fun getReplyAction(threadId: Long): NotificationCompat.Action {
-        val replyIntent = Intent(context, RemoteMessagingReceiver::class.java).putExtra("threadId", threadId)
-        val replyPI = PendingIntent.getBroadcast(context, threadId.toInt(), replyIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
-
-        val title = context.resources.getStringArray(R.array.notification_actions)[
-                Preferences.NOTIFICATION_ACTION_REPLY]
-        val responseSet = context.resources.getStringArray(R.array.qk_responses)
-        val remoteInput = RemoteInput.Builder("body")
-                .setLabel(title)
-
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-            remoteInput.setChoices(responseSet)
-        }
-
-        return NotificationCompat.Action.Builder(R.drawable.ic_reply_white_24dp, title, replyPI)
-                .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
-                .addRemoteInput(remoteInput.build())
                 .build()
+
+        NotificationManagerCompat.from(context).notify(threadId.toInt(), notification)
     }
 
-    /**
-     * Creates a notification channel for the given conversation
-     */
-    override fun createNotificationChannel(threadId: Long) {
-
-        // Only proceed if the android version supports notification channels
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return
-        }
-
-        val channels: List<NotificationChannel> = when (threadId) {
-            0L -> listOf(
-                NotificationChannel(
-                    DEFAULT_CHANNEL_ID,
-                    "Default",
-                    NotificationManager.IMPORTANCE_HIGH
-                ).apply {
-                    enableLights(true)
-                    lightColor = Color.WHITE
-                    enableVibration(true)
-                    vibrationPattern = VIBRATE_PATTERN
-                },
-                NotificationChannel(
-                    RECEIVING_WORKER_CHANNEL_ID,
-                    context.getString(R.string.notification_foreground_worker_channel_name),
-                    NotificationManager.IMPORTANCE_LOW
-                ).apply {
-                    enableLights(false)
-                    enableVibration(false)
-                },
-            )
-
-            else -> {
-                if (getNotificationChannel(threadId) != null) return
-                val conversation = conversationRepo.getConversation(threadId) ?: return
-                val channelId = buildNotificationChannelId(threadId)
-                val title = conversation.getTitle()
-                listOf(
-                    NotificationChannel(channelId, title, NotificationManager.IMPORTANCE_HIGH).apply {
-                        enableLights(true)
-                        lightColor = Color.WHITE
-                        enableVibration(true)
-                        vibrationPattern = VIBRATE_PATTERN
-                        lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                        setSound(prefs.ringtone().get().let(Uri::parse), AudioAttributes.Builder()
-                                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                                .build())
-                    }
-                )
-            }
-        }
-
-        for (channel in channels)
-            notificationManager.createNotificationChannel(channel)
-    }
-
-    /**
-     * Returns the notification channel for the given conversation, or null if it doesn't exist
-     */
-    private fun getNotificationChannel(threadId: Long): NotificationChannel? {
-        val channelId = buildNotificationChannelId(threadId)
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            return notificationManager.notificationChannels
-                    .find { channel -> channel.id == channelId }
-        }
-
-        return null
-    }
-
-    /**
-     * Returns the channel id that should be used for a notification based on the threadId
-     *
-     * If a notification channel for the conversation exists, use the id for that. Otherwise return
-     * the default channel id
-     */
     private fun getChannelIdForNotification(threadId: Long): String {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            return getNotificationChannel(threadId)?.id ?: DEFAULT_CHANNEL_ID
-        }
-
         return DEFAULT_CHANNEL_ID
     }
 
-    /**
-     * Formats a notification channel id for a given thread id, whether the channel exists or not
-     */
-    override fun buildNotificationChannelId(threadId: Long): String {
-        return when (threadId) {
-            0L -> DEFAULT_CHANNEL_ID
-            else -> "notifications_$threadId"
-        }
-    }
-
-    override fun getNotificationForBackup(): NotificationCompat.Builder {
-        if (Build.VERSION.SDK_INT >= 26) {
-            val name = context.getString(R.string.backup_notification_channel_name)
-            val importance = NotificationManager.IMPORTANCE_LOW
-            val channel = NotificationChannel(BACKUP_RESTORE_CHANNEL_ID, name, importance)
-            val notificationManager = context.getSystemService(NotificationManager::class.java)
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                DEFAULT_CHANNEL_ID,
+                context.getString(R.string.notification_channel_default),
+                NotificationManager.IMPORTANCE_MAX
+            )
             notificationManager.createNotificationChannel(channel)
+
+            val backupChannel = NotificationChannel(
+                BACKUP_RESTORE_CHANNEL_ID,
+                context.getString(R.string.notification_channel_backup_restore),
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            notificationManager.createNotificationChannel(backupChannel)
+
+            val workerChannel = NotificationChannel(
+                RECEIVING_WORKER_CHANNEL_ID,
+                context.getString(R.string.notification_channel_receiving_worker),
+                NotificationManager.IMPORTANCE_LOW
+            )
+            notificationManager.createNotificationChannel(workerChannel)
         }
-
-        return NotificationCompat.Builder(context, BACKUP_RESTORE_CHANNEL_ID)
-                .setContentTitle(context.getString(R.string.backup_restoring))
-                .setShowWhen(false)
-                .setWhen(System.currentTimeMillis()) // Set this anyway in case it's shown
-                .setSmallIcon(R.drawable.ic_file_download_black_24dp)
-                .setColor(colors.theme().theme)
-                .setCategory(NotificationCompat.CATEGORY_PROGRESS)
-                .setPriority(NotificationCompat.PRIORITY_MIN)
-                .setProgress(0, 0, true)
-                .setOngoing(true)
     }
-
-    override fun cancel(i: Int) {
-        notificationManager.cancel(i)
-    }
-
 }
+```


### PR DESCRIPTION
The foreground notification for Android 12 and older wasn't clickable. Added a PendingIntent that launches ComposeActivity when tapped. Fixes #727