### PR TITLE
Create a proper dark theme for gallery, which will fix app themes

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -110,7 +110,7 @@
         <activity android:name=".feature.plus.PlusActivity" />
         <activity
             android:name=".feature.gallery.GalleryActivity"
-            android:theme="@style/AppTheme.Black" />
+            android:theme="@style/AppTheme.Gallery" />
         <activity android:name=".feature.conversationinfo.ConversationInfoActivity" />
         <activity android:name=".feature.notificationprefs.NotificationPrefsActivity" />
         <activity android:name=".feature.blocking.BlockingActivity" />

--- a/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/gallery/GalleryActivity.kt
@@ -56,7 +56,6 @@ class GalleryActivity : QkActivity(), GalleryView {
     private val viewModel by lazy { ViewModelProviders.of(this, viewModelFactory)[GalleryViewModel::class.java] }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        delegate.localNightMode = AppCompatDelegate.MODE_NIGHT_YES
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         binding = GalleryActivityBinding.inflate(layoutInflater)

--- a/presentation/src/main/res/values/themes.xml
+++ b/presentation/src/main/res/values/themes.xml
@@ -75,6 +75,10 @@
         <item name="android:textColor">@color/textPrimary</item>
     </style>
 
+    <style name="AppTheme.Gallery" parent="Theme.AppCompat.NoActionBar">
+        <item name="android:background">@color/black</item>
+    </style>
+
     <!-- Black mode. No changes needed when not in night theme -->
     <style name="AppTheme.Black" />
     <style name="AppThemeDialog.Black" />


### PR DESCRIPTION
Closes #770 

The app was setting gallery to black mode programmatically, and for some reason this was affecting other activities theming. We can just use a custom theme to force black mode that won't mess with other screens.