### PR TITLE
Attempt various fixes to stop the app dropping messages

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/receiver/SmsReceivedReceiver.kt
+++ b/data/src/main/java/com/moez/QKSMS/receiver/SmsReceivedReceiver.kt
@@ -42,8 +42,9 @@ class SmsReceivedReceiver : BroadcastReceiver() {
         AndroidInjection.inject(this, context)
 
         Sms.Intents.getMessagesFromIntent(intent)?.let { messages ->
+            val pendingResult = goAsync()
             // reduce list of messages to single message and save in db
-            val messageId = Single.just(messages)
+            Single.just(messages)
                 .observeOn(Schedulers.io())
                 .map {
                     Timber.v("onReceive() new sms")  // here so runs on io thread
@@ -55,15 +56,18 @@ class SmsReceivedReceiver : BroadcastReceiver() {
                         messages[0].timestampMillis
                     ).id
                 }
-                .blockingGet()
-
-            // start worker with message id as param
-            WorkManager.getInstance(context).enqueue(
-                OneTimeWorkRequestBuilder<ReceiveSmsWorker>()
-                    .setInputData(workDataOf(INPUT_DATA_KEY_MESSAGE_ID to messageId))
-                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
-                    .build()
-            )
+                .subscribe({ messageId ->
+                    WorkManager.getInstance(context).enqueue(
+                        OneTimeWorkRequestBuilder<ReceiveSmsWorker>()
+                            .setInputData(workDataOf(INPUT_DATA_KEY_MESSAGE_ID to messageId))
+                            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                            .build()
+                    )
+                    pendingResult.finish()
+                }, { error ->
+                    Timber.e(error, "error receiving new sms")
+                    pendingResult.finish()
+                })
         }
     }
 

--- a/data/src/main/java/com/moez/QKSMS/repository/ContactRepositoryImpl.kt
+++ b/data/src/main/java/com/moez/QKSMS/repository/ContactRepositoryImpl.kt
@@ -177,7 +177,15 @@ class ContactRepositoryImpl @Inject constructor(
         } else {
             uri = Uri.withAppendedPath(ContactsContract.PhoneLookup.CONTENT_FILTER_URI, Uri.encode(address))
         }
-        return context.contentResolver.query(uri, arrayOf(BaseColumns._ID), null, null, null)?.count!! > 0
+        return context.contentResolver.query(
+            uri,
+            arrayOf(BaseColumns._ID),
+            null,
+            null,
+            null
+        )?.use { cursor ->
+            cursor.count > 0
+        } ?: false
     }
 
 }


### PR DESCRIPTION
- [ff6a28918ba6b254e2987f70a629315ab261378b](https://github.com/quik-sms/quik/pull/752/commits/33585096fc5fec4b5eae66a002c5685246963f67): Stops the sms received receiver from potentially getting killed by the android system, by using `goAsync()` rather than `blockingGet()`. This also restores the previous behavior from before 4.3.2.
- [46f17305327c681910af656b3f4afb842a3505b2](https://github.com/quik-sms/quik/pull/752/commits/6ef4ab04937d58dbdd53b7225a661f692666a402): There was a potential memory leak in the contact lookup, by a `query` call to `contentResolver` that was left open. This commit refactors this to use `use`, which should resolve any potential leaks.

Fixes #703
Fixes #689 
(I think) :)