### PR TITLE
Gorupa patch 2 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Grab QUIK from the official [github releases page](https://github.com/octoshrimp
 
 
 <a href="https://f-droid.org/repository/browse/?fdid=dev.octoshrimpy.quik.fdroid"><img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="100"></a>
-<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://app/{%22id%22:%22dev.octoshrimpy.quik%22,%22url%22:%22https://github.com/octoshrimpy/quik%22,%22author%22:%22octoshrimpy%22,%22name%22:%22QUIK%22,%22additionalSettings%22:%22{\%22apkFilterRegEx\%22:\%22release\%22,\%22invertAPKFilter\%22:false,\%22about\%22:\%22QUIK%20is%20an%20open%20source%20replacement%20for%20the%20stock%20messaging%20app%20on%20Android.%20It%20is%20a%20continuation%20of%20QKSMS.\%22}%22}"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/b1c8ac6f2ab08497189721a788a5763e28ff64cd/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" height="100"></a>
+<a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://app/{%22id%22:%22dev.octoshrimpy.quik%22,%22url%22:%22https://github.com/octoshrimpy/quik%22,%22author%22:%22octoshrimpy%22,%22name%22:%22QUIK%22,%22additionalSettings%22:%22{\\%22apkFilterRegEx\\%22:\\%22release\\%22,\\%22invertAPKFilter\\%22:false,\\%22about\\%22:\\%22QUIK%20is%20an%20open%20source%20replacement%20for%20the%20stock%20messaging%20app%20on%20Android.%20It%20is%20a%20continuation%20of%20QKSMS.\\%22}%22}"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/b1c8ac6f2ab08497189721a788a5763e28ff64cd/assets/graphics/badge_obtainium.png" alt="Get it on Obtainium" height="100"></a>
 <a href="https://github.com/octoshrimpy/quik/releases">
 <img src="https://user-images.githubusercontent.com/69304392/148696068-0cfea65d-b18f-4685-82b5-329a330b1c0d.png"
 alt="Download from GitHub releases" height="100" /></a>
@@ -66,6 +66,8 @@ If you'd like to add translations to QUIK, please join the project on [Weblate](
 A special thank you to Jake ([@klinker41](https://github.com/klinker41)) and Luke Klinker ([@klinker24](https://github.com/klinker24)) for their work on [android-smsmms](https://github.com/klinker41/android-smsmms), which has been an unspeakably large help in implementing MMS into QUIK.
 
 A giant thank you to Moez [moezbhatti](https://github.com/moezbhatti) for creating and maintaining QKSMS, of which QUIK would not exist without.
+
+A special thank you to [Gorupa](https://github.com/Gorupa) for localized UX auditing, Hindi translation quality review, and power-user testing from Udaipur, Rajasthan.
 
 ## Contact
 

--- a/presentation/src/main/res/layout/about_controller.xml
+++ b/presentation/src/main/res/layout/about_controller.xml
@@ -25,62 +25,322 @@
     android:background="?android:attr/windowBackground">
 
     <LinearLayout
-        android:id="@+id/preferences"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:animateLayoutChanges="true"
         android:orientation="vertical"
         android:paddingTop="8dp"
-        android:paddingBottom="8dp">
+        android:paddingBottom="24dp">
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/version"
+        <!-- ── App hero block ───────────────────────────────────────── -->
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:title="@string/about_version_title"
-            tools:summary="3.0.8" />
+            android:orientation="vertical"
+            android:gravity="center"
+            android:paddingTop="24dp"
+            android:paddingBottom="16dp"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp">
 
+            <ImageView
+                android:id="@+id/appIcon"
+                android:layout_width="72dp"
+                android:layout_height="72dp"
+                android:src="@mipmap/ic_launcher_round"
+                android:contentDescription="@string/app_name" />
+
+            <dev.octoshrimpy.quik.common.widget.QkTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/app_name"
+                android:textSize="22sp"
+                android:textStyle="bold"
+                android:textColor="?android:attr/textColorPrimary" />
+
+            <dev.octoshrimpy.quik.common.widget.QkTextView
+                android:id="@+id/versionBadge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:background="@drawable/rounded_rectangle_22dp"
+                android:backgroundTint="?attr/bubbleColor"
+                android:paddingStart="14dp"
+                android:paddingEnd="14dp"
+                android:paddingTop="4dp"
+                android:paddingBottom="4dp"
+                android:textSize="12sp"
+                android:textColor="?android:attr/textColorSecondary"
+                tools:text="v3.0.8" />
+
+        </LinearLayout>
+
+        <!-- ── Section divider ─────────────────────────────────────── -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginStart="24dp"
+            android:layout_marginEnd="24dp"
+            android:background="@color/separatorLight" />
+
+        <!-- ── Featured Contributors label ─────────────────────────── -->
+        <dev.octoshrimpy.quik.common.widget.QkTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp"
+            android:paddingTop="20dp"
+            android:paddingBottom="8dp"
+            android:text="@string/about_contributors_title"
+            android:textSize="12sp"
+            android:textAllCaps="true"
+            android:letterSpacing="0.1"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <!-- ── Featured contributor card 1 — Marcos (octoshrimpy) ──── -->
+        <LinearLayout
+            android:id="@+id/contributorOctoshrimpy"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:gravity="center_vertical"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true">
+
+            <ImageView
+                android:id="@+id/avatarOctoshrimpy"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="@drawable/circle"
+                android:backgroundTint="?attr/bubbleColor"
+                android:scaleType="centerCrop"
+                tools:src="@tools:sample/avatars[0]" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="14dp"
+                android:paddingEnd="8dp">
+
+                <dev.octoshrimpy.quik.common.widget.QkTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/about_contributor_octoshrimpy_name"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="15sp"
+                    android:textStyle="bold" />
+
+                <dev.octoshrimpy.quik.common.widget.QkTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:text="@string/about_contributor_octoshrimpy_role"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="13sp" />
+
+            </LinearLayout>
+
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/ic_chevron_right_black_24dp"
+                android:tint="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
+        <!-- ── Featured contributor card 2 — Moez (moezbhatti) ──────── -->
+        <LinearLayout
+            android:id="@+id/contributorMoez"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:gravity="center_vertical"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true">
+
+            <ImageView
+                android:id="@+id/avatarMoez"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="@drawable/circle"
+                android:backgroundTint="?attr/bubbleColor"
+                android:scaleType="centerCrop"
+                tools:src="@tools:sample/avatars[1]" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="14dp"
+                android:paddingEnd="8dp">
+
+                <dev.octoshrimpy.quik.common.widget.QkTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/about_contributor_moez_name"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="15sp"
+                    android:textStyle="bold" />
+
+                <dev.octoshrimpy.quik.common.widget.QkTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:text="@string/about_contributor_moez_role"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="13sp" />
+
+            </LinearLayout>
+
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/ic_chevron_right_black_24dp"
+                android:tint="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
+        <!-- ── Featured contributor card 3 — Gorupa ─────────────────── -->
+        <LinearLayout
+            android:id="@+id/contributorGorupa"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:gravity="center_vertical"
+            android:background="?attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true">
+
+            <ImageView
+                android:id="@+id/avatarGorupa"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="@drawable/circle"
+                android:backgroundTint="?attr/bubbleColor"
+                android:scaleType="centerCrop"
+                tools:src="@tools:sample/avatars[2]" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="14dp"
+                android:paddingEnd="8dp">
+
+                <dev.octoshrimpy.quik.common.widget.QkTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/about_contributor_gorupa_name"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="15sp"
+                    android:textStyle="bold" />
+
+                <dev.octoshrimpy.quik.common.widget.QkTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:text="@string/about_contributor_gorupa_role"
+                    android:textColor="?android:attr/textColorSecondary"
+                    android:textSize="13sp" />
+
+            </LinearLayout>
+
+            <ImageView
+                android:layout_width="18dp"
+                android:layout_height="18dp"
+                android:src="@drawable/ic_chevron_right_black_24dp"
+                android:tint="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
+        <!-- ── All contributors link ───────────────────────────────── -->
         <dev.octoshrimpy.quik.common.widget.PreferenceView
             android:id="@+id/developer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
             app:summary="@string/about_developer"
             app:title="@string/about_developer_title" />
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/source"
+        <!-- ── Divider ──────────────────────────────────────────────── -->
+        <View
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:summary="@string/about_source"
-            app:title="@string/about_source_title" />
+            android:layout_height="1dp"
+            android:layout_marginStart="24dp"
+            android:layout_marginEnd="24dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:background="@color/separatorLight" />
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/changelog"
+        <!-- ── App info section ─────────────────────────────────────── -->
+        <LinearLayout
+            android:id="@+id/preferences"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:summary="@string/about_changelog"
-            app:title="@string/about_changelog_title" />
+            android:animateLayoutChanges="true"
+            android:orientation="vertical">
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/contact"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:summary="@string/about_contact"
-            app:title="@string/about_contact_title" />
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/version"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:title="@string/about_version_title"
+                tools:summary="3.0.8" />
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/license"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:summary="@string/about_license"
-            app:title="@string/about_license_title" />
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/source"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_source"
+                app:title="@string/about_source_title" />
 
-        <dev.octoshrimpy.quik.common.widget.PreferenceView
-            android:id="@+id/copyright"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:summary="@string/about_copyright"
-            app:title="@string/about_copyright_title" />
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/changelog"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_changelog"
+                app:title="@string/about_changelog_title" />
+
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/contact"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_contact"
+                app:title="@string/about_contact_title" />
+
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/license"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_license"
+                app:title="@string/about_license_title" />
+
+            <dev.octoshrimpy.quik.common.widget.PreferenceView
+                android:id="@+id/copyright"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:summary="@string/about_copyright"
+                app:title="@string/about_copyright_title" />
+
+        </LinearLayout>
 
     </LinearLayout>
 


### PR DESCRIPTION
Redesigns the About screen from a plain preference list into a proper
contributor showcase with the following additions:

**Hero block**
- App icon + app name displayed at top
- Version shown as a styled badge pill

**Featured Contributor Cards (3)**
Each card shows a circular GitHub avatar (loaded via Glide),
contributor name, role description, and a chevron arrow.
Tapping opens their GitHub profile in the browser.

| Contributor | Role |
|---|---|
| Marcos Jones (@octoshrimpy) | Lead Developer · QUIK maintainer |
| Moez Bhatti (@moezbhatti) | Original QKSMS creator |
| Gorupa (@Gorupa) | Hindi Translator · UX Auditor |

**All contributors link preserved**
The existing "Developers" preference row still links to
the full GitHub contributors graph.

**All original rows preserved**
Version, Source, Changelog, Contact, License, Copyright
rows are all kept below the contributor section.

**New string keys added (strings.xml)**
- about_contributors_title
- about_contributor_octoshrimpy_name / _role
- about_contributor_moez_name / _role
- about_contributor_gorupa_name / _role

No new dependencies. Uses Glide which is already in the project.