### PR TITLE
Refactor and simplify the navigator

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/common/ExternalNavigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/ExternalNavigator.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+ *
+ * This file is part of QKSMS.
+ *
+ * QKSMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QKSMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.common
+
+import android.app.Activity
+import android.app.role.RoleManager
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.ContactsContract
+import android.provider.Settings
+import android.provider.Telephony
+import dev.octoshrimpy.quik.BuildConfig
+import dev.octoshrimpy.quik.manager.BillingManager
+import dev.octoshrimpy.quik.manager.PermissionManager
+import javax.inject.Inject
+import dev.octoshrimpy.quik.feature.notificationprefs.NotificationPrefsActivity
+import dev.octoshrimpy.quik.manager.NotificationManager
+
+/**
+ * Navigator to open activities outside of the app
+ * Sharing and Viewing files remains in [Navigator]
+ */
+class ExternalNavigator @Inject constructor(
+    context: Context,
+    private val billingManager: BillingManager,
+    private val permissions: PermissionManager,
+    private val notificationManager: NotificationManager
+) : QkNavigator(context) {
+    fun showDeveloper() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/graphs/contributors"))
+        startActivityExternal(intent)
+    }
+
+    fun showSourceCode() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
+        startActivityExternal(intent)
+    }
+
+    fun showChangelog() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/releases"))
+        startActivityExternal(intent)
+    }
+
+    fun showLicense() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/blob/master/LICENSE"))
+        startActivityExternal(intent)
+    }
+
+    fun makePhoneCall(address: String) {
+        val action = if (permissions.hasCalling()) Intent.ACTION_CALL else Intent.ACTION_DIAL
+        val intent = Intent(action, Uri.parse("tel:$address"))
+        startActivityExternal(intent)
+    }
+
+    fun showDonation() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
+        startActivityExternal(intent)
+    }
+
+    fun showRating() {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
+            .addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY
+                    or Intent.FLAG_ACTIVITY_NEW_DOCUMENT
+                    or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+
+        try {
+            startActivityExternal(intent)
+        } catch (_: ActivityNotFoundException) {
+            val url = "https://github.com/quik-sms/quik"
+            startActivityExternal(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        }
+    }
+
+    /**
+     * Launch the Play Store and display the Call Blocker listing
+     */
+    fun installCallBlocker() {
+        val url = "https://play.google.com/store/apps/details?id=com.cuiet.blockCalls"
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivityExternal(intent)
+    }
+
+    /**
+     * Launch the Play Store and display the Call Control listing
+     */
+    fun installCallControl() {
+        val url = "https://play.google.com/store/apps/details?id=com.flexaspect.android.everycallcontrol"
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivityExternal(intent)
+    }
+
+    /**
+     * Launch the Play Store and display the Should I Answer? listing
+     */
+    fun installSia() {
+        val url = "https://play.google.com/store/apps/details?id=org.mistergroup.shouldianswer"
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        startActivityExternal(intent)
+    }
+
+    fun showSupport() {
+        val intent = Intent(Intent.ACTION_SENDTO)
+        intent.data = Uri.parse("mailto:")
+        intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("quik@octo.sh"))
+        intent.putExtra(Intent.EXTRA_SUBJECT, "QUIK Support")
+        intent.putExtra(Intent.EXTRA_TEXT, StringBuilder("\n\n")
+            .append("\n\n--- Please write your message above this line ---\n\n")
+            .append("Package: ${context.packageName}\n")
+            .append("Version: ${BuildConfig.VERSION_NAME}\n")
+            .append("Device: ${Build.BRAND} ${Build.MODEL}\n")
+            .append("SDK: ${Build.VERSION.SDK_INT}\n")
+            .append("Upgraded"
+                .takeIf { billingManager.upgradeStatus.blockingFirst() } ?: "")
+            .toString())
+        startActivityExternal(intent)
+    }
+
+    fun showInvite() {
+        Intent(Intent.ACTION_SEND)
+            .setType("text/plain")
+            .putExtra(Intent.EXTRA_TEXT, "https://github.com/quik-sms/quik/releases/latest")
+            .let { Intent.createChooser(it, null) }
+            .let(::startActivityExternal)
+    }
+
+    fun showExactAlarmsSettings() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                .setData(Uri.parse("package:${context.packageName}"))
+            startActivity(intent)
+        }
+    }
+
+    fun showPermissionsInSettings() {
+        val intent = Intent()
+        intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+        intent.data = Uri.fromParts("package", context.packageName, null)
+
+        startActivity(intent)
+    }
+
+    fun addContact(address: String) {
+        val intent = Intent(Intent.ACTION_INSERT)
+            .setType(ContactsContract.Contacts.CONTENT_TYPE)
+            .putExtra(ContactsContract.Intents.Insert.PHONE, address)
+
+        startActivityExternal(intent)
+    }
+
+    fun showContact(lookupKey: String) {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setData(Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey))
+
+        startActivityExternal(intent)
+    }
+
+    // This must use startActivityForResult
+    fun showDefaultSmsDialog(context: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val roleManager = context.getSystemService(RoleManager::class.java) as RoleManager
+            val intent = roleManager.createRequestRoleIntent(RoleManager.ROLE_SMS)
+            context.startActivityForResult(intent, 42389)
+        } else {
+            val intent = Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT)
+            intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, context.packageName)
+            context.startActivity(intent)
+        }
+    }
+
+    fun showNotificationSettings(threadId: Long = 0) {
+        val intent = Intent(context, NotificationPrefsActivity::class.java)
+        intent.putExtra("threadId", threadId)
+        startActivity(intent)
+    }
+
+    fun showNotificationChannel(threadId: Long = 0) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (threadId != 0L) {
+                notificationManager.createNotificationChannel(threadId)
+            }
+
+            val channelId = notificationManager.buildNotificationChannelId(threadId)
+            val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+                .putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
+                .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+            startActivity(intent)
+        }
+    }
+}

