### PR TITLE
fix(utils): Prevent crash from reaching shortcut limit, refactor shortcut code

### DIFF
--- a/data/src/main/java/com/moez/QKSMS/worker/ReceiveMmsWorker.kt
+++ b/data/src/main/java/com/moez/QKSMS/worker/ReceiveMmsWorker.kt
@@ -223,7 +223,7 @@ class ReceiveMmsWorker(appContext: Context, workerParams: WorkerParameters)
                         // update shortcuts
                         Timber.v("update shortcuts")
                         shortcutManager.updateShortcuts()
-                        shortcutManager.reportShortcutUsed(conversation.id)
+                        shortcutManager.getOrCreateShortcut(conversation.id)
 
                         // update the badge and widget
                         Timber.v("update badge and widget")

--- a/data/src/main/java/com/moez/QKSMS/worker/ReceiveSmsWorker.kt
+++ b/data/src/main/java/com/moez/QKSMS/worker/ReceiveSmsWorker.kt
@@ -120,7 +120,7 @@ class ReceiveSmsWorker(appContext: Context, workerParams: WorkerParameters)
         // update shortcuts
         Timber.v("update shortcuts")
         shortcutManager.updateShortcuts()
-        shortcutManager.reportShortcutUsed(conversation.id)
+        shortcutManager.getOrCreateShortcut(conversation.id)
 
         // update the badge and widget
         Timber.v("update badge and widget")

