### PR TITLE
fix(utils): Allow characters to be included after normalizing numbers 

### DIFF
--- a/data/src/androidTest/java/com/moez/QKSMS/repository/PhoneNumberUtilsTest.kt
+++ b/data/src/androidTest/java/com/moez/QKSMS/repository/PhoneNumberUtilsTest.kt
@@ -69,4 +69,14 @@ class PhoneNumberUtilsTest {
         assertFalse(phoneNumberUtils.compare("123 456 7890", "234 567 8901"))
     }
 
+    @Test
+    fun compare_formatted_SenderID_returnsTrue() {
+        assertTrue(phoneNumberUtils.compare("Vi-CARE-S", "ViCARES"))
+    }
+
+    @Test
+    fun compare_different_SenderID_returnsFalse() {
+        assertFalse(phoneNumberUtils.compare("VM-ViCARE-S", "VZ-ViCARE-S"))
+    }
+
 }

--- a/data/src/main/java/com/moez/QKSMS/util/PhoneNumberUtils.kt
+++ b/data/src/main/java/com/moez/QKSMS/util/PhoneNumberUtils.kt
@@ -68,9 +68,8 @@ class PhoneNumberUtils @Inject constructor(context: Context) {
         return PhoneNumberUtils.formatNumber(number.toString(), countryCode) ?: number.toString()
     }
 
-    fun normalizeNumber(number: String): String {
-        return PhoneNumberUtils.stripSeparators(number)
-    }
+    fun normalizeNumber(number: String): String =
+        number.filter { it.isLetterOrDigit() || it in "+*#" }
 
     private fun parse(number: CharSequence): Phonenumber.PhoneNumber? {
         return tryOrNull(false) { phoneNumberUtil.parse(number, countryCode) }


### PR DESCRIPTION
Android's normalizing function stripped out characters too aggressively leading to false matches between different numbers. This commit introduces a faster normalizing function that includes characters. I also added some tests to verify that this fixes the issue.

Closes #611 
Closes #742
Closes #720 