--- a/presentation/src/main/java/com/moez/QKSMS/common/ExternalNavigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/ExternalNavigator.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+ *
+ * This file is part of QKSMS.
+ *
+ * QKSMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QKSMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.common
+
+import android.app.Activity
+import android.app.role.RoleManager
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.ContactsContract
+import android.provider.Settings
+import android.provider.Telephony
+import androidx.core.net.toUri
+import dev.octoshrimpy.quik.BuildConfig
+import dev.octoshrimpy.quik.manager.BillingManager
+import dev.octoshrimpy.quik.manager.PermissionManager
+import javax.inject.Inject
+import dev.octoshrimpy.quik.feature.notificationprefs.NotificationPrefsActivity
+import dev.octoshrimpy.quik.manager.NotificationManager
+
+/**
+ * Navigator to open activities outside the app
+ * Sharing and Viewing files remains in [Navigator]
+ */
+class ExternalNavigator @Inject constructor(
+    context: Context,
+    private val billingManager: BillingManager,
+    private val permissions: PermissionManager,
+    private val notificationManager: NotificationManager
+) : QkNavigator(context) {
+    fun showDeveloper() =
+        openExternalActivity("https://github.com/quik-sms/quik/graphs/contributors")
+
+    fun showSourceCode() = openExternalActivity("https://github.com/quik-sms/quik")
+
+    fun showChangelog() = openExternalActivity("https://github.com/quik-sms/quik/releases")
+
+    fun showLicense() =
+        openExternalActivity("https://github.com/quik-sms/quik/blob/master/LICENSE")
+
+    fun makePhoneCall(address: String) {
+        val action = if (permissions.hasCalling()) Intent.ACTION_CALL else Intent.ACTION_DIAL
+        val intent = Intent(action, "tel:$address".toUri())
+        startActivityExternal(intent)
+    }
+
+    fun showDonation() = openExternalActivity("https://github.com/quik-sms/quik")
+
+    fun showRating() {
+        val intent = Intent(Intent.ACTION_VIEW, "https://github.com/quik-sms/quik".toUri())
+            .addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY
+                    or Intent.FLAG_ACTIVITY_NEW_DOCUMENT
+                    or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+
+        try {
+            startActivityExternal(intent)
+        } catch (_: ActivityNotFoundException) {
+            val url = "https://github.com/quik-sms/quik"
+            startActivityExternal(Intent(Intent.ACTION_VIEW, url.toUri()))
+        }
+    }
+
+    fun openAppStoreForCallBlocker() =
+        openExternalActivity(
+            "https://play.google.com/store/apps/details?id=com.cuiet.blockCalls"
+        )
+
+    fun openAppStoreForCallControl() =
+        openExternalActivity(
+            "https://play.google.com/store/apps/details?id=com.flexaspect.android.everycallcontrol"
+        )
+
+    fun openAppStoreForSia() =
+        openExternalActivity(
+            "https://play.google.com/store/apps/details?id=org.mistergroup.shouldianswer"
+        )
+
+    fun showSupport() {
+        val intent = Intent(Intent.ACTION_SENDTO)
+        intent.data = "mailto:".toUri()
+        intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("quik@octo.sh"))
+        intent.putExtra(Intent.EXTRA_SUBJECT, "QUIK Support")
+        intent.putExtra(Intent.EXTRA_TEXT, StringBuilder("\n\n")
+            .append("\n\n--- Please write your message above this line ---\n\n")
+            .append("Package: ${context.packageName}\n")
+            .append("Version: ${BuildConfig.VERSION_NAME}\n")
+            .append("Device: ${Build.BRAND} ${Build.MODEL}\n")
+            .append("SDK: ${Build.VERSION.SDK_INT}\n")
+            .append("Upgraded"
+                .takeIf { billingManager.upgradeStatus.blockingFirst() } ?: "")
+            .toString())
+        startActivityExternal(intent)
+    }
+
+    fun showInvite() {
+        Intent(Intent.ACTION_SEND)
+            .setType("text/plain")
+            .putExtra(Intent.EXTRA_TEXT, "https://github.com/quik-sms/quik/releases/latest")
+            .let { Intent.createChooser(it, null) }
+            .let(::startActivityExternal)
+    }
+
+    fun showExactAlarmsSettings() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                .setData("package:${context.packageName}".toUri())
+            startActivity(intent)
+        }
+    }
+
+    fun showPermissionsInSettings() {
+        val intent = Intent()
+        intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+        intent.data = Uri.fromParts("package", context.packageName, null)
+
+        startActivity(intent)
+    }
+
+    fun addContact(address: String) {
+        val intent = Intent(Intent.ACTION_INSERT)
+            .setType(ContactsContract.Contacts.CONTENT_TYPE)
+            .putExtra(ContactsContract.Intents.Insert.PHONE, address)
+
+        startActivityExternal(intent)
+    }
+
+    fun showContact(lookupKey: String) {
+        val intent = Intent(Intent.ACTION_VIEW)
+            .setData(Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey))
+
+        startActivityExternal(intent)
+    }
+
+    // This must use startActivityForResult
+    fun showDefaultSmsDialog(context: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val roleManager = context.getSystemService(RoleManager::class.java) as RoleManager
+            val intent = roleManager.createRequestRoleIntent(RoleManager.ROLE_SMS)
+            context.startActivityForResult(intent, 42389)
+        } else {
+            val intent = Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT)
+            intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, context.packageName)
+            context.startActivity(intent)
+        }
+    }
+
+    fun showNotificationSettings(threadId: Long = 0) {
+        val intent = Intent(context, NotificationPrefsActivity::class.java)
+        intent.putExtra("threadId", threadId)
+        startActivity(intent)
+    }
+
+    fun showNotificationChannel(threadId: Long = 0) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (threadId != 0L) {
+                notificationManager.createNotificationChannel(threadId)
+            }
+
+            val channelId = notificationManager.buildNotificationChannelId(threadId)
+            val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+                .putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
+                .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+            startActivity(intent)
+        }
+    }
+
+    private fun openExternalActivity(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
+        startActivityExternal(intent)
+    }
+}

--- a/presentation/src/main/java/com/moez/QKSMS/common/ExternalNavigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/ExternalNavigator.kt
@@ -32,6 +32,7 @@ import dev.octoshrimpy.quik.BuildConfig
 import dev.octoshrimpy.quik.manager.BillingManager
 import dev.octoshrimpy.quik.manager.PermissionManager
 import javax.inject.Inject
+import androidx.core.net.toUri
 import dev.octoshrimpy.quik.feature.notificationprefs.NotificationPrefsActivity
 import dev.octoshrimpy.quik.manager.NotificationManager
 
@@ -46,38 +47,40 @@ class ExternalNavigator @Inject constructor(
     private val notificationManager: NotificationManager
 ) : QkNavigator(context) {
     fun showDeveloper() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/graphs/contributors"))
+        val intent = Intent(Intent.ACTION_VIEW,
+            "https://github.com/quik-sms/quik/graphs/contributors".toUri())
         startActivityExternal(intent)
     }
 
     fun showSourceCode() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
+        val intent = Intent(Intent.ACTION_VIEW, "https://github.com/quik-sms/quik".toUri())
         startActivityExternal(intent)
     }
 
     fun showChangelog() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/releases"))
+        val intent = Intent(Intent.ACTION_VIEW, "https://github.com/quik-sms/quik/releases".toUri())
         startActivityExternal(intent)
     }
 
     fun showLicense() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/blob/master/LICENSE"))
+        val intent = Intent(Intent.ACTION_VIEW,
+            "https://github.com/quik-sms/quik/blob/master/LICENSE".toUri())
         startActivityExternal(intent)
     }
 
     fun makePhoneCall(address: String) {
         val action = if (permissions.hasCalling()) Intent.ACTION_CALL else Intent.ACTION_DIAL
-        val intent = Intent(action, Uri.parse("tel:$address"))
+        val intent = Intent(action, "tel:$address".toUri())
         startActivityExternal(intent)
     }
 
     fun showDonation() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
