### PR TITLE
compose: Fix sendAsGroup switch resetting while typing on new conversation

### DIFF
--- a/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
+++ b/presentation/src/main/java/com/moez/QKSMS/feature/compose/ComposeViewModel.kt
@@ -621,9 +621,11 @@ class ComposeViewModel @Inject constructor(
 
         // toggle the group sending mode and update the conversation saved value
         view.sendAsGroupIntent
+            .withLatestFrom(state) { _, state -> !state.sendAsGroup }
+            .doOnNext { newSendAsGroup -> newState { copy(sendAsGroup = newSendAsGroup) } }
             .observeOn(Schedulers.io())
-            .withLatestFrom(conversation, state) { _, conversation, state ->
-                conversationRepo.updateSendAsGroup(conversation.id, !state.sendAsGroup)
+            .withLatestFrom(conversation) { newSendAsGroup, conversation ->
+                conversationRepo.updateSendAsGroup(conversation.id, newSendAsGroup)
             }
             .autoDisposable(view.scope())
             .subscribe()


### PR DESCRIPTION
Fixes #841

## Problem
When composing a new message to multiple recipients, disabling the "send as group message" switch would get silently re-enabled on every keystroke while typing the message body. This only happened the first time a conversation was created (with new recipients) — reopening an already-existing conversation did not reproduce the issue.

## Root Cause
Clicking the switch only wrote the new value to the database (via `conversationRepo.updateSendAsGroup`). It relied entirely on a separate reactive listener (observing the conversation from the database) to reflect that change back into the ViewModel's `state.sendAsGroup`.

For a **newly created** conversation, this listener took a noticeably long time to pick up the change (confirmed via logging — 30+ seconds in testing). During that window, `state.sendAsGroup` still held the old value. Since `render()` re-sets the switch's checked state from `state.sendAsGroup` on every state emission (including on every keystroke, due to character-count recalculation), the switch would visually flip back to its old value while the user typed.

## Fix
Updated the switch's click handler to update `state.sendAsGroup` immediately and synchronously when clicked, instead of waiting on the database round-trip. The database write still happens (on `Schedulers.io()`, unaffected), but the UI no longer depends on it to reflect the change.

## Testing
- Reproduced the original bug: created a new conversation with 2 recipients, disabled the group-message switch, typed a message — switch flipped back to enabled on each keystroke.
- Applied the fix, repeated the same steps — switch correctly stayed disabled while typing.
- Verified normal switch toggling still works on existing/previously-created conversations.