### PR TITLE
Refactor release notes cleaning process for manual release

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -124,15 +124,17 @@ jobs:
         run: |
           set -euo pipefail
           python3 <<'PY'
+          
           import os, re, pathlib
           notes = os.environ.get("NOTES", "")
-          clean = re.sub(
-              r'(?im)^\s*by\s+\S+\s+in\s+.*$',
-              '',
-              re.sub(r'(?im)^\s*["\']?\*\*Full\s+Changelog\*\*\s*:\s*.*$', '', notes)
-          ).rstrip()
+          
+          cleanPrTitles = re.sub(r'(?im)\s+by\s+@?\S+\s+in\s+https?://\S+', '', notes)
+          cleanNewContributors = re.sub(r'(?is)##\s+New\s+Contributors.*', '', cleanPrTitles).strip()
+          # In case there isn't a 'New Contributors' line we should still remove the full changelog line after it
+          cleanTotalChangelog = re.sub(r'(?im)^\s*["\']?\*\*Full\s+Changelog\*\*\s*:\s*.*$', '', cleanNewContributors)
 
-          pathlib.Path("sanitized_notes.txt").write_text(clean)
+          pathlib.Path("sanitized_notes.txt").write_text(cleanTotalChangelog)
+          
           PY
           {
             echo "clean_notes<<EOF"


### PR DESCRIPTION
I changed the behavior: to first work; but also to remove the new contributors line, as it shouldn't be shown in app. `## Total Changelog` is after new contributors so it will be removed anyway.

Tested with old release notes, and it works as expected.