+        val intent = Intent(Intent.ACTION_VIEW, "https://github.com/quik-sms/quik".toUri())
         startActivityExternal(intent)
     }
 
     fun showRating() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
+        val intent = Intent(Intent.ACTION_VIEW, "https://github.com/quik-sms/quik".toUri())
             .addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY
                     or Intent.FLAG_ACTIVITY_NEW_DOCUMENT
                     or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
@@ -86,7 +89,7 @@ class ExternalNavigator @Inject constructor(
             startActivityExternal(intent)
         } catch (_: ActivityNotFoundException) {
             val url = "https://github.com/quik-sms/quik"
-            startActivityExternal(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+            startActivityExternal(Intent(Intent.ACTION_VIEW, url.toUri()))
         }
     }
 
@@ -95,7 +98,7 @@ class ExternalNavigator @Inject constructor(
      */
     fun installCallBlocker() {
         val url = "https://play.google.com/store/apps/details?id=com.cuiet.blockCalls"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         startActivityExternal(intent)
     }
 
@@ -104,7 +107,7 @@ class ExternalNavigator @Inject constructor(
      */
     fun installCallControl() {
         val url = "https://play.google.com/store/apps/details?id=com.flexaspect.android.everycallcontrol"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         startActivityExternal(intent)
     }
 
@@ -113,13 +116,13 @@ class ExternalNavigator @Inject constructor(
      */
     fun installSia() {
         val url = "https://play.google.com/store/apps/details?id=org.mistergroup.shouldianswer"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         startActivityExternal(intent)
     }
 
     fun showSupport() {
         val intent = Intent(Intent.ACTION_SENDTO)
-        intent.data = Uri.parse("mailto:")
+        intent.data = "mailto:".toUri()
         intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("quik@octo.sh"))
         intent.putExtra(Intent.EXTRA_SUBJECT, "QUIK Support")
         intent.putExtra(Intent.EXTRA_TEXT, StringBuilder("\n\n")
@@ -145,7 +148,7 @@ class ExternalNavigator @Inject constructor(
     fun showExactAlarmsSettings() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
-                .setData(Uri.parse("package:${context.packageName}"))
+                .setData("package:${context.packageName}".toUri())
             startActivity(intent)
         }
     }

--- a/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
@@ -18,17 +18,10 @@
  */
 package dev.octoshrimpy.quik.common
 
-import android.app.Activity
-import android.app.role.RoleManager
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
-import android.provider.ContactsContract
-import android.provider.Settings
-import android.provider.Telephony
-import dev.octoshrimpy.quik.BuildConfig
+import androidx.core.net.toUri
 import dev.octoshrimpy.quik.compat.TelephonyCompat
 import dev.octoshrimpy.quik.extensions.resourceExists
 import dev.octoshrimpy.quik.feature.settings.about.AboutActivity
@@ -39,65 +32,27 @@ import dev.octoshrimpy.quik.feature.conversationinfo.ConversationInfoActivity
 import dev.octoshrimpy.quik.feature.gallery.GalleryActivity
 import dev.octoshrimpy.quik.feature.main.MainActivity
 import dev.octoshrimpy.quik.feature.messageutils.MessageUtilsActivity
-import dev.octoshrimpy.quik.feature.notificationprefs.NotificationPrefsActivity
 import dev.octoshrimpy.quik.feature.plus.PlusActivity
 import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivity
 import dev.octoshrimpy.quik.feature.settings.SettingsActivity
-import dev.octoshrimpy.quik.manager.BillingManager
-import dev.octoshrimpy.quik.manager.NotificationManager
-import dev.octoshrimpy.quik.manager.PermissionManager
 import dev.octoshrimpy.quik.model.ScheduledMessage
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class Navigator @Inject constructor(
-    private val context: Context,
-    private val billingManager: BillingManager,
-    private val notificationManager: NotificationManager,
-    private val permissions: PermissionManager
-) {
-
-    private fun startActivity(intent: Intent) {
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-    }
-
-    private fun startActivityExternal(intent: Intent) {
-        if (intent.resolveActivity(context.packageManager) != null) {
-            startActivity(intent)
-        } else {
-            startActivity(Intent.createChooser(intent, null))
-        }
-    }
-
+    context: Context
+) : QkNavigator(context) {
     /**
      * @param source String to indicate where this QKSMS+ screen was launched from. This should be
      * one of [main_menu, compose_schedule, settings_night, settings_theme]
      */
     fun showQksmsPlusActivity(source: String) {
-        val intent = Intent(context, PlusActivity::class.java)
-        startActivity(intent)
-    }
-
-    /**
-     * This won't work unless we use startActivityForResult
-     */
-    fun showDefaultSmsDialog(context: Activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val roleManager = context.getSystemService(RoleManager::class.java) as RoleManager
-            val intent = roleManager.createRequestRoleIntent(RoleManager.ROLE_SMS)
-            context.startActivityForResult(intent, 42389)
-        } else {
-            val intent = Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT)
-            intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, context.packageName)
-            context.startActivity(intent)
-        }
+        startActivity(Intent(context, PlusActivity::class.java))
     }
 
     fun showMainActivity() {
-        val intent = Intent(context, MainActivity::class.java)
-        startActivity(intent)
+        startActivity(Intent(context, MainActivity::class.java))
     }
 
     fun showCompose(body: String? = null, attachments: List<Uri>? = null, mode: String? = null) {
@@ -136,7 +91,7 @@ class Navigator @Inject constructor(
         scheduledMessage.attachments
             .takeIf { it.isNotEmpty() }
             ?.mapNotNull {
-                val uri = Uri.parse(it)
+                val uri = it.toUri()
                 if (uri.resourceExists(context)) uri
                 else null
             }
@@ -175,135 +130,19 @@ class Navigator @Inject constructor(
     }
 
     fun showMessageUtils() {
-        val intent = Intent(context, MessageUtilsActivity::class.java)
-        startActivity(intent)
+        startActivity(Intent(context, MessageUtilsActivity::class.java))
     }
 
     fun showSettings() {
-        val intent = Intent(context, SettingsActivity::class.java)
-        startActivity(intent)
+        startActivity(Intent(context, SettingsActivity::class.java))
     }
 
     fun showAbout() {
-        val intent = Intent(context, AboutActivity::class.java)
-        startActivity(intent)
-    }
-
-    fun showDeveloper() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/graphs/contributors"))
-        startActivityExternal(intent)
-    }
-
-    fun showSourceCode() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
-        startActivityExternal(intent)
-    }
-
-    fun showChangelog() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/releases"))
-        startActivityExternal(intent)
-    }
-
-    fun showLicense() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/blob/master/LICENSE"))
-        startActivityExternal(intent)
+        startActivity(Intent(context, AboutActivity::class.java))
     }
 
     fun showBlockedConversations() {
-        val intent = Intent(context, BlockingActivity::class.java)
-        startActivity(intent)
-    }
-
-    fun makePhoneCall(address: String) {
-        val action = if (permissions.hasCalling()) Intent.ACTION_CALL else Intent.ACTION_DIAL
-        val intent = Intent(action, Uri.parse("tel:$address"))
-        startActivityExternal(intent)
-    }
-
-    fun showDonation() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
-        startActivityExternal(intent)
-    }
-
-    fun showRating() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
-                .addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY
-                        or Intent.FLAG_ACTIVITY_NEW_DOCUMENT
-                        or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
-
-        try {
-            startActivityExternal(intent)
-        } catch (e: ActivityNotFoundException) {
-            val url = "https://github.com/quik-sms/quik"
-            startActivityExternal(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-        }
-    }
-
-    /**
-     * Launch the Play Store and display the Call Blocker listing
-     */
-    fun installCallBlocker() {
-        val url = "https://play.google.com/store/apps/details?id=com.cuiet.blockCalls"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        startActivityExternal(intent)
-    }
-
-    /**
-     * Launch the Play Store and display the Call Control listing
-     */
-    fun installCallControl() {
-        val url = "https://play.google.com/store/apps/details?id=com.flexaspect.android.everycallcontrol"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        startActivityExternal(intent)
-    }
-
-    /**
-     * Launch the Play Store and display the Should I Answer? listing
-     */
-    fun installSia() {
-        val url = "https://play.google.com/store/apps/details?id=org.mistergroup.shouldianswer"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        startActivityExternal(intent)
-    }
-
-    fun showSupport() {
-        val intent = Intent(Intent.ACTION_SENDTO)
-        intent.data = Uri.parse("mailto:")
-        intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("quik@octo.sh"))
-        intent.putExtra(Intent.EXTRA_SUBJECT, "QUIK Support")
-        intent.putExtra(Intent.EXTRA_TEXT, StringBuilder("\n\n")
-                .append("\n\n--- Please write your message above this line ---\n\n")
-                .append("Package: ${context.packageName}\n")
-                .append("Version: ${BuildConfig.VERSION_NAME}\n")
-                .append("Device: ${Build.BRAND} ${Build.MODEL}\n")
-                .append("SDK: ${Build.VERSION.SDK_INT}\n")
-                .append("Upgraded"
-                        .takeIf { billingManager.upgradeStatus.blockingFirst() } ?: "")
-                .toString())
-        startActivityExternal(intent)
-    }
-
-    fun showInvite() {
-        Intent(Intent.ACTION_SEND)
-                .setType("text/plain")
-                .putExtra(Intent.EXTRA_TEXT, "https://github.com/quik-sms/quik/releases/latest")
-                .let { Intent.createChooser(it, null) }
-                .let(::startActivityExternal)
-    }
-
-    fun addContact(address: String) {
-        val intent = Intent(Intent.ACTION_INSERT)
-                .setType(ContactsContract.Contacts.CONTENT_TYPE)
-                .putExtra(ContactsContract.Intents.Insert.PHONE, address)
-
-        startActivityExternal(intent)
-    }
-
-    fun showContact(lookupKey: String) {
-        val intent = Intent(Intent.ACTION_VIEW)
-                .setData(Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey))
-
-        startActivityExternal(intent)
+        startActivity(Intent(context, BlockingActivity::class.java))
     }
 
     fun viewFile(uri: Uri, mimeType: String) {
@@ -324,41 +163,4 @@ class Navigator @Inject constructor(
 
         startActivityExternal(intent)
     }
-
-    fun showPermissions() {
-        val intent = Intent()
-        intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-        intent.data = Uri.fromParts("package", context.packageName, null)
-
-        startActivity(intent)
-    }
-
-    fun showNotificationSettings(threadId: Long = 0) {
-        val intent = Intent(context, NotificationPrefsActivity::class.java)
-        intent.putExtra("threadId", threadId)
-        startActivity(intent)
-    }
-
-    fun showNotificationChannel(threadId: Long = 0) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (threadId != 0L) {
-                notificationManager.createNotificationChannel(threadId)
-            }
-
-            val channelId = notificationManager.buildNotificationChannelId(threadId)
-            val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
-                    .putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
-                    .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-            startActivity(intent)
-        }
-    }
-
-    fun showExactAlarmsSettings() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
-                    .setData(Uri.parse("package:${context.packageName}"))
-            startActivity(intent)
-        }
-    }
-
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
@@ -20,15 +20,12 @@ package dev.octoshrimpy.quik.common
 
 import android.app.Activity
 import android.app.role.RoleManager
