### PR TITLE
Add read-only Messages for Web MVP

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <!-- Used for starting foreground service for backup/restore on Android P+ -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-<!--    <uses-permission android:name="android.permission.INTERNET" />-->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.READ_SMS" />
@@ -123,6 +124,7 @@
         <activity android:name=".feature.scheduled.ScheduledActivity" />
         <activity android:name=".feature.backup.BackupActivity" />
         <activity android:name=".feature.contacts.ContactsActivity" />
+        <activity android:name=".feature.webaccess.WebAccessActivity" />
 
         <receiver
             android:name=".receiver.BootReceiver"

--- a/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/common/Navigator.kt
@@ -33,6 +33,7 @@ import dev.octoshrimpy.quik.compat.TelephonyCompat
 import dev.octoshrimpy.quik.extensions.resourceExists
 import dev.octoshrimpy.quik.feature.settings.about.AboutActivity
 import dev.octoshrimpy.quik.feature.backup.BackupActivity
+import dev.octoshrimpy.quik.feature.webaccess.WebAccessActivity
 import dev.octoshrimpy.quik.feature.blocking.BlockingActivity
 import dev.octoshrimpy.quik.feature.compose.ComposeActivity
 import dev.octoshrimpy.quik.feature.conversationinfo.ConversationInfoActivity
