### PR TITLE
Move foreground notification to its own channel

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -80,6 +80,7 @@ class NotificationManagerImpl @Inject constructor(
     companion object {
         const val DEFAULT_CHANNEL_ID = "notifications_default"
         const val BACKUP_RESTORE_CHANNEL_ID = "notifications_backup_restore"
+        const val RECEIVING_WORKER_CHANNEL_ID = "notifications_receiving_worker"
 
         val VIBRATE_PATTERN = longArrayOf(0, 200, 0, 200)
     }
@@ -93,7 +94,7 @@ class NotificationManagerImpl @Inject constructor(
 
     // Required for running workers on Android 12 and older
     override fun getForegroundNotificationForWorkersOnOlderAndroids() =
-        NotificationCompat.Builder(context, DEFAULT_CHANNEL_ID)
+        NotificationCompat.Builder(context, RECEIVING_WORKER_CHANNEL_ID)
             .setContentTitle(context.getString(R.string.notification_foreground_worker_title))
             .setContentText(context.getString(R.string.notification_foreground_worker_text))
             .setShowWhen(false)
@@ -454,39 +455,56 @@ class NotificationManagerImpl @Inject constructor(
      */
     override fun createNotificationChannel(threadId: Long) {
 
-        // Only proceed if the android version supports notification channels, and the channel hasn't
-        // already been created
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || getNotificationChannel(threadId) != null) {
+        // Only proceed if the android version supports notification channels
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return
         }
 
-        val channel = when (threadId) {
-            0L -> NotificationChannel(DEFAULT_CHANNEL_ID, "Default", NotificationManager.IMPORTANCE_HIGH).apply {
-                enableLights(true)
-                lightColor = Color.WHITE
-                enableVibration(true)
-                vibrationPattern = VIBRATE_PATTERN
-            }
-
-            else -> {
-                val conversation = conversationRepo.getConversation(threadId) ?: return
-                val channelId = buildNotificationChannelId(threadId)
-                val title = conversation.getTitle()
-                NotificationChannel(channelId, title, NotificationManager.IMPORTANCE_HIGH).apply {
+        val channels: List<NotificationChannel> = when (threadId) {
+            0L -> listOf(
+                NotificationChannel(
+                    DEFAULT_CHANNEL_ID,
+                    "Default",
+                    NotificationManager.IMPORTANCE_HIGH
+                ).apply {
                     enableLights(true)
                     lightColor = Color.WHITE
                     enableVibration(true)
                     vibrationPattern = VIBRATE_PATTERN
-                    lockscreenVisibility = Notification.VISIBILITY_PUBLIC
-                    setSound(prefs.ringtone().get().let(Uri::parse), AudioAttributes.Builder()
-                            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
-                            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-                            .build())
-                }
+                },
+                NotificationChannel(
+                    RECEIVING_WORKER_CHANNEL_ID,
+                    context.getString(R.string.notification_foreground_worker_channel_name),
+                    NotificationManager.IMPORTANCE_LOW
+                ).apply {
+                    enableLights(false)
+                    enableVibration(false)
+                },
+            )
+
+            else -> {
+                if (getNotificationChannel(threadId) != null) return
+                val conversation = conversationRepo.getConversation(threadId) ?: return
+                val channelId = buildNotificationChannelId(threadId)
+                val title = conversation.getTitle()
+                listOf(
+                    NotificationChannel(channelId, title, NotificationManager.IMPORTANCE_HIGH).apply {
+                        enableLights(true)
+                        lightColor = Color.WHITE
+                        enableVibration(true)
+                        vibrationPattern = VIBRATE_PATTERN
+                        lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+                        setSound(prefs.ringtone().get().let(Uri::parse), AudioAttributes.Builder()
+                                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                                .build())
+                    }
+                )
             }
         }
 
-        notificationManager.createNotificationChannel(channel)
+        for (channel in channels)
+            notificationManager.createNotificationChannel(channel)
     }
 
     /**

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -519,6 +519,7 @@
     <string name="notification_message_failed_text">The message to %s failed to send</string>
     <string name="notification_foreground_worker_title">Receiving message</string>
     <string name="notification_foreground_worker_text">On Android 12 and older, a notification is required for the background work that enables receiving messages.</string>
+    <string name="notification_foreground_worker_channel_name">Message receiving worker notification</string>
     <string name="notification_message_failed_action">Resend</string>
 
     <string-array name="night_modes">


### PR DESCRIPTION
This allows users to hide the persistent notification in Android's settings menu. Turning the channel off does not stop the runner.

I do not like the solution that I used to create the channel, as it changed a good few function signatures to something less-than-ideal. Open to suggestions!!

<img width="480" height="854" alt="Screenshot_20260302-173432" src="https://github.com/user-attachments/assets/f68cff8c-436e-4195-b690-6e9dd5ab82ec" />
<img width="644" height="1287" alt="image" src="https://github.com/user-attachments/assets/1f6372fc-b2fe-4d4c-b925-adb01999e664" />
