### PR TITLE
fix(main): Get scheduled messages from view model

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/conversations/ConversationsAdapter.kt
@@ -35,7 +35,6 @@ import dev.octoshrimpy.quik.common.util.extensions.resolveThemeColor
 import dev.octoshrimpy.quik.common.util.extensions.setTint
 import dev.octoshrimpy.quik.databinding.ConversationListItemBinding
 import dev.octoshrimpy.quik.model.Conversation
-import dev.octoshrimpy.quik.repository.ScheduledMessageRepository
 import dev.octoshrimpy.quik.util.PhoneNumberUtils
 import io.reactivex.disposables.CompositeDisposable
 import javax.inject.Inject
@@ -44,11 +43,17 @@ class ConversationsAdapter @Inject constructor(
     private val colors: Colors,
     private val context: Context,
     private val dateFormatter: DateFormatter,
-    private val scheduledMessageRepo: ScheduledMessageRepository,
     private val navigator: Navigator,
     private val phoneNumberUtils: PhoneNumberUtils
 ) : QkRealmAdapter<Conversation, QkBindingViewHolder<ConversationListItemBinding>>() {
     private val disposables = CompositeDisposable()
+
+    var hasScheduledConversation: Set<Long> = emptySet()
+        set(value) {
+            if (field == value) return
+            field = value
+            notifyDataSetChanged()
+        }
 
     init {
         // This is how we access the threadId for the swipe actions
@@ -122,15 +127,7 @@ class ConversationsAdapter @Inject constructor(
         // Make the preview in italics if draft
         if (conversation.draft.isNotEmpty()) binding.snippet.setTypeface(null, Typeface.ITALIC)
 
-        // Get Scheduled Messages
-        val disposable = scheduledMessageRepo
-            .getScheduledMessagesForConversation(conversation.id)
-            .asFlowable()
-            .toObservable()
-            .subscribe { messages ->
-                binding.scheduled.isVisible = messages.isNotEmpty()
-            }
-        disposables.add(disposable)
+        binding.scheduled.isVisible = conversation.id in hasScheduledConversation
 
         binding.pinned.isVisible = conversation.pinned
         binding.unread.setTint(theme)

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainActivity.kt
@@ -28,7 +28,6 @@ import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.view.ViewStub
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
@@ -215,6 +214,8 @@ class MainActivity : QkThemedActivity(), MainView {
             finish()
             return
         }
+
+        conversationsAdapter.hasScheduledConversation = state.scheduledConversationIds
 
         val addContact = when (state.page) {
             is Inbox -> state.page.addContact

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainState.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainState.kt
@@ -34,6 +34,7 @@ data class MainState(
     val smsPermission: Boolean = true,
     val contactPermission: Boolean = true,
     val notificationPermission: Boolean = true,
+    val scheduledConversationIds: Set<Long> = emptySet()
 )
 
 sealed class MainPage

--- a/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/main/MainViewModel.kt
@@ -47,6 +47,7 @@ import dev.octoshrimpy.quik.model.SyncLog
 import dev.octoshrimpy.quik.repository.ConversationRepository
 import dev.octoshrimpy.quik.repository.EmojiReactionRepository
 import dev.octoshrimpy.quik.repository.MessageRepository
+import dev.octoshrimpy.quik.repository.ScheduledMessageRepository
 import dev.octoshrimpy.quik.repository.SyncRepository
 import dev.octoshrimpy.quik.util.Preferences
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -76,6 +77,7 @@ class MainViewModel @Inject constructor(
     private val markUnarchived: MarkUnarchived,
     private val markUnpinned: MarkUnpinned,
     private val markUnread: MarkUnread,
+    private val scheduledMessageRepo: ScheduledMessageRepository,
     private val speakThreads: SpeakThreads,
     private val navigator: Navigator,
     private val permissionManager: PermissionManager,
@@ -112,6 +114,15 @@ class MainViewModel @Inject constructor(
         disposables += ratingManager.shouldShowRating
                 .subscribe { show -> newState { copy(showRating = show) } }
 
+        // Fetch scheduled messages and assign it to hasScheduledMessage
+        disposables += scheduledMessageRepo.getScheduledMessages()
+            .asFlowable()
+            .map { messages ->
+                messages.map { it.conversationId }.toSet()
+            }
+            .subscribe { ids ->
+                newState { copy(scheduledConversationIds = ids) }
+            }
 
         // Migrate the preferences from 2.7.3
         migratePreferences.execute(Unit)


### PR DESCRIPTION
The previous behavior fetched scheduled messages directly from the conversation adaptor. This was causing memory leaks and potentially crashes. Now, the view model fetches it and provides the data through state.