-import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.provider.ContactsContract
 import android.provider.Settings
 import android.provider.Telephony
-import dev.octoshrimpy.quik.BuildConfig
 import dev.octoshrimpy.quik.compat.TelephonyCompat
 import dev.octoshrimpy.quik.extensions.resourceExists
 import dev.octoshrimpy.quik.feature.settings.about.AboutActivity
@@ -43,33 +40,16 @@ import dev.octoshrimpy.quik.feature.notificationprefs.NotificationPrefsActivity
 import dev.octoshrimpy.quik.feature.plus.PlusActivity
 import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivity
 import dev.octoshrimpy.quik.feature.settings.SettingsActivity
-import dev.octoshrimpy.quik.manager.BillingManager
 import dev.octoshrimpy.quik.manager.NotificationManager
-import dev.octoshrimpy.quik.manager.PermissionManager
 import dev.octoshrimpy.quik.model.ScheduledMessage
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class Navigator @Inject constructor(
-    private val context: Context,
-    private val billingManager: BillingManager,
-    private val notificationManager: NotificationManager,
-    private val permissions: PermissionManager
-) {
-
-    private fun startActivity(intent: Intent) {
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(intent)
-    }
-
-    private fun startActivityExternal(intent: Intent) {
-        if (intent.resolveActivity(context.packageManager) != null) {
-            startActivity(intent)
-        } else {
-            startActivity(Intent.createChooser(intent, null))
-        }
-    }
+    context: Context,
+    private val notificationManager: NotificationManager
+) : QkNavigator(context) {
 
     /**
      * @param source String to indicate where this QKSMS+ screen was launched from. This should be
@@ -78,21 +58,6 @@ class Navigator @Inject constructor(
     fun showQksmsPlusActivity(source: String) {
         val intent = Intent(context, PlusActivity::class.java)
         startActivity(intent)
-    }
-
-    /**
-     * This won't work unless we use startActivityForResult
-     */
-    fun showDefaultSmsDialog(context: Activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val roleManager = context.getSystemService(RoleManager::class.java) as RoleManager
-            val intent = roleManager.createRequestRoleIntent(RoleManager.ROLE_SMS)
-            context.startActivityForResult(intent, 42389)
-        } else {
-            val intent = Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT)
-            intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, context.packageName)
-            context.startActivity(intent)
-        }
     }
 
     fun showMainActivity() {
@@ -189,121 +154,9 @@ class Navigator @Inject constructor(
         startActivity(intent)
     }
 
-    fun showDeveloper() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/graphs/contributors"))
-        startActivityExternal(intent)
-    }
-
-    fun showSourceCode() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
-        startActivityExternal(intent)
-    }
-
-    fun showChangelog() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/releases"))
-        startActivityExternal(intent)
-    }
-
-    fun showLicense() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik/blob/master/LICENSE"))
-        startActivityExternal(intent)
-    }
-
     fun showBlockedConversations() {
         val intent = Intent(context, BlockingActivity::class.java)
         startActivity(intent)
-    }
-
-    fun makePhoneCall(address: String) {
-        val action = if (permissions.hasCalling()) Intent.ACTION_CALL else Intent.ACTION_DIAL
-        val intent = Intent(action, Uri.parse("tel:$address"))
-        startActivityExternal(intent)
-    }
-
-    fun showDonation() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
-        startActivityExternal(intent)
-    }
-
-    fun showRating() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/quik-sms/quik"))
-                .addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY
-                        or Intent.FLAG_ACTIVITY_NEW_DOCUMENT
-                        or Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
-
-        try {
-            startActivityExternal(intent)
-        } catch (e: ActivityNotFoundException) {
-            val url = "https://github.com/quik-sms/quik"
-            startActivityExternal(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-        }
-    }
-
-    /**
-     * Launch the Play Store and display the Call Blocker listing
-     */
-    fun installCallBlocker() {
-        val url = "https://play.google.com/store/apps/details?id=com.cuiet.blockCalls"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        startActivityExternal(intent)
-    }
-
-    /**
-     * Launch the Play Store and display the Call Control listing
-     */
-    fun installCallControl() {
-        val url = "https://play.google.com/store/apps/details?id=com.flexaspect.android.everycallcontrol"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        startActivityExternal(intent)
-    }
-
-    /**
-     * Launch the Play Store and display the Should I Answer? listing
-     */
-    fun installSia() {
-        val url = "https://play.google.com/store/apps/details?id=org.mistergroup.shouldianswer"
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        startActivityExternal(intent)
-    }
-
-    fun showSupport() {
-        val intent = Intent(Intent.ACTION_SENDTO)
-        intent.data = Uri.parse("mailto:")
-        intent.putExtra(Intent.EXTRA_EMAIL, arrayOf("quik@octo.sh"))
-        intent.putExtra(Intent.EXTRA_SUBJECT, "QUIK Support")
-        intent.putExtra(Intent.EXTRA_TEXT, StringBuilder("\n\n")
-                .append("\n\n--- Please write your message above this line ---\n\n")
-                .append("Package: ${context.packageName}\n")
-                .append("Version: ${BuildConfig.VERSION_NAME}\n")
-                .append("Device: ${Build.BRAND} ${Build.MODEL}\n")
-                .append("SDK: ${Build.VERSION.SDK_INT}\n")
-                .append("Upgraded"
-                        .takeIf { billingManager.upgradeStatus.blockingFirst() } ?: "")
-                .toString())
-        startActivityExternal(intent)
-    }
-
-    fun showInvite() {
-        Intent(Intent.ACTION_SEND)
-                .setType("text/plain")
-                .putExtra(Intent.EXTRA_TEXT, "https://github.com/quik-sms/quik/releases/latest")
-                .let { Intent.createChooser(it, null) }
-                .let(::startActivityExternal)
-    }
-
-    fun addContact(address: String) {
-        val intent = Intent(Intent.ACTION_INSERT)
-                .setType(ContactsContract.Contacts.CONTENT_TYPE)
-                .putExtra(ContactsContract.Intents.Insert.PHONE, address)
-
-        startActivityExternal(intent)
-    }
-
-    fun showContact(lookupKey: String) {
-        val intent = Intent(Intent.ACTION_VIEW)
-                .setData(Uri.withAppendedPath(ContactsContract.Contacts.CONTENT_LOOKUP_URI, lookupKey))
-
-        startActivityExternal(intent)
     }
 
     fun viewFile(uri: Uri, mimeType: String) {
@@ -324,41 +177,4 @@ class Navigator @Inject constructor(
 
         startActivityExternal(intent)
     }
-
-    fun showPermissions() {
-        val intent = Intent()
-        intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-        intent.data = Uri.fromParts("package", context.packageName, null)
-
-        startActivity(intent)
-    }
-
-    fun showNotificationSettings(threadId: Long = 0) {
-        val intent = Intent(context, NotificationPrefsActivity::class.java)
-        intent.putExtra("threadId", threadId)
-        startActivity(intent)
-    }
-
-    fun showNotificationChannel(threadId: Long = 0) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (threadId != 0L) {
-                notificationManager.createNotificationChannel(threadId)
-            }
-
-            val channelId = notificationManager.buildNotificationChannelId(threadId)
-            val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
-                    .putExtra(Settings.EXTRA_CHANNEL_ID, channelId)
-                    .putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
-            startActivity(intent)
-        }
-    }
-
-    fun showExactAlarmsSettings() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
-                    .setData(Uri.parse("package:${context.packageName}"))
-            startActivity(intent)
-        }
-    }
-
 }

