### PR TITLE
feat(about): revamped About screen with contributor cards and GitHub avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Grab QUIK from the official [github releases page](https://github.com/octoshrimp
 
 
 <a href="https://f-droid.org/repository/browse/?fdid=dev.octoshrimpy.quik.fdroid"><img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="100"></a>
-<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://app/{%22id%22:%22dev.octoshrimpy.quik%22,%22url%22:%22https://github.com/octoshrimpy/quik%22,%22author%22:%22octoshrimpy%22,%22name%22:%22QUIK%22,%22additionalSettings%22:%22{\%22apkFilterRegEx\%22:\%22release\%22,\%22invertAPKFilter\%22:false,\%22about\%22:\%22QUIK%20is%20an%20open%20source%20replacement%20for%20the%20stock%20messaging%20app%20on%20Android.%20It%20is%20a%20continuation%20of%20QKSMS.\%22}%22}"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/b1c8ac6f2ab08497189721a788a5763e28ff64cd/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" height="100"></a>
+<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://app/{%22id%22:%22dev.octoshrimpy.quik%22,%22url%22:%22https://github.com/octoshrimpy/quik%22,%22author%22:%22octoshrimpy%22,%22name%22:%22QUIK%22,%22additionalSettings%22:%22{\\%22apkFilterRegEx\\%22:\\%22release\\%22,\\%22invertAPKFilter\\%22:false,\\%22about\\%22:\\%22QUIK%20is%20an%20open%20source%20replacement%20for%20the%20stock%20messaging%20app%20on%20Android.%20It%20is%20a%20continuation%20of%20QKSMS.\\%22}%22}"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/b1c8ac6f2ab08497189721a788a5763e28ff64cd/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" height="100"></a>
 <a href="https://github.com/octoshrimpy/quik/releases">
 <img src="https://user-images.githubusercontent.com/69304392/148696068-0cfea65d-b18f-4685-82b5-329a330b1c0d.png"
 alt="Download from GitHub releases" height="100" /></a>
@@ -66,6 +66,8 @@ If you'd like to add translations to QUIK, please join the project on [Weblate](
 A special thank you to Jake ([@klinker41](https://github.com/klinker41)) and Luke Klinker ([@klinker24](https://github.com/klinker24)) for their work on [android-smsmms](https://github.com/klinker41/android-smsmms), which has been an unspeakably large help in implementing MMS into QUIK.
 
 A giant thank you to Moez [moezbhatti](https://github.com/moezbhatti) for creating and maintaining QKSMS, of which QUIK would not exist without.
+
+A special thank you to [Gorupa](https://github.com/Gorupa) for localized UX auditing, Hindi translation quality review, and power-user testing from Udaipur, Rajasthan.
 
 ## Contact
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutController.kt
@@ -18,9 +18,14 @@
  */
 package dev.octoshrimpy.quik.feature.settings.about
 
+import android.content.Intent
+import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CircleCrop
+import com.bumptech.glide.request.RequestOptions
 import com.jakewharton.rxbinding2.view.clicks
 import dev.octoshrimpy.quik.BuildConfig
 import dev.octoshrimpy.quik.R
@@ -38,12 +43,51 @@ class AboutController : QkController<AboutControllerBinding, AboutView, Unit, Ab
 
     @Inject override lateinit var presenter: AboutPresenter
 
+    // ── GitHub profile URLs for the three featured contributors ────────────
+    private val urlOctoshrimpy = "https://github.com/octoshrimpy"
+    private val urlMoez        = "https://github.com/moezbhatti"
+    private val urlGorupa      = "https://github.com/Gorupa"
+
+    // ── GitHub avatar URLs ─────────────────────────────────────────────────
+    private val avatarOctoshrimpy = "https://avatars.githubusercontent.com/u/10530368?v=4"
+    private val avatarMoez        = "https://avatars.githubusercontent.com/u/4685875?v=4"
+    private val avatarGorupa      = "https://avatars.githubusercontent.com/u/148386383?v=4"
+
     init {
         appComponent.inject(this)
     }
 
     override fun onViewCreated() {
+        // Version badge text
+        binding.versionBadge.text = "v${BuildConfig.VERSION_NAME}"
+        // Keep the hidden PreferenceView summary in sync for the version row
         binding.version.summary = BuildConfig.VERSION_NAME
+
+        // Load circular avatars using Glide
+        val circleOptions = RequestOptions().transform(CircleCrop())
+
+        Glide.with(this)
+            .load(avatarOctoshrimpy)
+            .apply(circleOptions)
+            .placeholder(R.drawable.ic_person_black_24dp)
+            .into(binding.avatarOctoshrimpy)
+
+        Glide.with(this)
+            .load(avatarMoez)
+            .apply(circleOptions)
+            .placeholder(R.drawable.ic_person_black_24dp)
+            .into(binding.avatarMoez)
+
+        Glide.with(this)
+            .load(avatarGorupa)
+            .apply(circleOptions)
+            .placeholder(R.drawable.ic_person_black_24dp)
+            .into(binding.avatarGorupa)
+
+        // Open GitHub profile on contributor row tap
+        binding.contributorOctoshrimpy.setOnClickListener { openUrl(urlOctoshrimpy) }
+        binding.contributorMoez.setOnClickListener       { openUrl(urlMoez) }
+        binding.contributorGorupa.setOnClickListener     { openUrl(urlGorupa) }
     }
 
     override fun onAttach(view: View) {
@@ -54,13 +98,18 @@ class AboutController : QkController<AboutControllerBinding, AboutView, Unit, Ab
     }
 
     override fun preferenceClicks(): Observable<PreferenceView> = (0 until binding.preferences.childCount)
-            .map { index -> binding.preferences.getChildAt(index) }
-            .mapNotNull { view -> view as? PreferenceView }
-            .map { preference -> preference.clicks().map { preference } }
-            .let { preferences -> Observable.merge(preferences) }
+        .map { index -> binding.preferences.getChildAt(index) }
+        .mapNotNull { view -> view as? PreferenceView }
+        .map { preference -> preference.clicks().map { preference } }
+        .let { preferences -> Observable.merge(preferences) }
 
     override fun render(state: Unit) {
         // No special rendering required
     }
 
+    // ── Helper ──────────────────────────────────────────────────────────────
+    private fun openUrl(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivity(intent)
+    }
 }


### PR DESCRIPTION
Redesigns the About screen from a plain preference list into a proper
contributor showcase with the following additions:

**Hero block**
- App icon + app name displayed at top
- Version shown as a styled badge pill

**Featured Contributor Cards (3)**
Each card shows a circular GitHub avatar (loaded via Glide),
contributor name, role description, and a chevron arrow.
Tapping opens their GitHub profile in the browser.

| Contributor | Role |
|---|---|
| Marcos Jones (@octoshrimpy) | Lead Developer · QUIK maintainer |
| Moez Bhatti (@moezbhatti) | Original QKSMS creator |
| Gorupa (@Gorupa) | Hindi Translator · UX Auditor |

**All contributors link preserved**
The existing "Developers" preference row still links to
the full GitHub contributors graph.

**All original rows preserved**
Version, Source, Changelog, Contact, License, Copyright
rows are all kept below the contributor section.

**New string keys added (strings.xml)**
- about_contributors_title
- about_contributor_octoshrimpy_name / _role
- about_contributor_moez_name / _role
- about_contributor_gorupa_name / _role

No new dependencies. Uses Glide which is already in the project.