### PR TITLE
compose: Fix sendAsGroup switch not responding on creating conversation

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -113,7 +113,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     override val optionsItemIntent: Subject<Int> = PublishSubject.create()
     override val contextItemIntent: Subject<MenuItem> = PublishSubject.create()
     override val scheduleAction: Subject<Boolean> = PublishSubject.create()
-    override val sendAsGroupIntent by lazy { binding.sendAsGroupBackground.clicks() }
+    override val sendAsGroupIntent by lazy { binding.sendAsGroupSwitch.clicks() }
     override val messagePartClickIntent: Subject<Long> by lazy { messageAdapter.partClicks }
     override val messagePartContextMenuRegistrar: Subject<View> by lazy { messageAdapter.partContextMenuRegistrar }
     override val messagesSelectedIntent by lazy { messageAdapter.selectionChanges }


### PR DESCRIPTION
The app was listening for clicks on the wrong part of the UI, now clicking on the switch flips it as expected.
Closes #668