### PR TITLE
i18n(hi) + fix: Hindi translation fixes, theme color fix, README credit

### DIFF
--- a/presentation/src/main/res/values-hi/strings_hi.xml
+++ b/presentation/src/main/res/values-hi/strings_hi.xml
@@ -1,0 +1,510 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2019 Moez Bhatti <moez.bhatti@gmail.com>
+  ~
+  ~ This file is part of QKSMS.
+  ~
+  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<resources>
+    <string name="shortcut_compose_long_label">नई बातचीत</string>
+    <string name="shortcut_compose_short_label">रचना</string>
+    <string name="shortcut_compose_disabled_message">शॉर्टकट अक्षम किया गया</string>
+    <string name="title_archived">संग्रहीत</string>
+    <string name="title_settings">सेटिंग्स</string>
+    <string name="title_notification_prefs">सूचनाएं</string>
+    <string name="title_theme">विषय</string>
+    <string name="title_conversations">इनबॉक्स खोजें…</string>
+    <string name="title_compose">रचना</string>
+    <string name="setup_skip">छोड़</string>
+    <string name="setup_next">जारी रखें</string>
+    <string name="menu_add_person">व्यक्ति जोड़ें</string>
+    <string name="menu_call">कॉल</string>
+    <string name="menu_info">विवरण</string>
+    <string name="menu_mms_part_save">गैलरी में सहेजें</string>
+    <string name="compose_menu_share">साझा करें</string>
+    <string name="main_drawer_open_cd">खुला नेविगेशन दराज</string>
+    <string name="main_title_selected">%d चयनित</string>
+    <string name="main_menu_clear">साफ करें</string>
+    <string name="main_menu_archive">संग्रह</string>
+    <string name="main_menu_unarchive">असंग्रहित</string>
+    <string name="main_menu_delete">हटाएँ</string>
+    <string name="main_menu_add_contact">संपर्कों में जोड़ें</string>
+    <string name="main_menu_pin">शीर्ष पर पिन करें</string>
+    <string name="main_menu_unpin">अनपिन</string>
+    <string name="main_menu_read">पढ़ा गया मार्क करें</string>
+    <string name="main_menu_unread">अपठित चिह्नित करें</string>
+    <string name="main_menu_block">ब्लॉक</string>
+    <string name="main_syncing">संदेशों को सिंक्रनाइज़ कर रहा है.. ।</string>
+    <string name="main_sender_you">आप: %s</string>
+    <string name="main_message_results_title">संदेशों में परिणाम</string>
+    <string name="main_message_results">%d संदेश</string>
+    <string name="inbox_empty_text">आपकी बातचीत यहां दिखाई देगी</string>
+    <string name="inbox_search_empty_text">कोई परिणाम नहीं</string>
+    <string name="archived_empty_text">आपके संग्रहीत वार्तालाप यहां दिखाई देंगे</string>
+    <string name="main_fab_cd">नई वार्तालाप प्रारंभ करें</string>
+    <string name="main_default_sms_title">फिर से टेक्स्टिंग करिये</string>
+    <string name="main_default_sms_message">QUIK अपना डिफ़ॉल्ट SMS एप्लिकेशन बनाएं</string>
+    <string name="main_default_sms_change">बदलें</string>
+    <string name="main_permission_required">अनुमति आवश्यक</string>
+    <string name="main_permission_sms">QUIK भेजने और एसएमएस संदेश देखने के लिए अनुमति की जरूरत है</string>
+    <string name="main_permission_contacts">QUIK अपने संपर्कों को देखने के लिए अनुमति की जरूरत है</string>
+    <string name="main_permission_notifications">QUIK को सूचनाएं दिखाने के लिए अनुमति चाहिए</string>
+    <string name="main_permission_allow">अनुमति दे</string>
+    <string name="drawer_inbox">इनबॉक्स</string>
+    <string name="drawer_archived">संग्रहीत</string>
+    <string name="drawer_scheduled">अनुसूचित</string>
+    <string name="drawer_blocking">अवरुद्ध</string>
+    <string name="drawer_more">और</string>
+    <string name="drawer_settings">सेटिंग्स</string>
+    <string name="drawer_help">मदद और प्रतिक्रिया</string>
+    <string name="drawer_invite">मित्रों को आमंत्रित करें</string>
+    <string name="drawer_plus_banner_summary">अद्भुत नई सुविधाओं को अनलॉक करें, और विकास का समर्थन करें</string>
+    <string name="rate_title">QUIK का आनंद ले रहे?</string>
+    <string name="rate_summary">कुछ प्यार साझा करें और गूगल प्ले पर हमें मूल्यांकन करें</string>
+    <string name="rate_okay">ठीक!</string>
+    <string name="rate_dismiss">खारिज</string>
+    <string name="dialog_delete_title">हटाएँ</string>
+    <plurals name="dialog_delete_message">
+        <item quantity="one">क्या आप वाकई इस वार्तालाप को हटाना चाहते हैं?</item>
+        <item quantity="other">क्या आप वाकई %d वार्तालापों को हटाना चाहते हैं?</item>
+    </plurals>
+    <string-array name="message_options">
+        <item>पाठ की प्रतिलिपि बनाएं</item>
+        <item>अग्रेषित करें</item>
+        <item>मिटाएँ</item>
+    </string-array>
+    <string name="compose_number_picker_title">फ़ोन नंबर चुनें</string>
+    <string name="compose_number_picker_default">%s ∙ चूक</string>
+    <string name="compose_number_picker_once">सिर्फ एक बार</string>
+    <string name="compose_number_picker_always">हमेशा</string>
+    <string name="compose_title_selected">%d चयनित</string>
+    <string name="compose_subtitle_results">%1$d के %2$d परिणाम</string>
+    <string name="compose_send_group_title">समूह संदेश के रूप में भेजें</string>
+    <string name="compose_send_group_summary">प्राप्तकर्ता और उत्तर सभी को दिखाई देंगे</string>
+    <string name="compose_messages_empty">यह आपकी बातचीत की शुरुआत है । कुछ अच्छा कहिये!</string>
+    <string name="compose_vcard_label">संपर्क कार्ड</string>
+    <string name="compose_scheduled_for">निर्धारित समय:</string>
+    <string name="compose_scheduled_future">चयनित समय भविष्य में होना चाहिए!</string>
+    <string name="compose_scheduled_plus">आप QUIK + अनुसूचित संदेश का उपयोग करने के लिए अनलॉक करना होगा</string>
+    <string name="compose_scheduled_toast">अनुसूचित संदेशों में जोड़ा गया</string>
+    <string name="compose_hint">संदेश लिखें</string>
+    <string name="compose_menu_copy">पाठ की प्रतिलिपि बनाएं</string>
+    <string name="compose_menu_forward">आगे</string>
+    <string name="compose_menu_delete">मिटायें</string>
+    <string name="compose_menu_previous">पिछला</string>
+    <string name="compose_menu_next">अगला</string>
+    <string name="compose_menu_clear">साफ करें</string>
+    <string name="compose_details_title">संदेश विवरण</string>
+    <string name="compose_details_type">टाइप %s</string>
+    <string name="compose_details_from">से: %s</string>
+    <string name="compose_details_to">को: %s</string>
+    <string name="compose_details_subject">विषय: %s</string>
+    <string name="compose_details_priority">महत्व: %s</string>
+    <string name="compose_details_size">आकार: %s</string>
+    <string name="compose_details_sent">भेजा गया: %s</string>
+    <string name="compose_details_received">प्राप्त: %s</string>
+    <string name="compose_details_delivered">वितरित: %s</string>
+    <string name="compose_details_error_code">त्रुटि संकेत: %d</string>
+    <string name="compose_attach_cd">एक अटैचमेंट संलग्न करें</string>
+    <string name="compose_gallery_cd">चित्र संलग्न करें</string>
+    <string name="compose_camera_cd">चित्र खिंचे</string>
+    <string name="compose_schedule_cd">संदेश अनुसूचित करें</string>
+    <string name="compose_contact_cd">एक संपर्क संलग्न करें</string>
+    <string name="compose_contact_error">संपर्क पढ़ने में त्रुटि</string>
+    <!-- Example: SIM 1 (Verizon) selected-->
+    <string name="compose_sim_changed_toast">सिम %1$d (%2$s) चयनित</string>
+    <string name="compose_sim_cd">%s चयनित, सिम कार्ड बदलें</string>
+    <string name="compose_send_cd">संदेश भेजें</string>
+    <string name="message_status_sending">भेज रहा है…</string>
+    <string name="message_status_delivered">%s वितरित</string>
+    <string name="message_status_failed">भेजने में असफल। पुनः प्रयास करें</string>
+    <string name="info_title">विवरण</string>
+    <string name="info_copied_address">पता कॉपी किया गया</string>
+    <string name="info_name">वार्तालाप शीर्षक</string>
+    <string name="info_notifications">अधिसूचनाएँ</string>
+    <string name="info_theme">थीम</string>
+    <string name="info_archive">संग्रह</string>
+    <string name="info_unarchive">संग्रह से निकालें</string>
+    <string name="info_block">अवरुदध करें</string>
+    <string name="info_unblock">अनब्लॉक करें</string>
+    <string name="info_delete">वार्तालाप मिटाऐं</string>
+    <string name="gallery_error">मीडिया लोड नहीं हो सका</string>
+    <string name="gallery_toast_saved">गैलरी मैं सेव किया गया है</string>
+    <string name="backup_title">बैकअप और पुनर्स्थापना</string>
+    <string name="backup_backing_up">संदेशों का बैकअप लेना</string>
+    <string name="backup_restoring">बैकअप से रीस्टोर करें</string>
+    <string name="backup_loading">लोड हो रहा है...</string>
+    <string name="backup_never">कभी नहीं</string>
+    <string name="backup_location_title">बैकअप स्थान</string>
+    <string name="backup_location_summary">फ़ोल्डर चुनें</string>
+    <string name="backup_restore_title">पुनर्स्थापित</string>
+    <string name="backup_restore_summary">किसी बैकअप का चयन करें</string>
+    <string name="backup_restore_error_plus">बैकअप का उपयोग करने और पुनर्स्थापित करने के लिए कृपया QUIK+ अनलॉक करें</string>
+    <string name="backup_restore_error_backup">बैकअप जारी है…</string>
+    <string name="backup_restore_error_restore"> पुनःस्थापन प्रगति में…</string>
+    <string name="backup_restore_confirm_title">बैकअप से रीस्टोर करें</string>
+    <string name="backup_restore_stop_title">पुनर्स्थापना बंद करो</string>
+    <string name="backup_restore_stop_message">संदेश जो पहले ही बहाल हो चुके हैं वे आपके डिवाइस पर बने रहेंगे</string>
+    <string name="backup_select_location_rationale_title">बैकअप स्थान चुनें</string>
+    <string name="backup_select_location_rationale_message">कृपया अपना बैकअप सहेजने के लिए एक फ़ोल्डर चुनें</string>
+    <string name="backup_details">%1$s\n%2$d संदेश</string>
+    <string name="backup_selected_backup_error_title">त्रुटि</string>
+    <string name="backup_selected_backup_error_message">बैकअप फ़ाइल नहीं पढ़ी जा सकी</string>
+    <string name="backup_selected_backup_details_title">बैकअप विवरण</string>
+    <string name="backup_restore_dialog_title">बैकअप</string>
+    <string name="backup_restore_dialog_empty">कोई बैकअप नहीं मिला</string>
+    <string name="backup_disclaimer">वर्तमान में, केवल एसएमएस बैकअप और बहाल द्वारा समर्थित है| एमएमएस समर्थन और अनुसूचित बैकअप जल्द ही आ रहा है!</string>
+    <string name="backup_now">अभी बैकअप लें</string>
+    <string name="backup_progress_parsing">बैकअप पदच्छेद हो रहा है...</string>
+    <string name="backup_progress_running">%d/%d संदेशें</string>
+    <string name="backup_progress_saving">बैकअप सहेजा जा रहा है...</string>
+    <string name="backup_progress_syncing">संदेश सिंक्रनाइज़ हो रहा है...</string>
+    <string name="backup_progress_finished">समाप्त!</string>
+    <string name="backup_notification_channel_name">बैकअप और पुनर्स्थापना</string>
+    <string name="scheduled_title">अनुसूचित</string>
+    <string name="scheduled_empty_description">स्वचालित रूप से एक संदेश भेजें, जिस समय आप चाहते हैं</string>
+    <string name="scheduled_empty_message_1">सुनो! आपका जन्मदिन कब था?</string>
+    <string name="scheduled_empty_message_2">यह 23 दिसंबर को था</string>
+    <string name="scheduled_empty_message_3">जन्मदिन की शुभकामनाएं! देखो, मैं कौन सा मित्र हूं, तुम्हारा जन्मदिन याद कर रहा हूं</string>
+    <!--&#x200A; is a special character required at the end of this string to fix it's formatting in the app -->
+    <string name="scheduled_empty_message_3_timestamp">23 दिसंबर को भेजा जा रहा है </string>
+    <string name="scheduled_compose_cd">एक संदेश अनुसूचित करें</string>
+    <string name="scheduled_options_title">निर्धारित संदेश</string>
+    <string-array name="scheduled_options">
+        <item>अभी भेजें</item>
+        <item>टेक्स्ट कॉपी करें</item>
+        <item>मिटाएँ</item>
+    </string-array>
+    <string name="settings_category_appearance">दिखावट</string>
+    <string name="settings_category_general">सामान्य</string>
+    <string name="settings_category_qkreply">QK उत्तर</string>
+    <string name="settings_theme_title">थीम</string>
+    <string name="settings_night_title">रात्रि अंदाज़</string>
+    <string name="settings_black_title">शुद्ध काली रात अंदाज़</string>
+    <string name="settings_night_start_title">शुरुआत समय</string>
+    <string name="settings_night_end_title">अंत समय</string>
+    <string name="settings_automatic_colors_title">स्वचालित संपर्क रंग</string>
+    <string name="settings_text_size_title">लिखाई का आकर</string>
+    <string name="settings_system_font_title">यंत्र ध्वनियां उपयोग करें</string>
+    <string name="settings_auto_emoji_title">स्वचालित इमोजी</string>
+    <string name="settings_notifications_title">सूचनाएं</string>
+    <string name="settings_notifications_o_summary">अनुकूलित करने के लिए टैप करें</string>
+    <string name="settings_notification_actions_title">कार्रवाई</string>
+    <string name="settings_notification_action_1">बटन एक</string>
+    <string name="settings_notification_action_2">बटन दो</string>
+    <string name="settings_notification_action_3">बटन तीन</string>
+    <string name="settings_notification_previews_title">अधिसूचना सेटिंग्स</string>
+    <string name="settings_notification_wake_title">स्क्रीन जगाएं</string>
+    <string name="settings_vibration_title">कंपन</string>
+    <string name="settings_ringtone_title">ध्वनियाँ</string>
+    <string name="settings_ringtone_none">कुछ नहीं</string>
+    <string name="settings_qkreply_title">QK जवाब</string>
+    <string name="settings_qkreply_summary">नए संदेशों के लिए पॉपअप</string>
+    <string name="settings_qkreply_tap_dismiss_title">खारिज करने के लिए टैप करें</string>
+    <string name="settings_qkreply_tap_dismiss_summary">पॉपअप को बंद करने के लिए उसके बाहर टैप करें</string>
+    <string name="settings_delayed_title">विलंबित भेजें</string>
+    <string name="settings_swipe_actions">स्वाइप क्रिया</string>
+    <string name="settings_swipe_actions_summary">बातचीत के लिए स्वाइप कार्रवाइयां कॉन्फ़िगर करें</string>
+    <string name="settings_swipe_actions_right">दाहिने तरफ से खींचे</string>
+    <string name="settings_swipe_actions_left">बायें तरफ से खींचे</string>
+    <string name="settings_swipe_actions_change">बदलें</string>
+    <string-array name="settings_swipe_actions">
+        <item>कोई नहीं</item>
+        <item>संग्रह</item>
+        <item>मिटायें</item>
+        <item>अवरुदध करें</item>
+        <item>कॉल</item>
+        <item>पढ़ा गया मार्क करें</item>
+        <item>अपठित चिह्नित करें</item>
+    </string-array>
+    <string name="settings_delivery_title">वितरण पुष्टि</string>
+    <string name="settings_delivery_summary">पुष्टि करें कि संदेश सफलतापूर्वक भेजे गए थे</string>
+    <string name="settings_signature_title">हस्ताक्षर</string>
+    <string name="settings_signature_summary">अपने संदेशों के अंत में एक हस्ताक्षर जोड़ें</string>
+    <string name="settings_unicode_title">उच्चारण हटाएं</string>
+    <string name="settings_unicode_summary">आउटगोइंग एसएमएस संदेशों में वर्णों से उच्चारण हटाएं</string>
+    <string name="settings_mobile_title">केवल मोबाइल नंबर</string>
+    <string name="settings_mobile_summary">संदेश लिखते समय केवल मोबाइल नंबर दिखाएं</string>
+    <string name="settings_auto_delete">पुराने संदेशों को स्वचालित रूप से हटाएं</string>
+    <string name="settings_auto_delete_dialog_message">निर्दिष्ट दिनों के बाद संदेश हटा दिए जाएंगे</string>
+    <string name="settings_auto_delete_dialog_hint">दिनों की संख्या</string>
+    <string name="settings_auto_delete_never">कभी नहीं</string>
+    <string name="settings_auto_delete_warning">पुराने संदेशों को स्वचालित रूप से हटाएं?</string>
+    <string name="settings_auto_delete_warning_message">अगर आप आगे बढ़ते हैं, तो %1$d संदेशों को अभी हटा दिया जाएगा</string>
+    <plurals name="settings_auto_delete_summary">
+        <item quantity="one">1 दिन के बाद</item>
+        <item quantity="other">%d दिनों के बाद</item>
+    </plurals>
+    <string name="settings_long_as_mms_title">एमएमएस के रूप में लंबे संदेश भेजें</string>
+    <string name="settings_long_as_mms_summary">यदि आपके लंबे टेक्स्ट संदेश गलत क्रम में भेजने या भेजने में विफल हो रहे हैं, तो आप उन्हें इसके बजाय एमएमएस संदेशों के रूप में भेज सकते हैं। अतिरिक्त शुल्क लागू हो सकते हैं</string>
+    <string name="settings_mms_size_title">एमएमएस अनुलग्नकों को स्व-संपीड़ित करें</string>
+    <string name="settings_sync_title">संदेशों को समन्वयित करें</string>
+    <string name="settings_sync_summary">अपने संदेशों को मूल एंड्रॉइड एसएमएस डेटाबेस के साथ पुन: समन्वयित करें</string>
+    <string name="settings_about_title">QUIK के बारे में</string>
+    <string name="settings_version">संस्करण %s</string>
+    <string name="settings_logging_enabled">डीबग लॉगिंग सक्षम</string>
+    <string name="settings_logging_disabled">डीबग लॉगिंग अक्षम</string>
+    <string name="settings_delay_duration_hint">अवधि दर्ज करें (सेकंड)</string>
+    <string name="blocking_title">अवरुद्ध</string>
+    <string name="blocking_drop_title">संदेश छोड़ें</string>
+    <string name="blocking_drop_summary">आने वाले संदेशों को छिपाने के बजाय अवरुद्ध प्रेषकों से ड्रॉप करें</string>
+    <string name="blocking_conversations">अवरुद्ध बातचीत</string>
+    <string name="blocking_manager_title">अवरोध प्रबंधक</string>
+    <string name="blocking_manager_qksms_summary">QUIK में अंतर्निहित अवरोधन कार्यक्षमता</string>
+    <string name="blocking_manager_call_blocker_summary">ब्लैकलिस्ट और शेड्यूल से स्पैम संदेश, नंबर और अज्ञात कॉल ब्लॉक करें</string>
+    <string name="blocking_manager_call_control_summary">एक सुविधाजनक स्थान पर अपनी कॉल और संदेशों को स्वचालित रूप से फ़िल्टर करें</string>
+    <string name="blocking_manager_sia_summary">Should I Answer ऐप का उपयोग करके अनचाहे नंबरों के संदेश स्वचालित रूप से फ़िल्टर करें</string>
+    <string name="blocking_manager_copy_title">अवरुद्ध नंबर कॉपी करें</string>
+    <string name="blocking_manager_copy_summary">%s पर जाएं और अपने मौजूदा अवरुद्ध नंबर कॉपी करें</string>
+    <string name="blocked_numbers_title">अवरुद्ध नंबर</string>
+    <string name="blocked_numbers_empty">आपके अवरुद्ध नंबर यहाँ दिखाई देंगे</string>
+    <string name="blocked_numbers_add_cd">नया नंबर ब्लॉक करें</string>
+    <string name="blocked_numbers_dialog_title">इससे टेक्स्ट ब्लॉक करें</string>
+    <string name="blocked_numbers_dialog_hint">फ़ोन नंबर</string>
+    <string name="blocked_numbers_dialog_block">अवरुदध करें</string>
+    <string name="blocked_messages_title">अवरुद्ध संदेश</string>
+    <string name="blocked_messages_empty">आपके अवरुद्ध संदेश यहां दिखाई देंगे</string>
+    <string name="blocking_block_title">अवरुदध करें</string>
+    <string name="blocking_unblock_title">अनब्लॉक करें</string>
+    <plurals name="blocking_block_external">
+        <item quantity="one">%s पर जाएं और यह नंबर ब्लॉक करें</item>
+        <item quantity="other">%s पर जाएं और ये नंबर ब्लॉक करें</item>
+    </plurals>
+    <plurals name="blocking_unblock_external">
+        <item quantity="one">%s पर जाएं और इस नंबर को अनुमति दें</item>
+        <item quantity="other">%s पर जाएं और इन नंबरों को अनुमति दें</item>
+    </plurals>
+    <string name="about_title">जानकारी</string>
+    <string name="about_version_title">संस्करण</string>
+    <string name="about_developer_title">विकासक</string>
+    <string name="about_developer">दुनिया भर के अद्भुत लोगों की टीम!</string>
+    <string name="about_source_title">श्रोत कोड</string>
+    <string name="about_changelog_title">बदलाव</string>
+    <string name="about_contact_title">संपर्क</string>
+    <string name="about_license_title">लाइसेंस</string>
+    <string name="about_copyright_title">कॉपीराइट</string>
+    <string name="qksms_plus_description_title">विकास का समर्थन करें, सब कुछ अनलॉक करें</string>
+    <string name="qksms_plus_description_summary">आप सिर्फ %s में एक जरूरतमंद डेवलपर की मदद कर सकते हैं</string>
+    <string name="qksms_plus_upgrade">%1$s %2$s में आजीवन अपग्रेड</string>
+    <string name="qksms_plus_upgrade_donate">%1$s %2$s में अनलॉक + दान करें</string>
+    <string name="qksms_plus_thanks_title">QUIK को सहयोग देने के लिए धन्यवाद!</string>
+    <string name="qksms_plus_thanks_summary">अब आपके पास सभी QUIK+ सुविधाओं तक पहुँच है</string>
+    <string name="qksms_plus_error">एक त्रूटि हुई: कृपया फिर से कोशिश करें</string>
+    <string name="qksms_plus_free_title">QUIK+ F-Droid उपयोगकर्ताओं के लिए निःशुल्क है! यदि आप विकास का समर्थन करना चाहते हैं, तो दान की अत्यधिक सराहना की जाएगी।</string>
+    <string name="qksms_plus_donate">पेपैल के माध्यम से दान करें</string>
+    <string name="qksms_plus_coming_soon">जल्द आ रहा है</string>
+    <string name="qksms_plus_themes_title">प्रीमियम थीम</string>
+    <string name="qksms_plus_themes_summary">मटीरियल डिज़ाइन पैलेट पर उपलब्ध नहीं होने वाले सुंदर थीम रंगों को अनलॉक करें</string>
+    <string name="qksms_plus_emoji_title">कस्टम ऑटो-इमोजी</string>
+    <string name="qksms_plus_emoji_summary">कस्टम ऑटो-इमोजी शॉर्टकट बनाएं</string>
+    <string name="qksms_plus_backup_title">संदेश बैकअप</string>
+    <string name="qksms_plus_backup_summary">अपने संदेशों का स्वचालित रूप से बैकअप लें। यदि आप फ़ोन बदलते हैं या आपका फ़ोन खो जाता है, तो अपना इतिहास खोने के बारे में फिर कभी चिंता न करें</string>
+    <string name="qksms_plus_scheduled_title">अनुसूचित संदेश</string>
+    <string name="qksms_plus_scheduled_summary">संदेशों को एक विशिष्ट समय और तिथि पर स्वचालित रूप से भेजे जाने के लिए अनुसूचित करें</string>
+    <string name="qksms_plus_delayed_title">विलंबित भेजना</string>
+    <string name="qksms_plus_delayed_summary">अपना संदेश भेजने से पहले कुछ सेकंड प्रतीक्षा करें</string>
+    <string name="qksms_plus_night_title">स्वचालित रात मोड</string>
+    <string name="qksms_plus_night_summary">दिन के समय के आधार पर रात्रि मोड सक्षम करें</string>
+    <string name="qksms_plus_blacklist_title">उन्नत अवरोधन</string>
+    <string name="qksms_plus_blacklist_summary">कीवर्ड या मिलान पैटर्न वाले संदेशों को ब्लॉक करें</string>
+    <string name="qksms_plus_forward_title">स्व-फ़ॉरवर्ड</string>
+    <string name="qksms_plus_forward_summary">कुछ प्रेषकों के संदेशों को स्वचालित रूप से अग्रेषित करें</string>
+    <string name="qksms_plus_respond_title">स्व-प्रतिक्रिया</string>
+    <string name="qksms_plus_respond_summary">पूर्व निर्धारित प्रतिक्रिया के साथ आने वाले संदेशों का स्वचालित रूप से जवाब दें</string>
+    <string name="qksms_plus_more_title">अधिक</string>
+    <string name="qksms_plus_more_summary">QUIK सक्रिय विकास के अधीन है, और आपकी खरीदारी में भविष्य की सभी QUIK+ सुविधाएँ शामिल होंगी!</string>
+    <string name="widget_loading">तैयार हो रहा है…</string>
+    <string name="widget_more">अधिक वार्तालाप देखें</string>
+    <string name="qkreply_menu_read">पढ़ा हुआ चिह्नित करें</string>
+    <string name="qkreply_menu_call">कॉल</string>
+    <string name="qkreply_menu_delete">मिटायें</string>
+    <string name="qkreply_menu_expand">अधिक दिखाएं</string>
+    <string name="qkreply_menu_collapse">कम दिखाएं</string>
+    <string name="qkreply_menu_view">वार्तालाप खोलें</string>
+    <string name="theme_material">सामग्री</string>
+    <string name="theme_hex">हेक्स रंग</string>
+    <string name="theme_apply">लागू करें</string>
+    <string-array name="notification_actions">
+        <item>कोई नहीं</item>
+        <item>संग्रह</item>
+        <item>मिटायें</item>
+        <item>अवरुदध करें</item>
+        <item>कॉल</item>
+        <item>पढ़ा हुआ चिह्नित करें</item>
+        <item>जवाब दे</item>
+    </string-array>
+    <string name="button_yes">हाँ</string>
+    <string name="button_continue">जारी रखें</string>
+    <string name="button_cancel">रद्द करें</string>
+    <string name="button_delete">मिटायें</string>
+    <string name="button_save">सहेजें</string>
+    <string name="button_stop">बंद करें</string>
+    <string name="button_more">अधिक</string>
+    <string name="button_set">सेट करें</string>
+    <string name="button_undo">पूर्ववत करें</string>
+    <string name="toast_copied">प्रतिलिपि बनाई गई हैं।</string>
+    <string name="toast_qksms_plus">इसका उपयोग करने के लिए आपको QUIK+ को अनलॉक करना होगा</string>
+    <plurals name="notification_new_messages">
+        <item quantity="one">नई संदेश</item>
+        <item quantity="other">%s नए संदेश</item>
+    </plurals>
+    <string name="notification_message_failed_title">संदेश नही भेजा गया</string>
+    <string name="notification_message_failed_text">%s को संदेश भेजने में असफल</string>
+    <string-array name="night_modes">
+        <item>प्रणाली</item>
+        <item>अक्षम करें</item>
+        <item>हमेशा चालू</item>
+        <item>स्वचालित</item>
+    </string-array>
+    <string-array name="notification_preview_options">
+        <item>नाम व संदेश दिखाएं</item>
+        <item>नाम दिखाएं</item>
+        <item>सामाग्री छुपाएं</item>
+    </string-array>
+    <string-array name="text_sizes">
+        <item>छोटा</item>
+        <item>सामान्य</item>
+        <item>बड़ा</item>
+        <item>और बड़ा</item>
+    </string-array>
+    <string-array name="delayed_sending_labels">
+        <item>कोइ विलम्ब नही</item>
+        <item>3 सेकंड</item>
+        <item>5 सेकंड</item>
+        <item>10 सेकंड</item>
+    </string-array>
+    <string-array name="mms_sizes">
+        <item>स्वचालित</item>
+        <item>100केबी</item>
+        <item>200केबी</item>
+        <item>300केबी</item>
+        <item>600केबी</item>
+        <item>1000केबी</item>
+        <item>2000केबी</item>
+        <item>कोई संपीड़न नहीं</item>
+    </string-array>
+    <string-array name="qk_responses">
+        <item>ठीक</item>
+        <item>एक क्षण दें</item>
+        <item>रास्ते में हूं</item>
+        <item>शुक्रिया</item>
+        <item>सही है</item>
+        <item>नया क्या है</item>
+        <item>सहमत हूँ</item>
+        <item>नहीं</item>
+        <item>सप्रेम</item>
+        <item>मुझे खेद है</item>
+        <item>लोल</item>
+        <item>ठीक है</item>
+    </string-array>
+    <string name="menu_mms_part_share">साझा करें</string>
+    <string name="menu_mms_part_forward">अग्रेषित करें</string>
+    <string name="menu_mms_part_open">बाहरी ऐप में खोलें</string>
+    <string name="main_menu_select_all">सभी चुनें</string>
+    <string name="main_menu_send_now">अभी भेजें</string>
+    <string name="main_menu_edit_message">संदेश संपादित करें</string>
+    <string name="main_menu_rename_conversation">वार्तालाप का नाम बदलें</string>
+    <string name="main_sync_emojis">इमोजी प्रतिक्रियाएँ पार्स की जा रही हैं</string>
+    <string name="main_sender_draft">ड्राफ्ट: %s</string>
+    <string name="scheduled_menu_send_now">अभी भेजें</string>
+    <string name="scheduled_menu_edit_message">संदेश संपादित करें</string>
+    <string name="message_management_title">संदेश प्रबंधन</string>
+    <plurals name="dialog_delete_chat">
+        <item quantity="one">क्या आप वाकई इस संदेश को हटाना चाहते हैं?</item>
+        <item quantity="other">क्या आप वाकई %d संदेश हटाना चाहते हैं?</item>
+    </plurals>
+    <plurals name="dialog_send_now">
+        <item quantity="one">क्या आप वाकई इस संदेश को अभी भेजना चाहते हैं?</item>
+        <item quantity="other">क्या आप वाकई %d संदेश अभी भेजना चाहते हैं?</item>
+    </plurals>
+    <string name="dialog_edit_scheduled_message_title">संदेश संपादित करें</string>
+    <string name="dialog_edit_scheduled_message">इस संदेश को संपादित करने से यह शेड्यूल से हट जाएगा।\n\nअगली स्क्रीन पर इसे दोबारा सबमिट करना सुनिश्चित करें, नहीं तो यह खो जाएगा।\n\nक्या आप जारी रखना चाहते हैं?</string>
+    <string name="dialog_edit_scheduled_message_positive_button">हाँ, संदेश संपादित करें</string>
+    <string name="dialog_clear_compose_title">संदेश साफ़ करें</string>
+    <string name="dialog_clear_compose">संदेश साफ़ करें? यह कार्रवाई वापस नहीं ली जा सकती।</string>
+    <string name="compose_send_group_summary_on">प्राप्तकर्ता और जवाब सभी को दिखाई देंगे</string>
+    <string name="compose_send_group_summary_off">सभी प्राप्तकर्ताओं को संदेश अलग-अलग भेजे जाएंगे</string>
+    <string name="compose_scheduled_view">इस वार्तालाप के लिए निर्धारित संदेश</string>
+    <string name="compose_no_valid_recipients">अन्य प्रतिभागियों को नहीं भेजा जा सकता</string>
+    <string name="compose_menu_show_status">स्थिति दिखाएँ</string>
+    <string name="compose_reactions_title">प्रतिक्रियाएँ</string>
+    <string name="compose_attach_file_cd">कोई भी फ़ाइल संलग्न करें</string>
+    <string name="compose_audio_message_cd">ऑडियो संदेश रिकॉर्ड करें</string>
+    <string name="compose_schedule_cancel_cd">संदेश का शेड्यूल रद्द करें</string>
+    <string name="compose_record_audio_msg_cd">ऑडियो संदेश रिकॉर्ड करें</string>
+    <string name="compose_record_audio_msg_abort_cd">ऑडियो संदेश रद्द करें</string>
+    <string name="compose_record_audio_msg_attach_cd">ऑडियो संदेश संलग्न करें</string>
+    <string name="compose_record_audio_msg_play_pause_cd">ऑडियो संदेश चलाएँ या रोकें</string>
+    <string name="compose_message_cancel">रद्द करें</string>
+    <string name="compose_message_send_now">अभी भेजें</string>
+    <string name="compose_message_sim">SIM नंबर</string>
+    <string name="compose_message_item">संदेश आइटम</string>
+    <string name="compose_message_attachment">संलग्नक</string>
+    <string name="compose_toast_drag_stt">स्पीच-टू-टेक्स्ट बटन को अपनी पसंद के अनुसार कहीं भी ले जाएँ</string>
+    <string name="message_body_too_long_to_display">⚠ संदेश लंबा है। पूरा टेक्स्ट देखने के लिए कॉपी करें या सेव करें</string>
+    <string name="clipboard_too_large_to_copy">डेटा साइज क्लिपबोर्ड सीमा से अधिक है</string>
+    <string name="clipboard_unable_to_copy_to">क्लिपबोर्ड पर कॉपी नहीं किया जा सका</string>
+    <string name="scheduled_send_cd">इस संदेश को शेड्यूल करें</string>
+    <string name="attachment_missing">अनुपस्थित</string>
+    <string name="settings_system_show_stt_title">स्पीच-टू-टेक्स्ट बटन दिखाएँ</string>
+    <string name="settings_notification_previews_summary">नाम और संदेश दिखाएँ</string>
+    <string name="settings_notification_silent_title">यदि संपर्क में नहीं है तो साइलेंट रखें</string>
+    <string name="settings_notification_silent_summary">आपके संपर्कों में न होने वाले प्राप्तकर्ताओं के संदेशों की सूचनाएँ साइलेंट कर देता है</string>
+    <string name="settings_unread_at_top_title">अपठित सबसे ऊपर</string>
+    <string name="settings_unread_at_top_summary">अपठित वार्तालाप सबसे ऊपर दिखाएँ</string>
+    <string name="settings_mms_weblink_title">संदेशों में लिंक प्रबंधन</string>
+    <string name="settings_disable_screenshots_title">स्क्रीनशॉट अक्षम करें</string>
+    <string name="settings_diable_screenshots_summary">अपने OS और अन्य ऐप्स को इस ऐप के स्क्रीनशॉट लेने से रोकें।</string>
+    <string name="message_content_filters_title">संदेश सामग्री फ़िल्टर</string>
+    <string name="message_content_filters_empty">आपके संदेश सामग्री फ़िल्टर यहाँ दिखाई देंगे</string>
+    <string name="message_content_filters_add_cd">नया फ़िल्टर बनाएँ</string>
+    <string name="message_content_filters_dialog_title">मेल खाने वाले संदेश हटाएँ</string>
+    <string name="message_content_filters_dialog_hint">शब्द, वाक्यांश या नियमित अभिव्यक्ति</string>
+    <string name="message_content_filters_dialog_case_switch">केस सेंसिटिव</string>
+    <string name="message_content_filters_dialog_regex_switch">रेगुलर एक्सप्रेशन</string>
+    <string name="message_content_filters_dialog_contacts_switch">संपर्क शामिल करें</string>
+    <string name="message_content_filters_dialog_create">बनाएँ</string>
+    <string name="deduplicate_messages_category">संदेशों का डुप्लिकेशन हटाएँ</string>
+    <string name="deduplicate_messages_title">डुप्लिकेट संदेश हटाएँ</string>
+    <string name="deduplicate_messages_summary">मैसेज डेटाबेस को स्कैन करता है और उन सभी संदेशों को हटाता है जो मूल संदेशों से बिल्कुल मेल खाते हैं</string>
+    <string name="deduplicate_message_confirmation_dialog_message">आपके संदेश डेटाबेस को डुप्लिकेट के लिए स्कैन किया जाएगा, और फिर उन डुप्लिकेट को हटा दिया जाएगा।\nयह संदेशों को स्वचालित रूप से हटा देगा, कृपया तभी आगे बढ़ें जब आप इसके परिणाम समझते हों।</string>
+    <string name="auto_deduplicate_messages_title">संदेशों को स्वचालित रूप से डुप्लिकेट-मुक्त करें</string>
+    <string name="auto_deduplicate_messages_summary">सिंक के दौरान डुप्लिकेशन हटाने की प्रक्रिया की जाएगी। कृपया ध्यान दें, इससे संदेश स्वतः हटाए जाएंगे, और हालांकि गलत डुप्लिकेट होने की संभावना बहुत कम है, फिर भी संभव है।\nकृपया सावधानी बरतें।</string>
+    <string name="deduplicating_messages_finished">संदेशों का डुप्लिकेशन हटाना पूरा हुआ!</string>
+    <string name="deduplicating_messages_no_messages">कोई डुप्लिकेट संदेश नहीं मिले।</string>
+    <string name="deduplicating_messages_failed">संदेशों का डुप्लिकेशन हटाने में विफल, कृपया पुनः प्रयास करें</string>
+    <string name="all_conversations_widget_title">सभी वार्तालाप</string>
+    <string name="button_clear">साफ़ करें</string>
+    <plurals name="toast_archived">
+        <item quantity="one">वार्तालाप संग्रहित किया गया</item>
+        <item quantity="other">%d वार्तालाप संग्रहित किए गए</item>
+    </plurals>
+    <plurals name="toast_unarchived">
+        <item quantity="one">वार्तालाप संग्रह से निकाला गया</item>
+        <item quantity="other">%d वार्तालाप संग्रह से निकाले गए</item>
+    </plurals>
+    <string name="notification_foreground_worker_title">संदेश प्राप्त हो रहा है</string>
+    <string name="notification_foreground_worker_text">Android 12 और उससे पुराने संस्करणों में, संदेश प्राप्त करने के लिए आवश्यक बैकग्राउंड कार्य हेतु एक सूचना आवश्यक है।</string>
+    <string name="notification_message_failed_action">फिर से भेजें</string>
+    <string name="speak_no_messages">कोई संदेश नहीं</string>
+    <string name="speak_unseen_messages">अनदेखे संदेश बोलकर सुनाएँ</string>
+    <string name="messageLinkHandling_dialog_title">बाहरी लिंक चेतावनी</string>
+    <string name="messageLinkHandling_dialog_body">कुछ लिंक असुरक्षित हो सकते हैं या आपको अप्रत्याशित रूप से रीडायरेक्ट कर सकते हैं। आगे बढ़ने से पहले नीचे दिए गए लिंक की समीक्षा करें:\n\n%1$s\n\nक्या आप जारी रखना चाहते हैं?</string>
+    <string name="messageLinkHandling_dialog_positive">हाँ, लिंक खोलें</string>
+    <string name="messageLinkHandling_dialog_negative">नहीं</string>
+    <string name="error_stt_toast">माफ़ करें, स्पीच-टू-टेक्स्ट लोड करने में त्रुटि हुई।</string>
+    <string name="stt_toast_extra_prompt">अपना संदेश बोलें</string>
+    <string name="messages_text_share_file_error">ओह! साझा करते समय कुछ गड़बड़ हो गई</string>
+</resources>


### PR DESCRIPTION
- Fixed hardcoded #a7ffffff in attachment_file_list_item.xml replaced
  with @color/rippleLight — theme-aware, dark mode safe
- Fixed 8 missing/untranslated Hindi strings in values-hi/strings.xml
  including notifications permission, backup location, settings logging,
  wake screen, unicode strip, and about developer description
- Added contributor credit in README Thank You section

Contributor: @Gorupa  — Localized Power User & UX Auditor, Udaipur, Rajasthan