### PR TITLE
Separate launcher label from app name (launcher-only — does not rename the app)

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
         <activity
             android:name=".feature.main.MainActivity"
             android:exported="true"
+            android:label="@string/launcher_name"
             android:launchMode="singleTask"
             android:windowSoftInputMode="stateAlwaysHidden">
             <intent-filter>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
 <resources>
 
     <string name="app_name" translatable="false">QUIK</string>
+    <string name="launcher_name" translatable="false">Messages</string>
 
     <string name="shortcut_compose_long_label">New conversation</string>
     <string name="shortcut_compose_short_label">Compose</string>


### PR DESCRIPTION
## 🎯 TL;DR
**Surgical 2-line change.** It renames **only** the home-screen launcher label — **the app itself is NOT renamed** anywhere else (system Settings, package name and in-app branding all stay `QUIK`). 🔒

🔗 Related to #799

## 🛠️ What it does
- ➕ Adds a dedicated `launcher_name` string, kept fully separate from `app_name`.
- 🔁 Sets `android:label="@string/launcher_name"` on the **launcher activity only** (`MainActivity`); the `<application>` label is left untouched.

> 👀 Full diff is right there in the **Files changed** tab — it's literally 2 added lines, nothing removed.

## 🚫 What this PR does NOT touch
- ❌ `app_name` / **`QUIK`** branding → unchanged
- ❌ `<application android:label>` → unchanged → **Settings ▸ Apps** still shows `QUIK`
- ❌ Package name / `applicationId` (`dev.octoshrimpy.quik`) → unchanged
- ❌ In-app branding, About & settings screens → unchanged
- ❌ Build config / Gradle / flavors / signing → unchanged
- ❌ Translations → untouched (`translatable="false"`, no locale files modified)

## ✅ Net effect
| Surface | Before | After |
|---|---|---|
| 🏠 Launcher / app-drawer label | QUIK | **Messages** |
| ⚙️ Settings ▸ Apps (app name) | QUIK | QUIK *(unchanged)* |
| 🎨 In-app branding | QUIK | QUIK *(unchanged)* |
| 📦 Package name | dev.octoshrimpy.quik | dev.octoshrimpy.quik *(unchanged)* |

## 🧪 Testing
Built & installed the `debug` variant on a physical device: the launcher icon reads **"Messages"**, while app info and all in-app branding still show **QUIK**. ✔️