### PR TITLE
fix: Remove hardcoded theme color

### DIFF
--- a/presentation/src/main/res/layout/attachment_file_list_item.xml
+++ b/presentation/src/main/res/layout/attachment_file_list_item.xml
@@ -44,7 +44,7 @@
             android:id="@+id/fileName"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="#a7ffffff"
+            android:background="@color/rippleLight"
             android:gravity="center"
             android:textColor="@color/black"
             android:visibility="gone"


### PR DESCRIPTION
- Fixed hardcoded #a7ffffff in attachment_file_list_item.xml replaced
  with @color/rippleLight — theme-aware, dark mode safe
- Fixed 8 missing/untranslated Hindi strings in values-hi/strings.xml
  including notifications permission, backup location, settings logging,
  wake screen, unicode strip, and about developer description
- Added contributor credit in README Thank You section

Contributor: @Gorupa — Localized Power User & UX Auditor, Udaipur, Rajasthan