@@ -186,6 +187,11 @@ class Navigator @Inject constructor(
 
     fun showAbout() {
         val intent = Intent(context, AboutActivity::class.java)
+        startActivity(intent)
+    }
+
+    fun showWebAccess() {
+        val intent = Intent(context, WebAccessActivity::class.java)
         startActivity(intent)
     }
 

--- a/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/settings/SettingsPresenter.kt
@@ -216,6 +216,8 @@ class SettingsPresenter @Inject constructor(
 
                         R.id.disableScreenshots -> prefs.disableScreenshots.set(!prefs.disableScreenshots.get())
 
+                        R.id.webAccess -> navigator.showWebAccess()
+
                         R.id.sync -> syncMessages.execute(Unit)
 
                         R.id.about -> view.showAbout()

--- a/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessActivity.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+ *
+ * This file is part of QKSMS.
+ *
+ * QKSMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QKSMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.feature.webaccess
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.os.Bundle
+import android.widget.Toast
+import dagger.android.AndroidInjection
+import dev.octoshrimpy.quik.R
+import dev.octoshrimpy.quik.common.base.QkThemedActivity
+import dev.octoshrimpy.quik.databinding.WebAccessActivityBinding
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import javax.inject.Inject
+
+class WebAccessActivity : QkThemedActivity() {
+
+    @Inject lateinit var server: WebAccessServer
+
+    private lateinit var binding: WebAccessActivityBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this)
+        super.onCreate(savedInstanceState)
+        binding = WebAccessActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.toolbar.setNavigationOnClickListener { finish() }
+
+        binding.toggleButton.setOnClickListener {
+            if (server.isRunning()) {
+                stopServer()
+            } else {
+                startServer()
+            }
+        }
+
+        binding.copyButton.setOnClickListener {
+            copyToClipboard()
+        }
+
+        updateUi()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (isFinishing) {
+            server.stop()
+        }
+    }
+
+    private fun startServer() {
+        if (server.start()) {
+            Toast.makeText(this, R.string.web_access_started, Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, R.string.web_access_failed, Toast.LENGTH_SHORT).show()
+        }
+        updateUi()
+    }
+
+    private fun stopServer() {
+        server.stop()
+        Toast.makeText(this, R.string.web_access_stopped, Toast.LENGTH_SHORT).show()
+        updateUi()
+    }
+
+    private fun updateUi() {
+        val running = server.isRunning()
+        binding.toggleButton.text = getString(
+            if (running) R.string.web_access_stop else R.string.web_access_start
+        )
+
+        if (running) {
+            val ip = getLocalIpAddress()
+            val url = "http://$ip:${server.serverPort}"
+            binding.urlText.text = url
+            binding.tokenText.text = server.accessToken
+            binding.instructionsText.text = getString(R.string.web_access_instructions)
+            binding.copyButton.isEnabled = true
+        } else {
+            binding.urlText.text = getString(R.string.web_access_not_running)
+            binding.tokenText.text = ""
+            binding.instructionsText.text = getString(R.string.web_access_description)
+            binding.copyButton.isEnabled = false
+        }
+    }
+
+    private fun copyToClipboard() {
+        val ip = getLocalIpAddress()
+        val url = "http://$ip:${server.serverPort}"
+        val text = "$url\nToken: ${server.accessToken}"
+
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText("Web Access", text))
+        Toast.makeText(this, R.string.web_access_copied, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun getLocalIpAddress(): String {
+        try {
+            val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as? WifiManager
+            val wifiInfo = wifiManager?.connectionInfo
+            if (wifiInfo != null) {
+                val ip = wifiInfo.ipAddress
+                if (ip != 0) {
+                    return String.format(
+                        "%d.%d.%d.%d",
+                        ip and 0xff,
+                        ip shr 8 and 0xff,
+                        ip shr 16 and 0xff,
+                        ip shr 24 and 0xff
+                    )
+                }
+            }
+
+            NetworkInterface.getNetworkInterfaces()?.toList()?.forEach { intf ->
+                intf.inetAddresses?.toList()?.forEach { addr ->
+                    if (!addr.isLoopbackAddress && addr is Inet4Address) {
+                        return addr.hostAddress ?: "0.0.0.0"
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // Fall through
+        }
+        return "0.0.0.0"
+    }
+}

--- a/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/webaccess/WebAccessServer.kt
@@ -1,0 +1,402 @@
+/*
+ * Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+ *
+ * This file is part of QKSMS.
+ *
+ * QKSMS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QKSMS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dev.octoshrimpy.quik.feature.webaccess
+
+import android.content.Context
+import dev.octoshrimpy.quik.repository.ConversationRepository
+import dev.octoshrimpy.quik.repository.MessageRepository
+import org.json.JSONArray
+import org.json.JSONObject
+import timber.log.Timber
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.PrintWriter
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.security.SecureRandom
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+
+class WebAccessServer @Inject constructor(
+    private val context: Context,
+    private val conversationRepo: ConversationRepository,
+    private val messageRepo: MessageRepository
+) {
+    companion object {
+        private const val DEFAULT_PORT = 8642
+        private const val TOKEN_LENGTH = 32
+        private const val SOCKET_TIMEOUT_MS = 5000
+        private const val MAX_HANDLER_THREADS = 4
+    }
+
+    private var serverSocket: ServerSocket? = null
+    private var serverThread: Thread? = null
+    private var executor: ExecutorService? = null
+    private val running = AtomicBoolean(false)
+
+    var accessToken: String = ""
+        private set
+    var serverPort: Int = DEFAULT_PORT
+        private set
+
+    fun start(): Boolean {
+        if (running.get()) return true
+
+        accessToken = generateToken()
+        return try {
+            serverSocket = ServerSocket(DEFAULT_PORT)
+            serverPort = serverSocket!!.localPort
+            executor = Executors.newFixedThreadPool(MAX_HANDLER_THREADS) { runnable ->
+                Thread(runnable).apply { isDaemon = true }
+            }
+            running.set(true)
+
+            serverThread = Thread {
+                while (running.get()) {
+                    try {
+                        val client = serverSocket?.accept() ?: break
+                        client.soTimeout = SOCKET_TIMEOUT_MS
+                        executor?.submit { handleClient(client) }
+                    } catch (e: SocketTimeoutException) {
+                        // Expected during shutdown
+                    } catch (e: Exception) {
+                        if (running.get()) {
+                            Timber.e(e, "Error accepting connection")
+                        }
+                    }
+                }
+            }.apply { isDaemon = true; start() }
+
+            true
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to start web server")
+            false
+        }
+    }
+
+    fun stop() {
+        running.set(false)
+        try {
+            serverSocket?.close()
+            executor?.shutdownNow()
+        } catch (e: Exception) {
+            Timber.e(e, "Error stopping server")
+        }
+        serverSocket = null
+        serverThread = null
+        executor = null
+        accessToken = ""
+    }
+
+    fun isRunning(): Boolean = running.get()
+
+    private fun generateToken(): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        val random = SecureRandom()
+        return (1..TOKEN_LENGTH).map { chars[random.nextInt(chars.length)] }.joinToString("")
+    }
+
+    private fun handleClient(client: Socket) {
+        try {
+            val reader = BufferedReader(InputStreamReader(client.getInputStream()))
+            val writer = PrintWriter(client.getOutputStream(), true)
+
+            val requestLine = reader.readLine() ?: return
+            val parts = requestLine.split(" ")
+            if (parts.size < 2) {
+                sendError(writer, 400, "Bad Request")
+                return
+            }
+
+            val method = parts[0]
+            val path = parts[1]
+
+            // Read headers
+            val headers = mutableMapOf<String, String>()
+            var line = reader.readLine()
+            while (!line.isNullOrEmpty()) {
+                val colonIdx = line.indexOf(':')
+                if (colonIdx > 0) {
+                    headers[line.substring(0, colonIdx).lowercase()] = line.substring(colonIdx + 1).trim()
+                }
+                line = reader.readLine()
+            }
+
+            // Route request
+            when {
+                path == "/" -> serveIndexHtml(writer)
+                path == "/style.css" -> serveStyleCss(writer)
+                path.startsWith("/api/") -> handleApi(writer, path, headers)
+                else -> sendError(writer, 404, "Not Found")
+            }
+        } catch (e: SocketTimeoutException) {
+            Timber.w("Client read timeout")
+        } catch (e: Exception) {
+            Timber.e(e, "Error handling client")
+        } finally {
+            try { client.close() } catch (_: Exception) {}
+        }
+    }
+
+    private fun handleApi(writer: PrintWriter, path: String, headers: Map<String, String>) {
+        val token = headers["x-access-token"] ?: path.substringAfter("token=", "").substringBefore("&")
+        if (token != accessToken) {
+            sendJson(writer, 401, """{"error":"Unauthorized"}""")
+            return
+        }
+
+        when {
+            path.startsWith("/api/conversations") -> {
+                val json = conversationsJson()
+                sendJson(writer, 200, json)
+            }
+            path.startsWith("/api/messages/") -> {
+                val threadId = path.removePrefix("/api/messages/")
+                    .substringBefore("?")
+                    .toLongOrNull()
+                if (threadId == null) {
+                    sendJson(writer, 400, """{"error":"Invalid thread ID"}""")
+                } else {
+                    val json = messagesJson(threadId)
+                    sendJson(writer, 200, json)
+                }
+            }
+            else -> sendJson(writer, 404, """{"error":"Not Found"}""")
+        }
+    }
+
+    private fun conversationsJson(): String {
+        val conversations = conversationRepo.getConversationsSnapshot(false)
+            .filter { !it.archived && !it.blocked }
+            .take(100)
+
+        val array = JSONArray()
+        for (conv in conversations) {
+            val obj = JSONObject()
+            obj.put("id", conv.id)
+            obj.put("title", JSONObject.quote(conv.getTitle()).removeSurrounding("\""))
+            obj.put("snippet", JSONObject.quote(conv.snippet).removeSurrounding("\""))
+            obj.put("date", conv.date)
+            obj.put("unread", conv.unread)
+            obj.put("recipients", conv.recipients.size)
+            array.put(obj)
+        }
+        return array.toString()
+    }
+
+    private fun messagesJson(threadId: Long): String {
+        val conversation = conversationRepo.getConversation(threadId)
+        if (conversation == null || conversation.archived || conversation.blocked) {
+            return """{"messages":[],"title":""}"""
+        }
+
+        val messages = messageRepo.getMessagesSync(threadId)
+        val array = JSONArray()
+        for (msg in messages.take(200)) {
+            val obj = JSONObject()
+            obj.put("id", msg.id)
+            obj.put("body", JSONObject.quote(msg.body).removeSurrounding("\""))
+            obj.put("date", msg.date)
+            obj.put("isMe", msg.isMe())
+            obj.put("read", msg.read)
+            array.put(obj)
+        }
+
+        val result = JSONObject()
+        result.put("title", JSONObject.quote(conversation.getTitle()).removeSurrounding("\""))
+        result.put("messages", array)
+        return result.toString()
+    }
+
+    private fun sendJson(writer: PrintWriter, status: Int, json: String) {
+        val statusText = when (status) {
+            200 -> "OK"
+            400 -> "Bad Request"
+            401 -> "Unauthorized"
+            404 -> "Not Found"
+            else -> "Error"
+        }
+        writer.print("HTTP/1.1 $status $statusText\r\n")
+        writer.print("Content-Type: application/json; charset=utf-8\r\n")
+        writer.print("Access-Control-Allow-Origin: *\r\n")
+        writer.print("Connection: close\r\n")
+        writer.print("\r\n")
+        writer.print(json)
+        writer.flush()
+    }
+
+    private fun sendError(writer: PrintWriter, status: Int, message: String) {
+        writer.print("HTTP/1.1 $status $message\r\n")
+        writer.print("Content-Type: text/plain\r\n")
+        writer.print("Connection: close\r\n")
+        writer.print("\r\n")
+        writer.print(message)
+        writer.flush()
+    }
+
+    private fun serveIndexHtml(writer: PrintWriter) {
+        val html = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>QUIK Messages</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+    <div id="app">
+        <header>
+            <h1>QUIK Messages</h1>
+            <div id="auth-form">
+                <input type="text" id="token-input" placeholder="Access Token">
+                <button onclick="authenticate()">Connect</button>
+            </div>
+        </header>
+        <main>
+            <div id="conversations-panel">
+                <h2>Conversations</h2>
+                <ul id="conversations-list"></ul>
+            </div>
+            <div id="messages-panel">
+                <h2 id="thread-title">Select a conversation</h2>
+                <div id="messages-list"></div>
+            </div>
+        </main>
+    </div>
+    <script>
+        let token = '';
+        
+        function authenticate() {
+            token = document.getElementById('token-input').value;
+            if (token) {
+                loadConversations();
+                document.getElementById('auth-form').style.display = 'none';
+            }
+        }
+        
+        async function loadConversations() {
+            try {
+                const res = await fetch('/api/conversations?token=' + token, {
+                    headers: { 'X-Access-Token': token }
+                });
+                if (!res.ok) throw new Error('Unauthorized');
+                const data = await res.json();
+                renderConversations(data);
+            } catch (e) {
+                alert('Failed to load: ' + e.message);
+            }
+        }
+        
+        function renderConversations(conversations) {
+            const list = document.getElementById('conversations-list');
+            list.innerHTML = conversations.map(c => 
+                '<li class="' + (c.unread ? 'unread' : '') + '" onclick="loadMessages(' + c.id + ')">' +
+                '<strong>' + escapeHtml(c.title) + '</strong>' +
+                '<span class="snippet">' + escapeHtml(c.snippet) + '</span>' +
+                '<span class="date">' + formatDate(c.date) + '</span></li>'
+            ).join('');
+        }
+        
+        async function loadMessages(threadId) {
+            try {
+                const res = await fetch('/api/messages/' + threadId + '?token=' + token, {
+                    headers: { 'X-Access-Token': token }
+                });
+                if (!res.ok) throw new Error('Failed');
+                const data = await res.json();
+                renderMessages(data);
+            } catch (e) {
+                alert('Failed to load messages');
+            }
+        }
+        
+        function renderMessages(data) {
+            document.getElementById('thread-title').textContent = data.title || 'Messages';
+            const list = document.getElementById('messages-list');
+            list.innerHTML = data.messages.map(m =>
+                '<div class="message ' + (m.isMe ? 'sent' : 'received') + '">' +
+                '<p>' + escapeHtml(m.body) + '</p>' +
+                '<span class="time">' + formatDate(m.date) + '</span></div>'
+            ).join('');
+            list.scrollTop = list.scrollHeight;
+        }
+        
+        function formatDate(ts) {
+            return new Date(ts).toLocaleString();
+        }
+        
+        function escapeHtml(str) {
+            const div = document.createElement('div');
+            div.textContent = str;
+            return div.innerHTML;
+        }
+    </script>
+</body>
+</html>
+        """.trimIndent()
+
+        writer.print("HTTP/1.1 200 OK\r\n")
+        writer.print("Content-Type: text/html; charset=utf-8\r\n")
+        writer.print("Connection: close\r\n")
+        writer.print("\r\n")
+        writer.print(html)
+        writer.flush()
+    }
+
+    private fun serveStyleCss(writer: PrintWriter) {
+        val css = """
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f5f5f5; }
+#app { max-width: 1200px; margin: 0 auto; padding: 16px; }
+header { background: #2196F3; color: white; padding: 16px; border-radius: 8px; margin-bottom: 16px; }
+header h1 { font-size: 1.5rem; margin-bottom: 8px; }
+#auth-form { display: flex; gap: 8px; }
+#auth-form input { flex: 1; padding: 8px; border: none; border-radius: 4px; }
+#auth-form button { padding: 8px 16px; background: white; color: #2196F3; border: none; border-radius: 4px; cursor: pointer; }
+main { display: grid; grid-template-columns: 300px 1fr; gap: 16px; height: calc(100vh - 150px); }
+#conversations-panel, #messages-panel { background: white; border-radius: 8px; overflow: hidden; display: flex; flex-direction: column; }
+#conversations-panel h2, #messages-panel h2 { padding: 12px 16px; background: #f0f0f0; font-size: 1rem; }
+#conversations-list { list-style: none; overflow-y: auto; flex: 1; }
+#conversations-list li { padding: 12px 16px; border-bottom: 1px solid #eee; cursor: pointer; }
+#conversations-list li:hover { background: #f9f9f9; }
+#conversations-list li.unread { font-weight: bold; }
+#conversations-list li strong { display: block; margin-bottom: 4px; }
+#conversations-list .snippet { color: #666; font-size: 0.9rem; display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#conversations-list .date { color: #999; font-size: 0.8rem; }
+#messages-list { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
+.message { max-width: 70%; padding: 10px 14px; border-radius: 16px; }
+.message.sent { align-self: flex-end; background: #2196F3; color: white; }
+.message.received { align-self: flex-start; background: #e0e0e0; }
+.message p { margin-bottom: 4px; word-wrap: break-word; }
+.message .time { font-size: 0.7rem; opacity: 0.7; }
+@media (max-width: 768px) { main { grid-template-columns: 1fr; } #conversations-panel { max-height: 40vh; } }
+        """.trimIndent()
+
+        writer.print("HTTP/1.1 200 OK\r\n")
+        writer.print("Content-Type: text/css; charset=utf-8\r\n")
+        writer.print("Connection: close\r\n")
+        writer.print("\r\n")
+        writer.print(css)
+        writer.flush()
+    }
+}

--- a/presentation/src/main/java/com/moez/QKSMS/injection/android/ActivityBuilderModule.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/injection/android/ActivityBuilderModule.kt
@@ -42,6 +42,7 @@ import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivity
 import dev.octoshrimpy.quik.feature.scheduled.ScheduledActivityModule
 import dev.octoshrimpy.quik.feature.settings.SettingsActivity
 import dev.octoshrimpy.quik.feature.settings.about.AboutActivity
+import dev.octoshrimpy.quik.feature.webaccess.WebAccessActivity
 import dev.octoshrimpy.quik.injection.scope.ActivityScope
 
 @Module
@@ -102,5 +103,9 @@ abstract class ActivityBuilderModule {
     @ActivityScope
     @ContributesAndroidInjector(modules = [])
     abstract fun bindBlockingActivity(): BlockingActivity
+
+    @ActivityScope
+    @ContributesAndroidInjector(modules = [])
+    abstract fun bindWebAccessActivity(): WebAccessActivity
 
 }

--- a/presentation/src/main/res/drawable/ic_arrow_back_black_24dp.xml
+++ b/presentation/src/main/res/drawable/ic_arrow_back_black_24dp.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+  ~
+  ~ This file is part of QKSMS.
+  ~
+  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/presentation/src/main/res/drawable/ic_language_black_24dp.xml
+++ b/presentation/src/main/res/drawable/ic_language_black_24dp.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+  ~
+  ~ This file is part of QKSMS.
+  ~
+  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM18.92,8h-2.95c-0.32,-1.25 -0.78,-2.45 -1.38,-3.56 1.84,0.63 3.37,1.91 4.33,3.56zM12,4.04c0.83,1.2 1.48,2.53 1.91,3.96h-3.82c0.43,-1.43 1.08,-2.76 1.91,-3.96zM4.26,14C4.1,13.36 4,12.69 4,12s0.1,-1.36 0.26,-2h3.38c-0.08,0.66 -0.14,1.32 -0.14,2 0,0.68 0.06,1.34 0.14,2L4.26,14zM5.08,16h2.95c0.32,1.25 0.78,2.45 1.38,3.56 -1.84,-0.63 -3.37,-1.9 -4.33,-3.56zM8.03,8L5.08,8c0.96,-1.66 2.49,-2.93 4.33,-3.56C8.81,5.55 8.35,6.75 8.03,8zM12,19.96c-0.83,-1.2 -1.48,-2.53 -1.91,-3.96h3.82c-0.43,1.43 -1.08,2.76 -1.91,3.96zM14.34,14L9.66,14c-0.09,-0.66 -0.16,-1.32 -0.16,-2 0,-0.68 0.07,-1.35 0.16,-2h4.68c0.09,0.65 0.16,1.32 0.16,2 0,0.68 -0.07,1.34 -0.16,2zM14.59,17.56c0.6,-1.11 1.06,-2.31 1.38,-3.56h2.95c-0.96,1.65 -2.49,2.93 -4.33,3.56zM16.36,14c0.08,-0.66 0.14,-1.32 0.14,-2 0,-0.68 -0.06,-1.34 -0.14,-2h3.38c0.16,0.64 0.26,1.31 0.26,2s-0.1,1.36 -0.26,2h-3.38z"/>
+</vector>

--- a/presentation/src/main/res/layout/settings_controller.xml
+++ b/presentation/src/main/res/layout/settings_controller.xml
@@ -238,6 +238,14 @@
             android:background="?android:attr/divider" />
 
         <dev.octoshrimpy.quik.common.widget.PreferenceView
+            android:id="@+id/webAccess"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_language_black_24dp"
+            app:summary="@string/web_access_description"
+            app:title="@string/settings_web_access_title" />
+
+        <dev.octoshrimpy.quik.common.widget.PreferenceView
             android:id="@+id/sync"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/presentation/src/main/res/layout/web_access_activity.xml
+++ b/presentation/src/main/res/layout/web_access_activity.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2017 Moez Bhatti <moez.bhatti@gmail.com>
+  ~
+  ~ This file is part of QKSMS.
+  ~
+  ~ QKSMS is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ QKSMS is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with QKSMS.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/windowBackground"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:navigationIcon="@drawable/ic_arrow_back_black_24dp"
+        app:title="@string/web_access_title"
+        app:titleTextColor="?android:attr/textColorPrimaryInverse" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="24dp">
+
+            <TextView
+                android:id="@+id/instructionsText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/web_access_description"
+                android:textSize="14sp"
+                android:lineSpacingMultiplier="1.3" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="24dp"
+                android:layout_marginBottom="24dp"
+                android:background="?android:attr/divider" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/web_access_url_label"
+                android:textSize="12sp"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <TextView
+                android:id="@+id/urlText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/web_access_not_running"
+                android:textSize="18sp"
+                android:textIsSelectable="true"
+                android:fontFamily="monospace" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/web_access_token_label"
+                android:textSize="12sp"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <TextView
+                android:id="@+id/tokenText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textSize="14sp"
+                android:textIsSelectable="true"
+                android:fontFamily="monospace" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/toggleButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="8dp"
+                    android:text="@string/web_access_start" />
+
+                <Button
+                    android:id="@+id/copyButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:enabled="false"
+                    android:text="@string/web_access_copy"
+                    style="@style/Widget.AppCompat.Button.Borderless.Colored" />
+
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:text="@string/web_access_warning"
+                android:textSize="12sp"
+                android:textColor="?android:attr/textColorSecondary" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -608,4 +608,20 @@
     <string name="stt_toast_extra_prompt">Speak your message</string>
 
     <string name="messages_text_share_file_error">Oops! Something went wrong while sharing</string>
+
+    <string name="settings_web_access_title">Web Access (Beta)</string>
+    <string name="web_access_title">Web Access</string>
+    <string name="web_access_description">Access your messages from any browser on your local network. Start the server, then open the URL on your computer and enter the access token.</string>
+    <string name="web_access_instructions">Open the URL below in a browser on the same network, then enter the access token to connect.</string>
+    <string name="web_access_url_label">URL</string>
+    <string name="web_access_token_label">Access Token</string>
+    <string name="web_access_not_running">Server not running</string>
+    <string name="web_access_start">Start Server</string>
+    <string name="web_access_stop">Stop Server</string>
+    <string name="web_access_copy">Copy</string>
+    <string name="web_access_started">Web server started</string>
+    <string name="web_access_stopped">Web server stopped</string>
+    <string name="web_access_failed">Failed to start server</string>
+    <string name="web_access_copied">URL and token copied to clipboard</string>
+    <string name="web_access_warning">Keep the server running only while you need it. Anyone on your local network with the token can read your messages.</string>
 </resources>


### PR DESCRIPTION
This implements a read-only web interface for accessing messages from a browser, addressing issue #422.

When enabled via Settings, the app hosts a local HTTP server that serves a minimal browser UI. Users open the displayed URL on any device on the same network, enter the randomly generated access token, and can browse conversations and read message threads.

The implementation covers the read-only MVP scope discussed in #422:

- Settings entry that opens the Web Access screen
- Start/stop controls with URL and token display
- Local HTTP server using a bounded thread pool with socket read timeouts
- JSON API endpoints for conversations and messages, protected by per-session token
- Embedded HTML/CSS/JS for the browser UI with conversation list and thread view
- Privacy guard that excludes archived and blocked threads from both the list and direct ID lookups
- Proper JSON escaping via JSONObject.quote to handle SMS control characters

Not included: sending messages, remote/cloud access, accounts, notifications. These can be added in a follow-up PR if the approach looks good.

I tested the build locally with \gradlew :presentation:compileDebugKotlin\ and \gradlew :presentation:assembleDebug\ on a macOS machine with JDK 17. GitHub Actions should validate the PR build.