--- a/domain/src/main/java/com/moez/QKSMS/interactor/SendNewMessage.kt
+++ b/domain/src/main/java/com/moez/QKSMS/interactor/SendNewMessage.kt
@@ -72,7 +72,7 @@ class SendNewMessage @Inject constructor(
             conversationRepo.markUnarchived(threadIds)
 
             AndroidSchedulers.mainThread().scheduleDirect {
-                threadIds.forEach { shortcutManager.reportShortcutUsed(it) }
+                threadIds.forEach { shortcutManager.getOrCreateShortcut(it) }
             }
 
             // delete attachment local files, if any, because they're saved to mms db by now

--- a/domain/src/main/java/com/moez/QKSMS/manager/ShortcutManager.kt
+++ b/domain/src/main/java/com/moez/QKSMS/manager/ShortcutManager.kt
@@ -26,7 +26,7 @@ interface ShortcutManager {
 
     fun updateShortcuts()
 
-    fun getShortcut(threadId: Long): ShortcutInfoCompat?
+    fun getOrCreateShortcut(threadId: Long): ShortcutInfoCompat?
 
     fun reportShortcutUsed(threadId: Long)
 

--- a/domain/src/main/java/com/moez/QKSMS/manager/ShortcutManager.kt
+++ b/domain/src/main/java/com/moez/QKSMS/manager/ShortcutManager.kt
@@ -28,6 +28,4 @@ interface ShortcutManager {
 
     fun getOrCreateShortcut(threadId: Long): ShortcutInfoCompat?
 
-    fun reportShortcutUsed(threadId: Long)
-
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/NotificationManagerImpl.kt
@@ -356,7 +356,7 @@ class NotificationManagerImpl @Inject constructor(
 
             context.startActivity(intent)
         }
-        val sc = shortcutManager.getShortcut(threadId)
+        val sc = shortcutManager.getOrCreateShortcut(threadId)
         notification.setShortcutInfo(sc)
         notificationManager.notify(threadId.toInt(), notification.build())
 

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
@@ -23,7 +23,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutManager
 import android.os.Build
-import androidx.core.app.Person
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import dev.octoshrimpy.quik.common.util.extensions.getThemedIcon
@@ -54,7 +53,10 @@ class ShortcutManagerImpl @Inject constructor(
             if (shortcutManager.isRateLimitingActive) return
 
             val shortcuts: List<ShortcutInfoCompat> = conversationRepo.getTopConversations()
-                    .take(shortcutManager.maxShortcutCountPerActivity - shortcutManager.manifestShortcuts.size)
+                    .take(
+                        shortcutManager.maxShortcutCountPerActivity -
+                                shortcutManager.manifestShortcuts.size
+                    )
                     .map { conversation -> createShortcutForConversation(conversation) }
 
             ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
@@ -64,17 +66,17 @@ class ShortcutManagerImpl @Inject constructor(
     /**
      * Get the shortcut for a threadId. Will create it if it doesn't exist.
      */
-    override fun getShortcut(threadId: Long): ShortcutInfoCompat? {
+    override fun getOrCreateShortcut(threadId: Long): ShortcutInfoCompat? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
             var sc = getShortcuts().find { it.id == threadId.toString() }
-            if(sc != null)
+            if (sc != null)
                 sc = updateShortcut(sc)
-            if (sc == null)  {
+            if (sc == null) {
                 val conv = conversationRepo.getConversation(threadId)
                 if (conv == null)
                     return null
                 else
-                    sc =  createShortcutForConversation(conv)
+                    sc = createShortcutForConversation(conv)
             }
             return sc
         } else {
@@ -88,10 +90,8 @@ class ShortcutManagerImpl @Inject constructor(
     override fun reportShortcutUsed(threadId: Long) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
             val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
-            if(getShortcut(threadId ) == null) {
-                val conversation = conversationRepo.getOrCreateConversation(threadId)
-                if (conversation == null)
-                    return
+            if (getOrCreateShortcut(threadId ) == null) {
+                val conversation = conversationRepo.getOrCreateConversation(threadId) ?: return
                 val shortcut = createShortcutForConversation(conversation)
                 ShortcutManagerCompat.setDynamicShortcuts(context, listOf(shortcut))
             }
@@ -120,7 +120,7 @@ class ShortcutManagerImpl @Inject constructor(
             }
         }
 
-        val persons: Array<Person> = conversation.recipients.map { it -> it.toPerson(context, colors) }.toTypedArray();
+        val persons = conversation.recipients.map { it.toPerson(context, colors) }.toTypedArray()
 
         val intent = Intent(context, ComposeActivity::class.java)
                 .setAction(Intent.ACTION_VIEW)
@@ -152,10 +152,10 @@ class ShortcutManagerImpl @Inject constructor(
     }
 
     private fun getShortcuts() : List<ShortcutInfoCompat> {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            return ShortcutManagerCompat.getDynamicShortcuts(context)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            ShortcutManagerCompat.getDynamicShortcuts(context)
         } else {
-            return emptyList()
+            emptyList()
         }
     }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
@@ -69,14 +69,11 @@ class ShortcutManagerImpl @Inject constructor(
     override fun getOrCreateShortcut(threadId: Long): ShortcutInfoCompat? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
             var sc = getShortcuts().find { it.id == threadId.toString() }
-            if (sc != null)
-                sc = updateShortcut(sc)
-            if (sc == null) {
-                val conv = conversationRepo.getConversation(threadId)
-                if (conv == null)
-                    return null
-                else
-                    sc = createShortcutForConversation(conv)
+            sc = if (sc != null) {
+                updateShortcut(sc)
+            } else {
+                val conv = conversationRepo.getConversation(threadId) ?: return null
+                createShortcutForConversation(conv)
             }
             return sc
         } else {
@@ -141,14 +138,12 @@ class ShortcutManagerImpl @Inject constructor(
     }
 
     private fun updateShortcut(shortcut: ShortcutInfoCompat): ShortcutInfoCompat {
-        val conversation = conversationRepo.getConversation(shortcut.id.toLong())
-        if (conversation == null)
-            return shortcut
-        else {
-            val sc = createShortcutForConversation(conversation)
-            ShortcutManagerCompat.pushDynamicShortcut(context, sc)
-            return sc
-        }
+        val conversation = conversationRepo.getConversation(
+            shortcut.id.toLong()
+        ) ?: return shortcut
+        val sc = createShortcutForConversation(conversation)
+        ShortcutManagerCompat.pushDynamicShortcut(context, sc)
+        return sc
     }
 
     private fun getShortcuts() : List<ShortcutInfoCompat> {

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
@@ -18,11 +18,11 @@
  */
 package dev.octoshrimpy.quik.common.util
 
-import android.annotation.TargetApi
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ShortcutManager
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import dev.octoshrimpy.quik.common.util.extensions.getThemedIcon
@@ -47,62 +47,47 @@ class ShortcutManagerImpl @Inject constructor(
         ShortcutBadger.applyCount(context, count)
     }
 
+    /**
+     * Replaces shortcuts with newly created ones of the top conversations. Respects rate limiting.
+     */
     override fun updateShortcuts() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
-            if (shortcutManager.isRateLimitingActive) return
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) return
 
-            val shortcuts: List<ShortcutInfoCompat> = conversationRepo.getTopConversations()
-                    .take(
-                        shortcutManager.maxShortcutCountPerActivity -
-                                shortcutManager.manifestShortcuts.size
-                    )
-                    .map { conversation -> createShortcutForConversation(conversation) }
+        val shortcutManager =
+            context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
+        if (shortcutManager.isRateLimitingActive) return
 
-            ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
-        }
+        val shortcuts: List<ShortcutInfoCompat> = conversationRepo.getTopConversations()
+            .take(
+                shortcutManager.maxShortcutCountPerActivity -
+                        shortcutManager.manifestShortcuts.size
+            )
+            .map { conversation -> createShortcutForConversation(conversation) }
+
+        ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
     }
 
     /**
      * Get the shortcut for a threadId. Will create it if it doesn't exist.
      */
     override fun getOrCreateShortcut(threadId: Long): ShortcutInfoCompat? {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            var sc = getShortcuts().find { it.id == threadId.toString() }
-            sc = if (sc != null) {
-                updateShortcut(sc)
-            } else {
-                val conv = conversationRepo.getConversation(threadId) ?: return null
-                createShortcutForConversation(conv)
-            }
-            return sc
-        } else {
-            return null
-        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N_MR1) return null
+
+        val conv = conversationRepo.getConversation(threadId) ?: return null
+        val sc = createShortcutForConversation(conv)
+        pushShortcut(sc, conv)
+
+        return sc
     }
 
-    /**
-     * Report thread usage. Will create the shortcut if it doesn't exist.
-     */
-    override fun reportShortcutUsed(threadId: Long) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
-            if (getOrCreateShortcut(threadId ) == null) {
-                val conversation = conversationRepo.getOrCreateConversation(threadId) ?: return
-                val shortcut = createShortcutForConversation(conversation)
-                ShortcutManagerCompat.setDynamicShortcuts(context, listOf(shortcut))
-            }
-            shortcutManager.reportShortcutUsed(threadId.toString())
-        }
-    }
-
-    @TargetApi(29)
     private fun createShortcutForConversation(conversation: Conversation): ShortcutInfoCompat {
         Timber.v("creating shortcut for conversation ${conversation.id}")
+
         val icon = when {
             conversation.recipients.size == 1 -> {
                 val recipient = conversation.recipients.first()!!
-                recipient.getThemedIcon(context,
+                recipient.getThemedIcon(
+                    context,
                     colors.theme(recipient),
                     ShortcutManagerCompat.getIconMaxWidth(context),
                     ShortcutManagerCompat.getIconMaxHeight(context)
@@ -110,7 +95,8 @@ class ShortcutManagerImpl @Inject constructor(
             }
 
             else -> {
-                conversation.getThemedIcon(context,
+                conversation.getThemedIcon(
+                    context,
                     ShortcutManagerCompat.getIconMaxWidth(context),
                     ShortcutManagerCompat.getIconMaxHeight(context)
                 )
@@ -120,18 +106,30 @@ class ShortcutManagerImpl @Inject constructor(
         val persons = conversation.recipients.map { it.toPerson(context, colors) }.toTypedArray()
 
         val intent = Intent(context, ComposeActivity::class.java)
-                .setAction(Intent.ACTION_VIEW)
-                .putExtra("threadId", conversation.id)
-                .putExtra("fromShortcut", true)
+            .setAction(Intent.ACTION_VIEW)
+            .putExtra("threadId", conversation.id)
+            .putExtra("fromShortcut", true)
 
         val sc = ShortcutInfoCompat.Builder(context, "${conversation.id}")
-                .setShortLabel(conversation.getTitle())
-                .setLongLabel(conversation.getTitle())
-                .setIcon(icon)
-                .setIntent(intent)
-                .setPersons(persons)
-                .setLongLived(true)
-                .build()
+            .setShortLabel(conversation.getTitle())
+            .setLongLabel(conversation.getTitle())
+            .setIcon(icon)
+            .setIntent(intent)
+            .setPersons(persons)
+            .setLongLived(true)
+            .build()
+
+        return sc
+    }
+
+    /**
+     * Pushes dynamic shortcut, removing old shortcut if space is needed.
+     * Includes static shortcuts when calculating space,
+     * unlike [ShortcutManagerCompat.pushDynamicShortcut]
+     */
+    @RequiresApi(25)
+    private fun pushShortcut(shortcut: ShortcutInfoCompat, conversation: Conversation) {
+        Timber.v("pushing shortcut for conversation ${conversation.id}")
 
         // pushDynamicShortcut excludes static shortcuts in total count, so we must check ourselves
         val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
@@ -146,33 +144,16 @@ class ShortcutManagerImpl @Inject constructor(
         ) {
             var rank = -1
             var lowestRankShortcut: String? = null
-            for (s in shortcutManager.dynamicShortcuts) {
-                if (s.rank > rank) {
-                    lowestRankShortcut = s.id
-                    rank = s.rank
+            for (sc in shortcutManager.dynamicShortcuts) {
+                if (sc.rank > rank) {
+                    lowestRankShortcut = sc.id
+                    rank = sc.rank
                 }
             }
+            Timber.v("removing shortcut for conversation $lowestRankShortcut to make space")
             shortcutManager.removeDynamicShortcuts(listOf(lowestRankShortcut))
         }
 
-        ShortcutManagerCompat.pushDynamicShortcut(context, sc)
-        return sc
-    }
-
-    private fun updateShortcut(shortcut: ShortcutInfoCompat): ShortcutInfoCompat {
-        val conversation = conversationRepo.getConversation(
-            shortcut.id.toLong()
-        ) ?: return shortcut
-        val sc = createShortcutForConversation(conversation)
-        ShortcutManagerCompat.pushDynamicShortcut(context, sc)
-        return sc
-    }
-
-    private fun getShortcuts() : List<ShortcutInfoCompat> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-            ShortcutManagerCompat.getDynamicShortcuts(context)
-        } else {
-            emptyList()
-        }
+        ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
     }
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/util/ShortcutManagerImpl.kt
@@ -133,6 +133,28 @@ class ShortcutManagerImpl @Inject constructor(
                 .setLongLived(true)
                 .build()
 
+        // pushDynamicShortcut excludes static shortcuts in total count, so we must check ourselves
+        val shortcutManager = context.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
+        val hasNoShortcut = shortcutManager.dynamicShortcuts.find {
+            it.id == conversation.id.toString()
+        } == null
+        val maxShortcutsReached = shortcutManager.manifestShortcuts.size +
+                shortcutManager.dynamicShortcuts.size >= shortcutManager.maxShortcutCountPerActivity
+
+        if (
+            Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q && hasNoShortcut && maxShortcutsReached
+        ) {
+            var rank = -1
+            var lowestRankShortcut: String? = null
+            for (s in shortcutManager.dynamicShortcuts) {
+                if (s.rank > rank) {
+                    lowestRankShortcut = s.id
+                    rank = s.rank
+                }
+            }
+            shortcutManager.removeDynamicShortcuts(listOf(lowestRankShortcut))
+        }
+
         ShortcutManagerCompat.pushDynamicShortcut(context, sc)
         return sc
     }


### PR DESCRIPTION
Fixes #738

Needs testing outside of emulator to ensure the "New Conversation" manifest shortcut still works. Seems to be broken on emulator on both 4.3.4 and this version.