--- a/presentation/src/main/java/com/moez/QKSMS/common/QkNavigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/QkNavigator.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+ *
+ * This file is part of QKSMS.
+ *
+ * QKSMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QKSMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.common
+
+import android.content.Context
+import android.content.Intent
+import javax.inject.Inject
+
+open class QkNavigator @Inject constructor(val context: Context) {
+    protected fun startActivity(intent: Intent) {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(intent)
+    }
+
+    protected fun startActivityExternal(intent: Intent) {
+        if (intent.resolveActivity(context.packageManager) != null) {
+            startActivity(intent)
+        } else {
+            startActivity(Intent.createChooser(intent, null))
+        }
+    }
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/manager/BlockingManagerPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/manager/BlockingManagerPresenter.kt
@@ -9,7 +9,7 @@ import dev.octoshrimpy.quik.blocking.CallBlockerBlockingClient
 import dev.octoshrimpy.quik.blocking.CallControlBlockingClient
 import dev.octoshrimpy.quik.blocking.QksmsBlockingClient
 import dev.octoshrimpy.quik.blocking.ShouldIAnswerBlockingClient
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.base.QkPresenter
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.util.Preferences
@@ -24,7 +24,7 @@ class BlockingManagerPresenter @Inject constructor(
     private val callControl: CallControlBlockingClient,
     private val context: Context,
     private val conversationRepo: ConversationRepository,
-    private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val prefs: Preferences,
     private val qksms: QksmsBlockingClient,
     private val shouldIAnswer: ShouldIAnswerBlockingClient
@@ -74,7 +74,7 @@ class BlockingManagerPresenter @Inject constructor(
                 .filter {
                     val installed = callBlocker.isAvailable()
                     if (!installed) {
-                        navigator.installCallBlocker()
+                        externalNavigator.installCallBlocker()
                     }
 
                     val enabled = prefs.blockingManager.get() == Preferences.BLOCKING_MANAGER_CB
@@ -89,7 +89,7 @@ class BlockingManagerPresenter @Inject constructor(
                 .filter {
                     val installed = callControl.isAvailable()
                     if (!installed) {
-                        navigator.installCallControl()
+                        externalNavigator.installCallControl()
                     }
 
                     val enabled = prefs.blockingManager.get() == Preferences.BLOCKING_MANAGER_CC
@@ -120,7 +120,7 @@ class BlockingManagerPresenter @Inject constructor(
                 .filter {
                     val installed = shouldIAnswer.isAvailable()
                     if (!installed) {
-                        navigator.installSia()
+                        externalNavigator.installSia()
                     }
 
                     val enabled = prefs.blockingManager.get() == Preferences.BLOCKING_MANAGER_SIA

--- a/presentation/src/main/java/com/moez/QKSMS/feature/blocking/manager/BlockingManagerPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/blocking/manager/BlockingManagerPresenter.kt
@@ -9,7 +9,7 @@ import dev.octoshrimpy.quik.blocking.CallBlockerBlockingClient
 import dev.octoshrimpy.quik.blocking.CallControlBlockingClient
 import dev.octoshrimpy.quik.blocking.QksmsBlockingClient
 import dev.octoshrimpy.quik.blocking.ShouldIAnswerBlockingClient
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.base.QkPresenter
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.util.Preferences
@@ -24,7 +24,7 @@ class BlockingManagerPresenter @Inject constructor(
     private val callControl: CallControlBlockingClient,
     private val context: Context,
     private val conversationRepo: ConversationRepository,
-    private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val prefs: Preferences,
     private val qksms: QksmsBlockingClient,
     private val shouldIAnswer: ShouldIAnswerBlockingClient
@@ -74,7 +74,7 @@ class BlockingManagerPresenter @Inject constructor(
                 .filter {
                     val installed = callBlocker.isAvailable()
                     if (!installed) {
-                        navigator.installCallBlocker()
+                        externalNavigator.openAppStoreForCallBlocker()
                     }
 
                     val enabled = prefs.blockingManager.get() == Preferences.BLOCKING_MANAGER_CB
@@ -89,7 +89,7 @@ class BlockingManagerPresenter @Inject constructor(
                 .filter {
                     val installed = callControl.isAvailable()
                     if (!installed) {
-                        navigator.installCallControl()
+                        externalNavigator.openAppStoreForCallControl()
                     }
 
                     val enabled = prefs.blockingManager.get() == Preferences.BLOCKING_MANAGER_CC
@@ -120,7 +120,7 @@ class BlockingManagerPresenter @Inject constructor(
                 .filter {
                     val installed = shouldIAnswer.isAvailable()
                     if (!installed) {
-                        navigator.installSia()
+                        externalNavigator.openAppStoreForSia()
                     }
 
                     val enabled = prefs.blockingManager.get() == Preferences.BLOCKING_MANAGER_SIA

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeActivity.kt
@@ -62,7 +62,7 @@ import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dagger.android.AndroidInjection
 import dev.octoshrimpy.quik.R
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.base.QkThemedActivity
 import dev.octoshrimpy.quik.common.util.DateFormatter
 import dev.octoshrimpy.quik.common.util.extensions.autoScrollToStart
@@ -101,7 +101,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     @Inject lateinit var chipsAdapter: ChipsAdapter
     @Inject lateinit var dateFormatter: DateFormatter
     @Inject lateinit var messageAdapter: MessagesAdapter
-    @Inject lateinit var navigator: Navigator
+    @Inject lateinit var externalNavigator : ExternalNavigator
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
     private lateinit var binding: ComposeActivityBinding
@@ -574,7 +574,7 @@ class ComposeActivity : QkThemedActivity(), ComposeView {
     }
 
     override fun requestDefaultSms() {
-        navigator.showDefaultSmsDialog(this)
+        externalNavigator.showDefaultSmsDialog(this)
     }
 
     override fun requestStoragePermission() {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -39,6 +39,7 @@ import com.moez.QKSMS.manager.MediaRecorderManager.AUDIO_FILE_SUFFIX
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkViewModel
 import dev.octoshrimpy.quik.common.util.ClipboardUtils
@@ -120,6 +121,7 @@ class ComposeViewModel @Inject constructor(
     private val messageRepo: MessageRepository,
     private val scheduledMessageRepo: ScheduledMessageRepository,
     private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val permissionManager: PermissionManager,
     private val phoneNumberUtils: PhoneNumberUtils,
     private val prefs: Preferences,
@@ -401,7 +403,7 @@ class ComposeViewModel @Inject constructor(
                     ?: conversation.recipients.firstOrNull()?.address  // first recipient in convo
             }
             .autoDisposable(view.scope())
-            .subscribe { navigator.makePhoneCall(it) }
+            .subscribe { externalNavigator.makePhoneCall(it) }
 
         // Open the conversation settings if info button is clicked
         view.optionsItemIntent
@@ -1194,7 +1196,7 @@ class ComposeViewModel @Inject constructor(
                 }
 
                 if ((delay != 0 || state.scheduled != 0L) && !permissionManager.hasExactAlarms()) {
-                    navigator.showExactAlarmsSettings()
+                    externalNavigator.showExactAlarmsSettings()
                     return@withLatestFrom false
                 }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoController.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoController.kt
@@ -27,7 +27,7 @@ import com.bluelinelabs.conductor.RouterTransaction
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.QkChangeHandler
 import dev.octoshrimpy.quik.common.base.QkController
 import dev.octoshrimpy.quik.common.util.extensions.scrapViews
@@ -51,7 +51,7 @@ class ConversationInfoController(
 
     @Inject override lateinit var presenter: ConversationInfoPresenter
     @Inject lateinit var blockingDialog: BlockingDialog
-    @Inject lateinit var navigator: Navigator
+    @Inject lateinit var externalNavigator : ExternalNavigator
     @Inject lateinit var adapter: ConversationInfoAdapter
 
     private val nameDialog: TextInputDialog by lazy {
@@ -125,7 +125,7 @@ class ConversationInfoController(
     }
 
     override fun requestDefaultSms() {
-        navigator.showDefaultSmsDialog(activity!!)
+        externalNavigator.showDefaultSmsDialog(activity!!)
     }
 
     override fun showDeleteDialog() {

--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversationinfo/ConversationInfoPresenter.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.Lifecycle
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkPresenter
 import dev.octoshrimpy.quik.common.util.ClipboardUtils
@@ -58,6 +59,7 @@ class ConversationInfoPresenter @Inject constructor(
     private val markArchived: MarkArchived,
     private val markUnarchived: MarkUnarchived,
     private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val permissionManager: PermissionManager
 ) : QkPresenter<ConversationInfoView, ConversationInfoState>(
         ConversationInfoState(threadId = threadId)
@@ -114,8 +116,8 @@ class ConversationInfoPresenter @Inject constructor(
         view.recipientClicks()
                 .mapNotNull(conversationRepo::getRecipient)
                 .doOnNext { recipient ->
-                    recipient.contact?.lookupKey?.let(navigator::showContact)
-                            ?: navigator.addContact(recipient.address)
+                    recipient.contact?.lookupKey?.let(externalNavigator::showContact)
+                            ?: externalNavigator.addContact(recipient.address)
                 }
                 .autoDisposable(view.scope(Lifecycle.Event.ON_DESTROY)) // ... this should be the default
                 .subscribe()
@@ -158,7 +160,7 @@ class ConversationInfoPresenter @Inject constructor(
         view.notificationClicks()
                 .withLatestFrom(conversation) { _, conversation -> conversation }
                 .autoDisposable(view.scope())
-                .subscribe { conversation -> navigator.showNotificationSettings(conversation.id) }
+                .subscribe { conversation -> externalNavigator.showNotificationSettings(conversation.id) }
 
         view.markUnreadClicks()
                 .withLatestFrom(conversation) { _, conversation -> conversation }

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -45,7 +45,7 @@ import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dagger.android.AndroidInjection
 import dev.octoshrimpy.quik.R
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.androidxcompat.drawerOpen
 import dev.octoshrimpy.quik.common.base.QkThemedActivity
 import dev.octoshrimpy.quik.common.util.extensions.autoScrollToStart
@@ -75,7 +75,7 @@ class MainActivity : QkThemedActivity(), MainView {
 
     @Inject lateinit var blockingDialog: BlockingDialog
     @Inject lateinit var disposables: CompositeDisposable
-    @Inject lateinit var navigator: Navigator
+    @Inject lateinit var externalNavigator: ExternalNavigator
     @Inject lateinit var conversationsAdapter: ConversationsAdapter
     @Inject lateinit var drawerBadgesExperiment: DrawerBadgesExperiment
     @Inject lateinit var searchAdapter: SearchAdapter
@@ -398,7 +398,7 @@ class MainActivity : QkThemedActivity(), MainView {
         }
 
     override fun requestDefaultSms() =
-        navigator.showDefaultSmsDialog(this)
+        externalNavigator.showDefaultSmsDialog(this)
 
     override fun requestPermissions() {
         val permissions = mutableListOf(

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -44,7 +44,7 @@ import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dagger.android.AndroidInjection
 import dev.octoshrimpy.quik.R
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.androidxcompat.drawerOpen
 import dev.octoshrimpy.quik.common.base.QkThemedActivity
 import dev.octoshrimpy.quik.common.util.extensions.autoScrollToStart
@@ -74,7 +74,7 @@ class MainActivity : QkThemedActivity(), MainView {
 
     @Inject lateinit var blockingDialog: BlockingDialog
     @Inject lateinit var disposables: CompositeDisposable
-    @Inject lateinit var navigator: Navigator
+    @Inject lateinit var externalNavigator: ExternalNavigator
     @Inject lateinit var conversationsAdapter: ConversationsAdapter
     @Inject lateinit var drawerBadgesExperiment: DrawerBadgesExperiment
     @Inject lateinit var searchAdapter: SearchAdapter
@@ -399,7 +399,7 @@ class MainActivity : QkThemedActivity(), MainView {
         }
 
     override fun requestDefaultSms() =
-        navigator.showDefaultSmsDialog(this)
+        externalNavigator.showDefaultSmsDialog(this)
 
     override fun requestPermissions() {
         val permissions = mutableListOf(

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkViewModel
 import dev.octoshrimpy.quik.extensions.mapNotNull
@@ -78,6 +79,7 @@ class MainViewModel @Inject constructor(
     private val markUnread: MarkUnread,
     private val speakThreads: SpeakThreads,
     private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val permissionManager: PermissionManager,
     private val prefs: Preferences,
     private val ratingManager: RatingManager,
@@ -250,7 +252,7 @@ class MainViewModel @Inject constructor(
 
         view.changelogMoreIntent
                 .autoDisposable(view.scope())
-                .subscribe { navigator.showChangelog() }
+                .subscribe { externalNavigator.showChangelog() }
 
         view.queryChangedIntent
                 .debounce(200, TimeUnit.MILLISECONDS)
@@ -336,7 +338,7 @@ class MainViewModel @Inject constructor(
                         NavItem.ABOUT -> navigator.showAbout()
 //                        NavItem.PLUS -> navigator.showQksmsPlusActivity("main_menu")
 //                        NavItem.HELP -> navigator.showSupport()
-                        NavItem.INVITE -> navigator.showInvite()
+                        NavItem.INVITE -> externalNavigator.showInvite()
                         else -> Unit
                     }
                     drawerItem
@@ -396,7 +398,7 @@ class MainViewModel @Inject constructor(
                 .mapNotNull(conversationRepo::getConversation)
                 .map { conversation -> conversation.recipients }
                 .mapNotNull { recipients -> recipients[0]?.address?.takeIf { recipients.size == 1 } }
-                .doOnNext(navigator::addContact)
+                .doOnNext(externalNavigator::addContact)
                 .autoDisposable(view.scope())
                 .subscribe()
 
@@ -464,7 +466,7 @@ class MainViewModel @Inject constructor(
         view.rateIntent
                 .autoDisposable(view.scope())
                 .subscribe {
-                    navigator.showRating()
+                    externalNavigator.showRating()
                     ratingManager.rate()
                 }
 
@@ -553,7 +555,7 @@ class MainViewModel @Inject constructor(
                                     ?.address // most recent non-me msg address
                                 ?: conversationRepo.getConversation(threadId)
                                     ?.recipients?.firstOrNull()?.address  // first recipient in convo
-                            )?.let(navigator::makePhoneCall)
+                            )?.let(externalNavigator::makePhoneCall)
                         }
                         Preferences.SWIPE_ACTION_READ -> markRead.execute(listOf(threadId))
                         Preferences.SWIPE_ACTION_UNREAD -> markUnread.execute(listOf(threadId))
@@ -576,7 +578,7 @@ class MainViewModel @Inject constructor(
                         !state.contactPermission -> view.requestPermissions()
                         !state.notificationPermission -> {
                             if (prefs.hasAskedForNotificationPermission.get()) {
-                                navigator.showPermissions()
+                                externalNavigator.showPermissionsInSettings()
                             } else {
                                 prefs.hasAskedForNotificationPermission.set(true)
                                 view.requestPermissions()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -22,6 +22,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkViewModel
 import dev.octoshrimpy.quik.extensions.mapNotNull
@@ -80,6 +81,7 @@ class MainViewModel @Inject constructor(
     private val scheduledMessageRepo: ScheduledMessageRepository,
     private val speakThreads: SpeakThreads,
     private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val permissionManager: PermissionManager,
     private val prefs: Preferences,
     private val ratingManager: RatingManager,
@@ -261,7 +263,7 @@ class MainViewModel @Inject constructor(
 
         view.changelogMoreIntent
                 .autoDisposable(view.scope())
-                .subscribe { navigator.showChangelog() }
+                .subscribe { externalNavigator.showChangelog() }
 
         view.queryChangedIntent
                 .debounce(200, TimeUnit.MILLISECONDS)
@@ -347,7 +349,7 @@ class MainViewModel @Inject constructor(
                         NavItem.ABOUT -> navigator.showAbout()
 //                        NavItem.PLUS -> navigator.showQksmsPlusActivity("main_menu")
 //                        NavItem.HELP -> navigator.showSupport()
-                        NavItem.INVITE -> navigator.showInvite()
+                        NavItem.INVITE -> externalNavigator.showInvite()
                         else -> Unit
                     }
                     drawerItem
@@ -407,7 +409,7 @@ class MainViewModel @Inject constructor(
                 .mapNotNull(conversationRepo::getConversation)
                 .map { conversation -> conversation.recipients }
                 .mapNotNull { recipients -> recipients[0]?.address?.takeIf { recipients.size == 1 } }
-                .doOnNext(navigator::addContact)
+                .doOnNext(externalNavigator::addContact)
                 .autoDisposable(view.scope())
                 .subscribe()
 
@@ -475,7 +477,7 @@ class MainViewModel @Inject constructor(
         view.rateIntent
                 .autoDisposable(view.scope())
                 .subscribe {
-                    navigator.showRating()
+                    externalNavigator.showRating()
                     ratingManager.rate()
                 }
 
@@ -564,7 +566,7 @@ class MainViewModel @Inject constructor(
                                     ?.address // most recent non-me msg address
                                 ?: conversationRepo.getConversation(threadId)
                                     ?.recipients?.firstOrNull()?.address  // first recipient in convo
-                            )?.let(navigator::makePhoneCall)
+                            )?.let(externalNavigator::makePhoneCall)
                         }
                         Preferences.SWIPE_ACTION_READ -> markRead.execute(listOf(threadId))
                         Preferences.SWIPE_ACTION_UNREAD -> markUnread.execute(listOf(threadId))
@@ -587,7 +589,7 @@ class MainViewModel @Inject constructor(
                         !state.contactPermission -> view.requestPermissions()
                         !state.notificationPermission -> {
                             if (prefs.hasAskedForNotificationPermission.get()) {
-                                navigator.showPermissions()
+                                externalNavigator.showPermissionsInSettings()
                             } else {
                                 prefs.hasAskedForNotificationPermission.set(true)
                                 view.requestPermissions()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/notificationprefs/NotificationPrefsViewModel.kt
@@ -24,7 +24,7 @@ import android.net.Uri
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.base.QkViewModel
 import dev.octoshrimpy.quik.extensions.mapNotNull
 import dev.octoshrimpy.quik.repository.ConversationRepository
@@ -39,7 +39,7 @@ class NotificationPrefsViewModel @Inject constructor(
     @Named("threadId") private val threadId: Long,
     private val context: Context,
     private val conversationRepo: ConversationRepository,
-    private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val prefs: Preferences
 ) : QkViewModel<NotificationPrefsView, NotificationPrefsState>(NotificationPrefsState(threadId = threadId)) {
 
@@ -107,7 +107,7 @@ class NotificationPrefsViewModel @Inject constructor(
                 .autoDisposable(view.scope())
                 .subscribe { preferenceView ->
                     when (preferenceView.id) {
-                        R.id.notificationsO -> navigator.showNotificationChannel(threadId)
+                        R.id.notificationsO -> externalNavigator.showNotificationChannel(threadId)
 
                         R.id.notifications -> notifications.set(!notifications.get())
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/qkreply/QkReplyViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/qkreply/QkReplyViewModel.kt
@@ -22,6 +22,7 @@ import android.telephony.SmsMessage
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkViewModel
 import dev.octoshrimpy.quik.compat.SubscriptionManagerCompat
@@ -52,6 +53,7 @@ class QkReplyViewModel @Inject constructor(
     private val markRead: MarkRead,
     private val messageRepo: MessageRepository,
     private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val sendNewMessage: SendNewMessage,
     private val subscriptionManager: SubscriptionManagerCompat
 ) : QkViewModel<QkReplyView, QkReplyState>(QkReplyState(threadId = threadId)) {
@@ -126,7 +128,7 @@ class QkReplyViewModel @Inject constructor(
                 state.data?.second?.lastOrNull { !it.isMe() }?.address // most recent non-me msg address
                     ?: conversation.recipients.firstOrNull()?.address  // first recipient in convo
             }
-            .doOnNext { navigator.makePhoneCall(it) }
+            .doOnNext { externalNavigator.makePhoneCall(it) }
             .autoDisposable(view.scope())
             .subscribe { newState { copy(hasError = true) } }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.Navigator
 import dev.octoshrimpy.quik.common.base.QkPresenter
 import dev.octoshrimpy.quik.common.util.Colors
@@ -45,6 +46,7 @@ class SettingsPresenter @Inject constructor(
     private val billingManager: BillingManager,
     private val dateFormatter: DateFormatter,
     private val navigator: Navigator,
+    private val externalNavigator: ExternalNavigator,
     private val nightModeManager: NightModeManager,
     private val prefs: Preferences,
     private val syncMessages: SyncMessages
@@ -178,7 +180,7 @@ class SettingsPresenter @Inject constructor(
 
                         R.id.autoEmoji -> prefs.autoEmoji.set(!prefs.autoEmoji.get())
 
-                        R.id.notifications -> navigator.showNotificationSettings()
+                        R.id.notifications -> externalNavigator.showNotificationSettings()
 
                         R.id.swipeActions -> view.showSwipeActions()
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/about/AboutPresenter.kt
@@ -21,12 +21,12 @@ package dev.octoshrimpy.quik.feature.settings.about
 import com.uber.autodispose.android.lifecycle.scope
 import com.uber.autodispose.autoDisposable
 import dev.octoshrimpy.quik.R
-import dev.octoshrimpy.quik.common.Navigator
+import dev.octoshrimpy.quik.common.ExternalNavigator
 import dev.octoshrimpy.quik.common.base.QkPresenter
 import javax.inject.Inject
 
 class AboutPresenter @Inject constructor(
-    private val navigator: Navigator
+    private val externalNavigator: ExternalNavigator
 ) : QkPresenter<AboutView, Unit>(Unit) {
 
     override fun bindIntents(view: AboutView) {
@@ -36,15 +36,15 @@ class AboutPresenter @Inject constructor(
                 .autoDisposable(view.scope())
                 .subscribe { preference ->
                     when (preference.id) {
-                        R.id.developer -> navigator.showDeveloper()
+                        R.id.developer -> externalNavigator.showDeveloper()
 
-                        R.id.source -> navigator.showSourceCode()
+                        R.id.source -> externalNavigator.showSourceCode()
 
-                        R.id.changelog -> navigator.showChangelog()
+                        R.id.changelog -> externalNavigator.showChangelog()
 
-                        R.id.contact -> navigator.showSupport()
+                        R.id.contact -> externalNavigator.showSupport()
 
-                        R.id.license -> navigator.showLicense()
+                        R.id.license -> externalNavigator.showLicense()
                     }
                 }
     }


### PR DESCRIPTION
Moved all external navigation to `ExternalNavigator.kt` and abstracted common parts to `QKNavigator.kt`. Should make things simpler, and easier to work with.