### PR TITLE
Add read-only Messages for Web MVP

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <!-- Used for starting foreground service for backup/restore on Android P+ -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-<!--    <uses-permission android:name="android.permission.INTERNET" />-->
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_SMS" />
@@ -105,6 +105,7 @@
                 android:value=".common.util.QkChooserTargetService" />
         </activity>
         <activity android:name=".feature.messageutils.MessageUtilsActivity" />
+        <activity android:name=".feature.webaccess.WebAccessActivity" />
         <activity android:name=".feature.settings.SettingsActivity" />
         <activity android:name=".feature.settings.about.AboutActivity" />
         <activity android:name=".feature.plus.PlusActivity" />

--- a/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
@@ -43,6 +43,7 @@ import dev.octoshrimpy.quik.feature.notificationprefs.NotificationPrefsActivity
 import dev.octoshrimpy.quik.feature.plus.PlusActivity
 import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivity
 import dev.octoshrimpy.quik.feature.settings.SettingsActivity
+import dev.octoshrimpy.quik.feature.webaccess.WebAccessActivity
 import dev.octoshrimpy.quik.manager.BillingManager
 import dev.octoshrimpy.quik.manager.NotificationManager
 import dev.octoshrimpy.quik.manager.PermissionManager
@@ -176,6 +177,11 @@ class Navigator @Inject constructor(
 
     fun showMessageUtils() {
         val intent = Intent(context, MessageUtilsActivity::class.java)
+        startActivity(intent)
+    }
+
+    fun showWebAccess() {
+        val intent = Intent(context, WebAccessActivity::class.java)
         startActivity(intent)
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -218,6 +218,8 @@ class SettingsPresenter @Inject constructor(
 
                         R.id.sync -> syncMessages.execute(Unit)
 
+                        R.id.webAccess -> navigator.showWebAccess()
+
                         R.id.about -> view.showAbout()
                     }
                 }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessActivity.kt
@@ -1,0 +1,93 @@
+package dev.octoshrimpy.quik.feature.webaccess
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.Gravity
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import dagger.android.AndroidInjection
+import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.base.QkThemedActivity
+
+class WebAccessActivity : QkThemedActivity() {
+    private val handler = Handler(Looper.getMainLooper())
+    private lateinit var status: TextView
+    private lateinit var url: TextView
+    private lateinit var token: TextView
+    private lateinit var startStop: Button
+
+    private val refresh = object : Runnable {
+        override fun run() {
+            updateState()
+            handler.postDelayed(this, 1000)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this)
+        super.onCreate(savedInstanceState)
+        title = getString(R.string.web_access_title)
+        setContentView(createContentView())
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refresh.run()
+    }
+
+    override fun onPause() {
+        handler.removeCallbacks(refresh)
+        super.onPause()
+    }
+
+    private fun createContentView(): LinearLayout {
+        val padding = (16 * resources.displayMetrics.density).toInt()
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(padding, padding, padding, padding)
+
+            addView(TextView(context).apply {
+                text = getString(R.string.web_access_summary)
+                textSize = 16f
+            }, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+
+            status = label()
+            url = label()
+            token = label()
+            addView(status)
+            addView(url)
+            addView(token)
+
+            startStop = Button(context).apply {
+                setOnClickListener {
+                    if (WebAccessServer.isRunning) WebAccessServer.stop() else WebAccessServer.start()
+                    updateState()
+                }
+            }
+            addView(startStop, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+
+            addView(TextView(context).apply {
+                text = getString(R.string.web_access_warning)
+                textSize = 14f
+            }, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        }
+    }
+
+    private fun label(): TextView = TextView(this).apply {
+        gravity = Gravity.START
+        textSize = 15f
+        setPadding(0, (16 * resources.displayMetrics.density).toInt(), 0, 0)
+        layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    private fun updateState() {
+        val running = WebAccessServer.isRunning
+        status.text = getString(if (running) R.string.web_access_status_running else R.string.web_access_status_stopped)
+        url.text = getString(R.string.web_access_url, if (running) WebAccessServer.localUrl else "-")
+        token.text = getString(R.string.web_access_token, if (running) WebAccessServer.token else "-")
+        startStop.text = getString(if (running) R.string.web_access_stop else R.string.web_access_start)
+    }
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
@@ -1,0 +1,244 @@
+package dev.octoshrimpy.quik.feature.webaccess
+
+import dev.octoshrimpy.quik.model.Conversation
+import dev.octoshrimpy.quik.model.Message
+import io.realm.Realm
+import io.realm.Sort
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URLDecoder
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+object WebAccessServer {
+    private const val DEFAULT_PORT = 8090
+    private const val MAX_MESSAGES = 500
+
+    private val running = AtomicBoolean(false)
+
+    @Volatile private var serverSocket: ServerSocket? = null
+    @Volatile private var worker: Thread? = null
+    @Volatile var token: String = ""
+        private set
+    @Volatile var port: Int = DEFAULT_PORT
+        private set
+
+    val isRunning: Boolean get() = running.get()
+    val localUrl: String get() = "http://${getLocalIpAddress()}:$port/?token=$token"
+
+    fun start() {
+        if (!running.compareAndSet(false, true)) return
+
+        token = UUID.randomUUID().toString().replace("-", "").take(16)
+        worker = Thread {
+            try {
+                serverSocket = try {
+                    ServerSocket(DEFAULT_PORT)
+                } catch (_: Exception) {
+                    ServerSocket(0)
+                }
+                port = serverSocket?.localPort ?: DEFAULT_PORT
+
+                while (running.get()) {
+                    val client = serverSocket?.accept() ?: break
+                    Thread { handleClient(client) }.start()
+                }
+            } catch (_: Exception) {
+                running.set(false)
+            } finally {
+                serverSocket?.close()
+                serverSocket = null
+            }
+        }.apply {
+            name = "quik-web-access"
+            isDaemon = true
+            start()
+        }
+    }
+
+    fun stop() {
+        running.set(false)
+        serverSocket?.close()
+        serverSocket = null
+        worker = null
+        token = ""
+    }
+
+    private fun handleClient(socket: Socket) {
+        socket.use { client ->
+            val reader = BufferedReader(InputStreamReader(client.getInputStream()))
+            val writer = BufferedWriter(OutputStreamWriter(client.getOutputStream()))
+            val requestLine = reader.readLine().orEmpty()
+            while (!reader.readLine().isNullOrEmpty()) {
+            }
+
+            val parts = requestLine.split(" ")
+            if (parts.size < 2 || parts[0] != "GET") {
+                writer.writeResponse(405, "text/plain", "Only GET is supported")
+                return
+            }
+
+            val request = parseRequest(parts[1])
+            val body = when {
+                request.path == "/" -> webAppHtml(request.query["token"].orEmpty())
+                request.query["token"] != token -> return writer.writeResponse(403, "application/json", """{"error":"Forbidden"}""")
+                request.path == "/api/conversations" -> conversationsJson()
+                request.path.startsWith("/api/conversations/") && request.path.endsWith("/messages") -> {
+                    val threadId = request.path
+                        .removePrefix("/api/conversations/")
+                        .removeSuffix("/messages")
+                        .toLongOrNull()
+                    if (threadId == null) """{"error":"Invalid conversation"}""" else messagesJson(threadId)
+                }
+                else -> return writer.writeResponse(404, "application/json", """{"error":"Not found"}""")
+            }
+
+            writer.writeResponse(200, if (request.path == "/") "text/html; charset=utf-8" else "application/json", body)
+        }
+    }
+
+    private fun conversationsJson(): String = Realm.getDefaultInstance().use { realm ->
+        val conversations = realm.where(Conversation::class.java)
+            .notEqualTo("id", 0L)
+            .equalTo("archived", false)
+            .equalTo("blocked", false)
+            .isNotNull("lastMessage")
+            .sort("lastMessage.date", Sort.DESCENDING)
+            .findAll()
+
+        conversations.joinToString(prefix = "[", postfix = "]") { conversation ->
+            """{"id":${conversation.id},"title":"${json(conversation.getTitle())}","snippet":"${json(conversation.snippet.orEmpty())}","date":${conversation.date},"unread":${conversation.unread},"me":${conversation.me}}"""
+        }
+    }
+
+    private fun messagesJson(threadId: Long): String = Realm.getDefaultInstance().use { realm ->
+        val conversation = realm.where(Conversation::class.java)
+            .equalTo("id", threadId)
+            .findFirst()
+        val messages = realm.where(Message::class.java)
+            .equalTo("threadId", threadId)
+            .equalTo("isEmojiReaction", false)
+            .sort("date", Sort.DESCENDING)
+            .limit(MAX_MESSAGES.toLong())
+            .findAll()
+            .sort("date", Sort.ASCENDING)
+
+        val messagesJson = messages.joinToString(prefix = "[", postfix = "]") { message ->
+            """{"id":${message.id},"date":${message.date},"fromMe":${message.isMe()},"address":"${json(message.address)}","text":"${json(message.getText())}"}"""
+        }
+        """{"id":$threadId,"title":"${json(conversation?.getTitle().orEmpty())}","messages":$messagesJson}"""
+    }
+
+    private fun parseRequest(target: String): Request {
+        val rawPath = target.substringBefore("?")
+        val query = target.substringAfter("?", "")
+            .split("&")
+            .filter { it.contains("=") }
+            .associate {
+                val key = decode(it.substringBefore("="))
+                val value = decode(it.substringAfter("="))
+                key to value
+            }
+
+        return Request(rawPath, query)
+    }
+
+    private fun decode(value: String): String = URLDecoder.decode(value, "UTF-8")
+
+    private fun BufferedWriter.writeResponse(status: Int, contentType: String, body: String) {
+        val reason = when (status) {
+            200 -> "OK"
+            403 -> "Forbidden"
+            404 -> "Not Found"
+            405 -> "Method Not Allowed"
+            else -> "Error"
+        }
+        write("HTTP/1.1 $status $reason\r\n")
+        write("Content-Type: $contentType\r\n")
+        write("Content-Length: ${body.toByteArray().size}\r\n")
+        write("Connection: close\r\n")
+        write("\r\n")
+        write(body)
+        flush()
+    }
+
+    private fun webAppHtml(initialToken: String): String = """
+        <!doctype html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width,initial-scale=1">
+          <title>Quik Web Access</title>
+          <style>
+            body{margin:0;font-family:system-ui,-apple-system,Segoe UI,sans-serif;background:#f7f7f7;color:#111}
+            header{padding:16px 20px;background:#202124;color:white}
+            main{display:grid;grid-template-columns:320px 1fr;height:calc(100vh - 57px)}
+            #threads{overflow:auto;border-right:1px solid #ddd;background:white}
+            button{display:block;width:100%;padding:12px 16px;border:0;border-bottom:1px solid #eee;background:white;text-align:left}
+            button:hover{background:#f1f3f4}
+            .snippet{color:#666;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+            #messages{overflow:auto;padding:16px}
+            .msg{max-width:720px;margin:0 0 12px;padding:10px 12px;border-radius:8px;background:white}
+            .me{margin-left:auto;background:#e8f0fe}
+            .meta{font-size:12px;color:#666;margin-bottom:4px}
+            input{padding:8px;margin-left:12px}
+            @media(max-width:700px){main{grid-template-columns:1fr;height:auto}#threads{max-height:40vh;border-right:0;border-bottom:1px solid #ddd}}
+          </style>
+        </head>
+        <body>
+          <header>Quik Web Access <input id="token" placeholder="token" value="${html(initialToken)}"></header>
+          <main><section id="threads"></section><section id="messages"></section></main>
+          <script>
+            const token = document.getElementById('token');
+            const threads = document.getElementById('threads');
+            const messages = document.getElementById('messages');
+            const fmt = ms => new Date(ms).toLocaleString();
+            async function api(path){ const r = await fetch(path + (path.includes('?')?'&':'?') + 'token=' + encodeURIComponent(token.value)); if(!r.ok) throw new Error(await r.text()); return r.json(); }
+            async function loadThreads(){
+              const rows = await api('/api/conversations');
+              threads.innerHTML = rows.map(c => '<button onclick="loadMessages('+c.id+')"><strong>'+esc(c.title)+'</strong><div class="snippet">'+esc(c.snippet)+'</div></button>').join('');
+            }
+            async function loadMessages(id){
+              const data = await api('/api/conversations/' + id + '/messages');
+              messages.innerHTML = '<h2>'+esc(data.title)+'</h2>' + data.messages.map(m => '<div class="msg '+(m.fromMe?'me':'')+'"><div class="meta">'+fmt(m.date)+' '+esc(m.address)+'</div><div>'+esc(m.text).replace(/\n/g,'<br>')+'</div></div>').join('');
+            }
+            function esc(s){return String(s ?? '').replace(/[&<>"']/g, ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));}
+            loadThreads().catch(e => threads.textContent = e.message);
+          </script>
+        </body>
+        </html>
+    """.trimIndent()
+
+    private fun getLocalIpAddress(): String {
+        NetworkInterface.getNetworkInterfaces().toList().forEach { networkInterface ->
+            if (!networkInterface.isUp || networkInterface.isLoopback) return@forEach
+            networkInterface.inetAddresses.toList().forEach { address ->
+                if (address is Inet4Address && !address.isLoopbackAddress) {
+                    return address.hostAddress ?: "127.0.0.1"
+                }
+            }
+        }
+        return "127.0.0.1"
+    }
+
+    private fun json(value: String): String = value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+
+    private fun html(value: String): String = value
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+
+    private data class Request(val path: String, val query: Map<String, String>)
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
@@ -120,7 +120,11 @@ object WebAccessServer {
     private fun messagesJson(threadId: Long): String = Realm.getDefaultInstance().use { realm ->
         val conversation = realm.where(Conversation::class.java)
             .equalTo("id", threadId)
+            .equalTo("archived", false)
+            .equalTo("blocked", false)
             .findFirst()
+            ?: return """{"id":$threadId,"title":"","messages":[]}"""
+
         val messages = realm.where(Message::class.java)
             .equalTo("threadId", threadId)
             .equalTo("isEmojiReaction", false)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
@@ -14,16 +14,23 @@ import java.net.ServerSocket
 import java.net.Socket
 import java.net.URLDecoder
 import java.util.UUID
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.atomic.AtomicBoolean
+import org.json.JSONObject
 
 object WebAccessServer {
     private const val DEFAULT_PORT = 8090
     private const val MAX_MESSAGES = 500
+    private const val MAX_CLIENT_THREADS = 8
+    private const val SOCKET_READ_TIMEOUT_MS = 5000
 
     private val running = AtomicBoolean(false)
 
     @Volatile private var serverSocket: ServerSocket? = null
     @Volatile private var worker: Thread? = null
+    @Volatile private var clientExecutor: ExecutorService? = null
     @Volatile var token: String = ""
         private set
     @Volatile var port: Int = DEFAULT_PORT
@@ -36,6 +43,9 @@ object WebAccessServer {
         if (!running.compareAndSet(false, true)) return
 
         token = UUID.randomUUID().toString().replace("-", "").take(16)
+        clientExecutor = Executors.newFixedThreadPool(MAX_CLIENT_THREADS) { runnable ->
+            Thread(runnable, "quik-web-access-client").apply { isDaemon = true }
+        }
         worker = Thread {
             try {
                 serverSocket = try {
@@ -47,13 +57,20 @@ object WebAccessServer {
 
                 while (running.get()) {
                     val client = serverSocket?.accept() ?: break
-                    Thread { handleClient(client) }.start()
+                    client.soTimeout = SOCKET_READ_TIMEOUT_MS
+                    try {
+                        clientExecutor?.execute { handleClient(client) } ?: client.close()
+                    } catch (_: RejectedExecutionException) {
+                        client.close()
+                    }
                 }
             } catch (_: Exception) {
                 running.set(false)
             } finally {
                 serverSocket?.close()
                 serverSocket = null
+                clientExecutor?.shutdownNow()
+                clientExecutor = null
             }
         }.apply {
             name = "quik-web-access"
@@ -66,6 +83,8 @@ object WebAccessServer {
         running.set(false)
         serverSocket?.close()
         serverSocket = null
+        clientExecutor?.shutdownNow()
+        clientExecutor = null
         worker = null
         token = ""
     }
@@ -113,7 +132,7 @@ object WebAccessServer {
             .findAll()
 
         conversations.joinToString(prefix = "[", postfix = "]") { conversation ->
-            """{"id":${conversation.id},"title":"${json(conversation.getTitle())}","snippet":"${json(conversation.snippet.orEmpty())}","date":${conversation.date},"unread":${conversation.unread},"me":${conversation.me}}"""
+            """{"id":${conversation.id},"title":${json(conversation.getTitle())},"snippet":${json(conversation.snippet.orEmpty())},"date":${conversation.date},"unread":${conversation.unread},"me":${conversation.me}}"""
         }
     }
 
@@ -134,9 +153,9 @@ object WebAccessServer {
             .sort("date", Sort.ASCENDING)
 
         val messagesJson = messages.joinToString(prefix = "[", postfix = "]") { message ->
-            """{"id":${message.id},"date":${message.date},"fromMe":${message.isMe()},"address":"${json(message.address)}","text":"${json(message.getText())}"}"""
+            """{"id":${message.id},"date":${message.date},"fromMe":${message.isMe()},"address":${json(message.address)},"text":${json(message.getText())}}"""
         }
-        """{"id":$threadId,"title":"${json(conversation?.getTitle().orEmpty())}","messages":$messagesJson}"""
+        """{"id":$threadId,"title":${json(conversation?.getTitle().orEmpty())},"messages":$messagesJson}"""
     }
 
     private fun parseRequest(target: String): Request {
@@ -231,12 +250,7 @@ object WebAccessServer {
         return "127.0.0.1"
     }
 
-    private fun json(value: String): String = value
-        .replace("\\", "\\\\")
-        .replace("\"", "\\\"")
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
+    private fun json(value: String): String = JSONObject.quote(value)
 
     private fun html(value: String): String = value
         .replace("&", "&amp;")

--- a/presentation/src/main/java/com/moez/QKSMS/injection/android/ActivityBuilderModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/injection/android/ActivityBuilderModule.kt
@@ -42,6 +42,7 @@ import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivity
 import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivityModule
 import dev.octoshrimpy.quik.feature.settings.SettingsActivity
 import dev.octoshrimpy.quik.feature.settings.about.AboutActivity
+import dev.octoshrimpy.quik.feature.webaccess.WebAccessActivity
 import dev.octoshrimpy.quik.injection.scope.ActivityScope
 
 @Module
@@ -102,5 +103,9 @@ abstract class ActivityBuilderModule {
     @ActivityScope
     @ContributesAndroidInjector(modules = [])
     abstract fun bindBlockingActivity(): BlockingActivity
+
+    @ActivityScope
+    @ContributesAndroidInjector(modules = [])
+    abstract fun bindWebAccessActivity(): WebAccessActivity
 
 }

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -257,6 +257,14 @@
             app:layout_constraintBottom_toBottomOf="parent" />
 
         <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/webAccess"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_message_black_24dp"
+            app:summary="@string/settings_web_access_summary"
+            app:title="@string/settings_web_access_title" />
+
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
             android:id="@+id/about"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -337,6 +337,17 @@
     <string name="settings_sync_title">Sync messages</string>
     <string name="settings_sync_summary">Re-sync your messages with the native Android SMS database</string>
     <string name="settings_about_title">About QUIK</string>
+    <string name="settings_web_access_title">Web Access</string>
+    <string name="settings_web_access_summary">Read messages from a browser on your local network</string>
+    <string name="web_access_title">Web Access</string>
+    <string name="web_access_summary">Start a local read-only web server, then open the URL from a browser on the same network.</string>
+    <string name="web_access_warning">Anyone who can reach this phone and knows the token can read conversations while Web Access is running. Stop it when finished.</string>
+    <string name="web_access_status_running">Status: running</string>
+    <string name="web_access_status_stopped">Status: stopped</string>
+    <string name="web_access_url">URL: %s</string>
+    <string name="web_access_token">Token: %s</string>
+    <string name="web_access_start">Start Web Access</string>
+    <string name="web_access_stop">Stop Web Access</string>
     <string name="settings_version">Version %s</string>
     <string name="settings_logging_enabled">Debug logging enabled</string>
     <string name="settings_logging_disabled">Debug logging disabled</string>


### PR DESCRIPTION
Implements a read-only Messages for Web MVP for #422.
/claim #422

What changed:
- Adds a Settings -> Web Access screen in the APK.
- Starts/stops a local HTTP server on the phone and displays the local URL plus a random access token.
- Serves a browser UI that lists conversations and opens a read-only message thread view.
- Protects JSON endpoints with the per-session token and exposes no send/write endpoint.

Scope notes:
- This intentionally covers the M1/M2 read-only MVP discussed in the issue: local server, inbox list, conversation view, and basic token protection.
- Sending messages, remote cloud access, accounts, and notifications are out of scope for this first PR.

Validation:
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ./gradlew :presentation:compileDebugKotlin`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ./gradlew :presentation:assembleDebug`
