### PR TITLE
Refactor provideSharedAttachments to handle actions

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivityModule.kt
@@ -86,9 +86,14 @@ class ComposeActivityModule {
     @Named("attachments")
     fun provideSharedAttachments(activity: ComposeActivity): List<Attachment> {
         val uris = mutableListOf<Uri>()
-        activity.intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::add)
-        activity.intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::addAll)
-
+        when (activity.intent.action) {
+            Intent.ACTION_SEND -> {
+                activity.intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::add)
+            }
+            Intent.ACTION_SEND_MULTIPLE -> {
+                activity.intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM)?.run(uris::addAll)
+            }
+        }
         return uris.map { Attachment(activity, it) }
     }
 


### PR DESCRIPTION
Prevent class cast exception; manage single and multiple URIs without throwing exception.